### PR TITLE
Fix release-build grep failure when no non-RC tags exist

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -38,7 +38,7 @@ jobs:
 
           # Find the highest existing release tag for this MAJOR.MINOR
           # (exclude RC/pre-release tags).
-          LAST_RELEASE=$(git tag -l "v${MAJOR_MINOR}.*" | grep -vE '(RC|rc|alpha|beta)' | sort -V | tail -1)
+          LAST_RELEASE=$(git tag -l "v${MAJOR_MINOR}.*" | { grep -vE '(RC|rc|alpha|beta)' || true; } | sort -V | tail -1)
 
           if [ -z "$LAST_RELEASE" ]; then
             TAG="v${MAJOR_MINOR}.0"


### PR DESCRIPTION
grep -vE exits 1 when zero lines match. With pipefail, this kills the compute-tag step. Wrapping in `{ grep ... || true; }` fixes it. Cherry-picked to release/rel_1.0 to unblock v1.0.0.