### PR TITLE
Code Review Phase C refactor

### DIFF
--- a/.docs/plans/20260414-0954-code-review-phase-c.md
+++ b/.docs/plans/20260414-0954-code-review-phase-c.md
@@ -80,7 +80,6 @@ Replace the timer + callback entirely with a dedicated FreeRTOS task:
 - **Loop shape:**
 
   ```cpp
-  TickType_t lastWake = xTaskGetTickCount();
   while (true) {
       // Body of the former animationTimerCallback — minus esp_timer_start_once.
       // Reads AnimationCtrl.scriptIsLoaded(), calls getNextCommandPtr(),
@@ -89,11 +88,11 @@ Replace the timer + callback entirely with a dedicated FreeRTOS task:
 
       uint32_t delayMs = AnimationCtrl.msTillNextServoCommand();
       if (delayMs < 10) delayMs = 10;   // minimum wake interval; matches idle-poll granularity
-      vTaskDelayUntil(&lastWake, pdMS_TO_TICKS(delayMs));
+      vTaskDelay(pdMS_TO_TICKS(delayMs));
   }
   ```
 
-- **`vTaskDelayUntil`** is deliberate: it schedules against an absolute last-wake timestamp, so the dispatch cadence doesn't drift by the command-build duration each iteration.
+- **`vTaskDelay`** (not `vTaskDelayUntil`) is deliberate: script delays are data-driven and variable, and the pre-refactor `esp_timer_start_once(delay * 1000)` scheduled each re-arm relative to *now*. `vTaskDelay` preserves that contract. `vTaskDelayUntil`'s absolute-wake semantics would cause catch-up bursts after a long scripted pause (e.g., a 5 s wait followed by 100 ms intervals) — after the long delay `lastWake` is far in the past, and subsequent small delays compute wake times that have already elapsed, so `vTaskDelayUntil` returns immediately and fires commands back-to-back. That is not what the old code did. **History:** an earlier draft of this spec chose `vTaskDelayUntil` for "cadence stability," but code-review caught the regression; the committed implementation uses `vTaskDelay`.
 - **Idle state** (no script loaded): the loop still runs, reads `scriptIsLoaded() == false`, takes the else branch, and sleeps on a minimum wake interval. Matches current callback behavior for the null-cmd recovery path from Phase B.
 - **Startup:** spawn `animationDispatchTask` in `setup()` alongside the other task creations. Remove the `esp_timer_create` + `esp_timer_start_once` calls for the animation timer.
 - **Shutdown:** `vTaskDelete` on the task handle if teardown is ever needed (not used today, listed for completeness).
@@ -109,13 +108,13 @@ Considered keeping `esp_timer` + adding a dispatch queue + new task (tick-enqueu
 Tradeoffs accepted:
 
 - `vTaskDelay` resolution is 1 ms at `CONFIG_FREERTOS_HZ=1000`; `esp_timer` is microsecond-resolution. Not material for animation delays in the 10+ ms range.
-- The task is blocked in `vTaskDelayUntil` rather than `xQueueReceive`, so an external "wake immediately" pre-emption would need `xTaskNotify`. Not needed today; can be added later if required.
+- The task is blocked in `vTaskDelay` rather than `xQueueReceive`, so an external "wake immediately" pre-emption would need `xTaskNotify`. Not needed today; can be added later if required.
 
 ### Risk
 
 Medium — animation dispatch timing is safety-relevant; any cadence regression is observable during real-world playback. Mitigated by:
 
-- `vTaskDelayUntil` honors absolute cadence.
+- `vTaskDelay` preserves the pre-refactor relative-from-now scheduling contract.
 - Ownership / malloc / free semantics carry over verbatim from the current callback — no new allocation sites or frees.
 - Panic-stop latency is bounded by one `delayMs` cycle, same as today's `esp_timer_start_once` pattern — no regression vs. current behavior.
 

--- a/.docs/plans/20260414-0954-code-review-phase-c.md
+++ b/.docs/plans/20260414-0954-code-review-phase-c.md
@@ -28,7 +28,7 @@ Two classes of items from the code review are **explicitly deferred out of Phase
 | 3 | P1 #13 | I2C `i2c_cmd_link_delete` on all early-return paths | `lib/I2cMaster/src/I2cMaster.cpp` |
 | 4 | P2 #20 | `button_listener_task` stack: 2048 → 4096 | `src/main.cpp` |
 | 5 | P2 #22 + #23 + #24 + #26 | `AstrOsStorageManager` error hardening | `lib/AstrOsStorageManager/src/AstrOsStorageManager.cpp` |
-| 6 | P3 #28 | `guid.h` `sprintf` → `snprintf` | `lib/Uuid/guid.h` |
+| 6 | P3 #28 | `stringFormat` `std::sprintf` → `std::snprintf` | `lib/AstrOsUtility/src/AstrOsStringUtils.hpp` |
 | 7 | P3 #29 | Silent-error counters exposed via the 10 s maintenance log | `src/main.cpp` |
 | 8 | — | QA test plan | `.docs/qa/code-review-phase-c.md` |
 
@@ -129,17 +129,27 @@ QA plan includes timing observation via log timestamps, panic-stop mid-script, a
 
 ### Problem
 
-`lib/I2cMaster/src/I2cMaster.cpp` uses the legacy ESP-IDF 4.x API pattern: `i2c_cmd_handle_t cmd = i2c_cmd_link_create()`, chain operations, `i2c_master_cmd_begin(cmd)`, `i2c_cmd_link_delete(cmd)`. On error paths that return early, `i2c_cmd_link_delete(cmd)` is skipped and the handle (plus its linked operations) leaks.
+`lib/I2cMaster/src/I2cMaster.cpp` uses the legacy ESP-IDF 4.x API pattern: `i2c_cmd_handle_t cmd = i2c_cmd_link_create()`, chain operations, `i2c_master_cmd_begin(cmd)`, `i2c_cmd_link_delete(cmd)`. An inspection of the file surfaced three distinct problems, more severe than the original review described:
+
+1. **`DeviceExists` (line 50)** — `cmd` is created but `i2c_cmd_link_delete(cmd)` is never called. Leaks on every I2C device-detection call (peer bringup, bus scan).
+2. **`ReadWord` (lines 209–215)** — `cmd` is re-assigned (line 215) without deleting the handle produced by the previous `i2c_cmd_link_create()` (line 209). Then at line 233 the code calls `i2c_cmd_link_delete(cmd)` a second time on a handle already deleted at line 222 → **double-free / use-after-free**.
+3. **`ReadTwoWords` (lines 264–270 and 306)** — identical pattern to `ReadWord`: a leaked `cmd` followed by a double-delete.
+
+Early-return paths in these functions also skip `i2c_cmd_link_delete` on the current handle, which is the originally reviewed issue.
 
 ### Design
 
-Audit every `i2c_cmd_link_create` call site in the file. For each, enumerate every early-return branch and ensure:
+Fix the three concrete bugs above, then audit the remaining `i2c_cmd_link_create` call sites for early-return paths that skip delete.
 
-1. `i2c_cmd_link_delete(cmd)` runs before the return.
-2. `xSemaphoreGive(i2cBusMutext)` runs before the return.
-3. Order: delete handle → give semaphore → return. Consistent across every call site.
+1. **`DeviceExists`** — add `i2c_cmd_link_delete(cmd)` before `xSemaphoreGive`.
+2. **`ReadWord`** — remove the stray double-create on lines 209–210; keep only the `cmd = i2c_cmd_link_create()` at line 215 (which becomes the second handle). Remove the duplicate `i2c_cmd_link_delete(cmd)` at line 233.
+3. **`ReadTwoWords`** — identical shape: remove the stray create at 264–265 and the duplicate delete at line 306.
 
-If the branch count is high at any single site (say 3+ early returns in one function), introduce a small stack-local RAII wrapper whose destructor calls `i2c_cmd_link_delete`. Only introduce the wrapper if it simplifies — plain cleanup is preferred when branch counts are low.
+For every other function with an `i2c_cmd_link_create`, confirm each early-return branch has `i2c_cmd_link_delete(cmd)` + `xSemaphoreGive(i2cBusMutext)` before returning, in that order.
+
+No RAII wrapper is introduced — the branch count per function after the fixes above is 1–2 early returns, within the "plain cleanup is clearer" threshold from the spec.
+
+**Note:** Lines 318+ of `I2cMaster.cpp` are wrapped in `/* ... */` — an incomplete migration to the new ESP-IDF 5.x `i2c_master_bus_*` API. This Phase C work does not touch the commented-out code.
 
 ### Risk
 
@@ -226,23 +236,34 @@ Low-to-medium. 5d is a signature change with a single call site (tracked in lock
 
 ---
 
-## Task 6 — GUID `sprintf` → `snprintf`
+## Task 6 — `stringFormat` `std::sprintf` → `std::snprintf`
 
 ### Problem
 
-`lib/Uuid/guid.h` uses `sprintf(buf, fmt, ...)` with a 64-byte stack buffer. The current format fits; this is pure defense against a future format-string edit.
+On inspection, `lib/Uuid/guid.h` already uses `snprintf` (review item #28 was stale). The remaining `std::sprintf` in the codebase is at `lib/AstrOsUtility/src/AstrOsStringUtils.hpp:155` in the `stringFormat` template:
+
+```cpp
+template <typename... Args> static std::string stringFormat(const std::string &format, Args &&...args) {
+    auto size = std::snprintf(nullptr, 0, format.c_str(), std::forward<Args>(args)...);
+    std::string output(size + 1, '\0');
+    std::sprintf(&output[0], format.c_str(), std::forward<Args>(args)...);
+    return output;
+}
+```
+
+Although the preceding `std::snprintf(nullptr, 0, ...)` computes the exact needed size, using `std::sprintf` here is still a defense-in-depth issue — if `size` or `output` is ever mis-computed by a future edit, `sprintf` gives no bounds protection.
 
 ### Design
 
-Replace `sprintf(buf, ...)` with `snprintf(buf, sizeof(buf), ...)`. One-line change.
+Replace `std::sprintf(&output[0], format.c_str(), ...)` with `std::snprintf(&output[0], size + 1, format.c_str(), ...)`. One-line change.
 
 ### Risk
 
-Zero.
+Zero. Semantics unchanged when the existing `size` is correct; a safety net when it is not.
 
 ### Verification
 
-Covered by any existing test that exercises GUID generation.
+Build both board environments and run native tests (`stringFormat` is used across `lib/AstrOsMessaging`, which has native test coverage).
 
 ---
 

--- a/.docs/plans/20260414-0954-code-review-phase-c.md
+++ b/.docs/plans/20260414-0954-code-review-phase-c.md
@@ -1,0 +1,326 @@
+# Code Review — Phase C: Resilience & Defensive Hardening
+
+**Status:** Spec (design) — implementation plan produced separately via `superpowers:writing-plans`.
+**Date:** 2026-04-14
+**Scope:** P1 / P2 / P3 resilience and defensive-hardening items from `.docs/code-review/code-review.md` and `.docs/code-review/follow-up-findings.md`.
+**Preceded by:** Phase A (memory leaks, buffer safety — merged), Phase B (thread safety, synchronization — merged).
+
+---
+
+## Intent
+
+Phase C wraps up the code-review remediation work by addressing the remaining resilience items — queue sizing, timer-task stack pressure, filesystem error handling, and a handful of defensive patches. There are **no cross-cutting semantic decisions** in this phase; every task is a localized fix with bounded risk.
+
+Two classes of items from the code review are **explicitly deferred out of Phase C** to future features:
+
+- **Animation dispatch-failure propagation (FF-1), `std::stoi` → `strtol` migration (#14), script validation on deploy.** These are philosophically entangled: they require a cross-node panic-stop model (master fans out to padawans when any node halts internally) plus a script-corruption story. The operator-initiated panic-stop path already exists today and satisfies the "kill switch" intent. A proper design for internal panic-stop propagation and on-disk script-corruption handling will ship as a future feature.
+- **Deprecated I2C driver API migration (#18).** Scheduled to coincide with an ESP-IDF 5.x bump, not a code-review patch.
+- **`malloc` / `new` style convention doc (#25).** Documentation task, not a code change.
+
+---
+
+## Task List
+
+| # | Source | Task | Primary files |
+|---|---|---|---|
+| 1 | P2 #19 | Queue depth bumps on dispatch queues | `src/main.cpp` |
+| 2 | P2 #21 | Replace `animationTimer` + `esp_timer` callback with a dedicated `vTaskDelayUntil` dispatch task | `src/main.cpp` |
+| 3 | P1 #13 | I2C `i2c_cmd_link_delete` on all early-return paths | `lib/I2cMaster/src/I2cMaster.cpp` |
+| 4 | P2 #20 | `button_listener_task` stack: 2048 → 4096 | `src/main.cpp` |
+| 5 | P2 #22 + #23 + #24 + #26 | `AstrOsStorageManager` error hardening | `lib/AstrOsStorageManager/src/AstrOsStorageManager.cpp` |
+| 6 | P3 #28 | `guid.h` `sprintf` → `snprintf` | `lib/Uuid/guid.h` |
+| 7 | P3 #29 | Silent-error counters exposed via the 10 s maintenance log | `src/main.cpp` |
+| 8 | — | QA test plan | `.docs/qa/code-review-phase-c.md` |
+
+All eight are independently reversible. The only task that changes a function signature is Task 5 (`formatSdCard` → `esp_err_t` return); all others are internal.
+
+---
+
+## Task 1 — Queue depth bumps
+
+### Problem
+
+All nine FreeRTOS queues in `src/main.cpp` are created with `QUEUE_LENGTH = 5`. The animation dispatch path can enqueue one message per channel per frame, and bursty producers (maestro servo traffic, OLED display coinciding with animation frames) can fill a depth-5 queue faster than the consumer task drains it.
+
+### Design
+
+Raise depth on the five dispatch queues. Leave the four control/response queues (`animationQueue`, `serviceQueue`, `interfaceResponseQueue`, `espnowQueue`) at 5 — they carry low-rate coordination traffic.
+
+| Queue | Current | New | Rationale |
+|---|---|---|---|
+| `servoQueue` | 5 | 20 | Highest churn — fan-in from animation frames plus Maestro traffic; two PCA9685 boards produce bursts. |
+| `i2cQueue` | 5 | 16 | Shared by OLED display writes *and* animation I2C commands; display updates can coincide with animation frames. |
+| `serialCh1Queue` | 5 | 10 | Doubled for slack; at most one serial channel dispatched per frame. |
+| `serialCh2Queue` | 5 | 10 | Same. |
+| `gpioQueue` | 5 | 10 | Low frequency but cheap to double. |
+| Other queues | 5 | 5 | Unchanged. |
+
+### Risk
+
+Deeper queues mean an `xQueueSend` success no longer guarantees prompt consumer service. For animation sequencing this is acceptable because commands are already time-ordered by the dispatch task at fixed intervals; a deep queue just adds buffering headroom. Called out in the QA plan so tuning gets real-world validation.
+
+### Verification
+
+Smoke test multi-channel animation scripts and confirm no `"Send X queue fail"` warnings across repeated playbacks.
+
+---
+
+## Task 2 — Animation dispatch refactor: drop `esp_timer`
+
+### Problem
+
+The `animationTimerCallback` runs in the shared `esp_timer` service task (fixed ~4 KB stack). The callback performs multiple `malloc` / `memcpy` / string-format / `xQueueSend` operations per tick — contrary to the `esp_timer` idiom of returning in microseconds and risking stack overflow in the shared timer task.
+
+### Design
+
+Replace the timer + callback entirely with a dedicated FreeRTOS task:
+
+- **Delete** `animationTimer` (`esp_timer_handle_t`) and `animationTimerCallback()` from `src/main.cpp`.
+- **Create** `animationDispatchTask`, pinned to **core 1**, stack size **4096**, same priority tier as other I/O consumer tasks. High-water-mark check follows the project convention (warn at 500 bytes remaining).
+- **Loop shape:**
+
+  ```cpp
+  TickType_t lastWake = xTaskGetTickCount();
+  while (true) {
+      // Body of the former animationTimerCallback — minus esp_timer_start_once.
+      // Reads AnimationCtrl.scriptIsLoaded(), calls getNextCommandPtr(),
+      // switches on MODULE_TYPE, builds + enqueues downstream message.
+      // Free payload on xQueueSend failure (ownership convention unchanged).
+
+      uint32_t delayMs = AnimationCtrl.msTillNextServoCommand();
+      if (delayMs < 10) delayMs = 10;   // minimum wake interval; matches idle-poll granularity
+      vTaskDelayUntil(&lastWake, pdMS_TO_TICKS(delayMs));
+  }
+  ```
+
+- **`vTaskDelayUntil`** is deliberate: it schedules against an absolute last-wake timestamp, so the dispatch cadence doesn't drift by the command-build duration each iteration.
+- **Idle state** (no script loaded): the loop still runs, reads `scriptIsLoaded() == false`, takes the else branch, and sleeps on a minimum wake interval. Matches current callback behavior for the null-cmd recovery path from Phase B.
+- **Startup:** spawn `animationDispatchTask` in `setup()` alongside the other task creations. Remove the `esp_timer_create` + `esp_timer_start_once` calls for the animation timer.
+- **Shutdown:** `vTaskDelete` on the task handle if teardown is ever needed (not used today, listed for completeness).
+
+### Rationale for dropping `esp_timer`
+
+Considered keeping `esp_timer` + adding a dispatch queue + new task (tick-enqueue pattern). Rejected because:
+
+1. It preserves two state machines (timer + consumer task) to solve a problem that collapses into one (the task itself).
+2. The tick-enqueue dispatch queue is a new leak/ownership surface for no behavioral benefit — `vTaskDelayUntil` provides the cadence directly.
+3. Ownership of animation dispatch code consolidates into one location instead of being split between timer re-arm (in the callback) and state reads (in the controller).
+
+Tradeoffs accepted:
+
+- `vTaskDelay` resolution is 1 ms at `CONFIG_FREERTOS_HZ=1000`; `esp_timer` is microsecond-resolution. Not material for animation delays in the 10+ ms range.
+- The task is blocked in `vTaskDelayUntil` rather than `xQueueReceive`, so an external "wake immediately" pre-emption would need `xTaskNotify`. Not needed today; can be added later if required.
+
+### Risk
+
+Medium — animation dispatch timing is safety-relevant; any cadence regression is observable during real-world playback. Mitigated by:
+
+- `vTaskDelayUntil` honors absolute cadence.
+- Ownership / malloc / free semantics carry over verbatim from the current callback — no new allocation sites or frees.
+- Panic-stop latency is bounded by one `delayMs` cycle, same as today's `esp_timer_start_once` pattern — no regression vs. current behavior.
+
+### Verification
+
+QA plan includes timing observation via log timestamps, panic-stop mid-script, and script chaining (queue → run → queue → run). Dispatch latency should be below ~2 ms on top of the scripted delay.
+
+---
+
+## Task 3 — I2C `cmd` handle leaks
+
+### Problem
+
+`lib/I2cMaster/src/I2cMaster.cpp` uses the legacy ESP-IDF 4.x API pattern: `i2c_cmd_handle_t cmd = i2c_cmd_link_create()`, chain operations, `i2c_master_cmd_begin(cmd)`, `i2c_cmd_link_delete(cmd)`. On error paths that return early, `i2c_cmd_link_delete(cmd)` is skipped and the handle (plus its linked operations) leaks.
+
+### Design
+
+Audit every `i2c_cmd_link_create` call site in the file. For each, enumerate every early-return branch and ensure:
+
+1. `i2c_cmd_link_delete(cmd)` runs before the return.
+2. `xSemaphoreGive(i2cBusMutext)` runs before the return.
+3. Order: delete handle → give semaphore → return. Consistent across every call site.
+
+If the branch count is high at any single site (say 3+ early returns in one function), introduce a small stack-local RAII wrapper whose destructor calls `i2c_cmd_link_delete`. Only introduce the wrapper if it simplifies — plain cleanup is preferred when branch counts are low.
+
+### Risk
+
+Low. All edits are additive cleanup — no logic shifts.
+
+### Verification
+
+Hardware test: force I2C errors (disconnect a PCA9685), observe logs for repeated errors, confirm `esp_get_free_heap_size()` stays stable across ~5 minutes of induced failures.
+
+---
+
+## Task 4 — `button_listener_task` stack bump
+
+### Problem
+
+`xTaskCreatePinnedToCore(button_listener_task, "BTN", 2048, NULL, 5, NULL, 1)` — 2 KB is tight. Task does GPIO reads, `ESP_LOGW`, and queue sends; formatted logging alone consumes several hundred bytes of stack. The existing high-water-mark warning at 500 bytes remaining suggests this is already close to the edge.
+
+### Design
+
+Change the stack size argument from `2048` to `4096`. Aligns with the other I/O tasks in the codebase (servo / i2c / gpio consumer tasks).
+
+### Risk
+
+Effectively zero. +2 KB RAM — irrelevant on either board.
+
+### Verification
+
+Flash and observe the `BTN` high-water-mark log line over a typical session; confirm no warnings.
+
+---
+
+## Task 5 — `AstrOsStorageManager` error hardening
+
+Four review items collapse into one consolidated pass on `lib/AstrOsStorageManager/src/AstrOsStorageManager.cpp`.
+
+### 5a — File handle validation (#22)
+
+Every `fopen()` needs a `NULL` check before use, and no code should call `fclose(NULL)`. Mechanical audit: grep for `fopen`, confirm each call site has `if (fd == NULL) { ESP_LOGE(...); return error; }`, confirm no `fclose` is reachable with a potentially-null `fd`.
+
+### 5b — Path sanitization (#23)
+
+File paths built from external input (script names and peer names delivered via serial / ESP-NOW) must be rejected if they attempt to escape the intended mount point. Add a helper:
+
+```cpp
+bool isPathSafe(const char *path);
+```
+
+that returns false + logs the rejection reason when:
+
+- `path` contains `..` anywhere
+- `path` starts with `/` (scripts/configs are expected to be mount-relative)
+- `path` contains `//`
+- `path` length exceeds the downstream buffer (mount prefix + path + null terminator fits)
+
+Call `isPathSafe` at every site that constructs a filesystem path from externally-supplied data (load/save/delete script, load/save config, etc.). Reject with a logged error and propagate the failure upstream — callers already handle a bool-false return from storage ops.
+
+### 5c — `mkdir` return value checks (#24)
+
+Every `mkdir()` call must check the return. Success is either `0` or `errno == EEXIST` (pre-existing directory is fine). Any other `errno` gets logged with `ESP_LOGE` and propagated as a failure to the caller.
+
+### 5d — `formatSdCard` error distinction (#26)
+
+Today `formatSdCard` returns `bool false` for both "format failed" and "work-buffer OOM". Change:
+
+- Return type: `bool` → `esp_err_t`
+- Return values: `ESP_OK` on success, `ESP_ERR_NO_MEM` on work-buffer allocation failure, pass-through of `esp_vfs_fat_*` error codes on format failure.
+- Update the single caller in `main.cpp`'s service queue task to accept `esp_err_t` and surface the distinct errors to the interface response.
+
+### Scope guard
+
+No refactors, no other API changes. If a fifth issue surfaces during the work it gets logged as a follow-up finding, not absorbed into this task.
+
+### Risk
+
+Low-to-medium. 5d is a signature change with a single call site (tracked in lockstep). 5b could reject a path the web UI currently relies on — confirm during QA that realistic deploys still succeed.
+
+### Verification
+
+- Deploy a script with `..` in its name — NAK expected.
+- Deploy a script with a path over buffer length — NAK expected.
+- Deploy to a full SD — meaningful log + propagated failure to caller.
+- Format SD with no card present — `ESP_ERR_NO_MEM` (or equivalent) surfaces distinctly from a format-failed error.
+- Regression: confirm normal deploy/load/delete flows still work.
+
+---
+
+## Task 6 — GUID `sprintf` → `snprintf`
+
+### Problem
+
+`lib/Uuid/guid.h` uses `sprintf(buf, fmt, ...)` with a 64-byte stack buffer. The current format fits; this is pure defense against a future format-string edit.
+
+### Design
+
+Replace `sprintf(buf, ...)` with `snprintf(buf, sizeof(buf), ...)`. One-line change.
+
+### Risk
+
+Zero.
+
+### Verification
+
+Covered by any existing test that exercises GUID generation.
+
+---
+
+## Task 7 — Silent-error counters
+
+### Problem
+
+Two sites silently drop errors:
+
+- **`astrosRxTask()`** — on buffer overflow, resets `bufferIndex = 0` and discards the partial message with only a warning log.
+- **`espnowRecvCallback()`** — on `malloc` failure, returns without propagating the error.
+
+These are observable only if an operator happens to be watching the serial monitor when they occur. A running tally is cheaper to monitor.
+
+### Design
+
+Two atomic counters in `main.cpp`, exposed via the existing 10-second maintenance timer that already logs free heap:
+
+```cpp
+static std::atomic<uint32_t> astrosRxOverflowCount{0};
+static std::atomic<uint32_t> espnowMallocFailureCount{0};
+```
+
+Increment with `.fetch_add(1, std::memory_order_relaxed)` at each of the offending sites. In the maintenance timer callback, if either counter is non-zero, emit:
+
+```
+ESP_LOGI(TAG, "err-counters rx-overflow=%u espnow-malloc-fail=%u", ...)
+```
+
+Skip the log line entirely when both counters are zero — avoids noise in a healthy system.
+
+### Rationale for `std::atomic` over mutex
+
+Single-word increments are atomic on ESP32 with `<atomic>`. `espnowRecvCallback` runs in the Wi-Fi driver task — a mutex would add unnecessary latency on a hot ISR-adjacent path. Relaxed memory ordering is sufficient because the counters are read-only observation; no happens-before relationship is needed with other state.
+
+### Rationale for not building a general framework
+
+YAGNI. If a third site surfaces, add a third counter and a third tally in the log line. A registry / dynamic counter framework would be design speculation.
+
+### Risk
+
+Essentially zero. Additive code, log line is skipped when counters are zero.
+
+### Verification
+
+Force a buffer overflow in `astrosRxTask` (send oversized message), confirm counter increments in the next maintenance log cycle.
+
+---
+
+## Task 8 — QA test plan
+
+Deliverable: `.docs/qa/code-review-phase-c.md` with sections for each of the above tasks. Coverage:
+
+- **Queue depth** — multi-channel animation script, 10+ playbacks, no `"Send X queue fail"` warnings.
+- **Animation dispatch refactor** — timing vs. expected script delays, panic-stop responsiveness mid-script, script chaining, idle-to-active transitions.
+- **I2C leak** — induced-error heap-stability test over ~5 min.
+- **Button stack** — high-water-mark watch over a typical session.
+- **Storage hardening** — path-traversal deploys (expect NAK), oversized path deploys, full-SD deploy, format-with-no-card, regression on normal deploy/load/delete.
+- **GUID snprintf** — covered by existing GUID-exercising paths.
+- **Error counters** — induced buffer overflow, counter visible in 10 s maintenance log.
+- **Regression sweep** — full animation playback across all five dispatch channels, peer registration + polling, OLED updates.
+
+No new native unit tests — no Phase C work lands in `lib/AstrOsMessaging` or `lib/AstrOsUtility`. All verification is hardware-in-the-loop.
+
+---
+
+## Out of scope (deferred)
+
+| Item | Reason | Future home |
+|---|---|---|
+| FF-1 dispatch-failure propagation | Needs cross-node halt design; philosophically tied to script corruption | "Internal panic-stop + corruption handling" feature |
+| P1 #14 `std::stoi` → `strtol` | Parse-failure semantics are entangled with script validation and internal panic-stop | Same feature as above |
+| Script validation on deploy (implied by #14) | Proper feature scope — grammar, NAK messaging, web UI feedback | Same feature as above |
+| P1 #18 Deprecated I2C driver API | Paired with ESP-IDF 5.x bump | IDF bump project |
+| P2 #25 malloc/new style doc | Documentation, not a code change | Standalone doc PR |
+
+---
+
+## Commit and review
+
+Plan file committed to `.docs/plans/` before any implementation code lands, per the `CLAUDE.md` planning rule. Implementation plan with checklist produced separately by the `superpowers:writing-plans` skill once this spec is approved.

--- a/.docs/plans/20260414-1020-code-review-phase-c-impl.md
+++ b/.docs/plans/20260414-1020-code-review-phase-c-impl.md
@@ -1,0 +1,1277 @@
+# Code Review — Phase C Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `.docs/plans/20260414-0954-code-review-phase-c.md` — read it first for design rationale.
+**Goal:** Land the remaining P1/P2/P3 resilience items from the code review as a set of small, independently reviewable commits on branch `fix/code-review-phase-c`.
+**Architecture:** Eight localized refactors; no cross-cutting semantic decisions. Biggest change (Task 2) replaces the animation `esp_timer` callback with a dedicated FreeRTOS task using `vTaskDelayUntil`.
+**Tech Stack:** ESP-IDF / PlatformIO, FreeRTOS, C++17 (gnu++2a). Host-side native tests via googletest under `[env:test]`.
+
+---
+
+## Repository facts
+
+- Current branch: `fix/code-review-phase-c` (already created)
+- Primary files: `src/main.cpp` (7 tasks touch it), `lib/I2cMaster/src/I2cMaster.cpp`, `lib/AstrOsStorageManager/src/AstOsStorageManager.cpp` (note: filename has typo, missing 'r'), `lib/AstrOsUtility/src/AstrOsStringUtils.hpp`
+- Build commands: `pio run -e metro_s3`, `pio run -e lolin_d32_pro`, `pio test -e test`
+- Commit convention: scoped short subject (e.g., `fix:`, `perf:`, `refactor:`), body explaining *why*, Co-Authored-By trailer
+
+## Task execution order
+
+Front-load the small mechanical wins so the big animation refactor (Task 2) lands on a branch that's already been partially validated:
+
+1. Task 1 — queue depth bumps (mechanical)
+2. Task 4 — button task stack bump (one-liner)
+3. Task 6 — `stringFormat` `snprintf` (one-liner)
+4. Task 3 — I2C leak fixes (bounded)
+5. Task 7 — silent-error counters (additive)
+6. Task 5 — storage manager error hardening
+7. Task 2 — animation dispatch refactor (largest; kept last so prior commits are already green)
+8. Task 8 — QA test plan
+
+---
+
+## Task 1: Queue depth bumps
+
+**Files:**
+- Modify: `src/main.cpp:236-244`
+
+- [ ] **Step 1: Replace the queue creation block**
+
+`src/main.cpp` line 236 is currently:
+
+```cpp
+    animationQueue = xQueueCreate(QUEUE_LENGTH, sizeof(queue_ani_cmd_t));
+    serviceQueue = xQueueCreate(QUEUE_LENGTH, sizeof(queue_svc_cmd_t));
+    interfaceResponseQueue = xQueueCreate(QUEUE_LENGTH, sizeof(astros_interface_response_t));
+    serialCh1Queue = xQueueCreate(QUEUE_LENGTH, sizeof(queue_serial_msg_t));
+    serialCh2Queue = xQueueCreate(QUEUE_LENGTH, sizeof(queue_serial_msg_t));
+    servoQueue = xQueueCreate(QUEUE_LENGTH, sizeof(queue_msg_t));
+    i2cQueue = xQueueCreate(QUEUE_LENGTH, sizeof(queue_msg_t));
+    gpioQueue = xQueueCreate(QUEUE_LENGTH, sizeof(queue_msg_t));
+    espnowQueue = xQueueCreate(QUEUE_LENGTH, sizeof(queue_espnow_msg_t));
+```
+
+Replace with:
+
+```cpp
+    // Dispatch queues sized for fan-in from animationTimerCallback + producer bursts.
+    // Control queues stay at QUEUE_LENGTH (5) since they carry low-rate coordination.
+    animationQueue = xQueueCreate(QUEUE_LENGTH, sizeof(queue_ani_cmd_t));
+    serviceQueue = xQueueCreate(QUEUE_LENGTH, sizeof(queue_svc_cmd_t));
+    interfaceResponseQueue = xQueueCreate(QUEUE_LENGTH, sizeof(astros_interface_response_t));
+    serialCh1Queue = xQueueCreate(10, sizeof(queue_serial_msg_t));
+    serialCh2Queue = xQueueCreate(10, sizeof(queue_serial_msg_t));
+    servoQueue = xQueueCreate(20, sizeof(queue_msg_t));
+    i2cQueue = xQueueCreate(16, sizeof(queue_msg_t));
+    gpioQueue = xQueueCreate(10, sizeof(queue_msg_t));
+    espnowQueue = xQueueCreate(QUEUE_LENGTH, sizeof(queue_espnow_msg_t));
+```
+
+- [ ] **Step 2: Build both board environments**
+
+```
+pio run -e metro_s3
+pio run -e lolin_d32_pro
+```
+
+Expected: both complete with no new warnings attributable to the change.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main.cpp
+git commit -m "$(cat <<'EOF'
+perf: bump dispatch queue depths to reduce send-fail under bursty animation frames
+
+servoQueue 5→20 (highest churn, fan-in from animation + Maestro),
+i2cQueue 5→16 (shared by OLED writes and animation I2C),
+serialCh1/Ch2/gpio 5→10 (double current for slack).
+Control queues unchanged — they carry low-rate coordination traffic.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `button_listener_task` stack bump
+
+**Files:**
+- Modify: `src/main.cpp:199`
+
+- [ ] **Step 1: Change the stack size**
+
+Line 199 is currently:
+
+```cpp
+    xTaskCreatePinnedToCore(&buttonListenerTask, "button_listener_task", 2048, (void *)serviceQueue, 5, NULL, 1);
+```
+
+Change `2048` to `4096`:
+
+```cpp
+    xTaskCreatePinnedToCore(&buttonListenerTask, "button_listener_task", 4096, (void *)serviceQueue, 5, NULL, 1);
+```
+
+- [ ] **Step 2: Build both envs**
+
+```
+pio run -e metro_s3
+pio run -e lolin_d32_pro
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main.cpp
+git commit -m "$(cat <<'EOF'
+fix: bump button_listener_task stack 2048→4096 to match other I/O tasks
+
+Task does GPIO reads, formatted logging, and queue sends; 2 KB is tight
+and the existing 500-byte HWM warning suggests it sits close to the edge.
+4 KB aligns with the other I/O consumer tasks in the codebase.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: `stringFormat` `std::sprintf` → `std::snprintf`
+
+**Files:**
+- Modify: `lib/AstrOsUtility/src/AstrOsStringUtils.hpp:155`
+
+- [ ] **Step 1: Change `sprintf` to `snprintf` with explicit bound**
+
+Line 151-157 is currently:
+
+```cpp
+    template <typename... Args> static std::string stringFormat(const std::string &format, Args &&...args)
+    {
+        auto size = std::snprintf(nullptr, 0, format.c_str(), std::forward<Args>(args)...);
+        std::string output(size + 1, '\0');
+        std::sprintf(&output[0], format.c_str(), std::forward<Args>(args)...);
+        return output;
+    }
+```
+
+Replace line 155 (`std::sprintf(...)` call) with a bounded `std::snprintf`:
+
+```cpp
+    template <typename... Args> static std::string stringFormat(const std::string &format, Args &&...args)
+    {
+        auto size = std::snprintf(nullptr, 0, format.c_str(), std::forward<Args>(args)...);
+        std::string output(size + 1, '\0');
+        std::snprintf(&output[0], size + 1, format.c_str(), std::forward<Args>(args)...);
+        return output;
+    }
+```
+
+- [ ] **Step 2: Build both envs + run native tests**
+
+```
+pio run -e metro_s3
+pio run -e lolin_d32_pro
+pio test -e test
+```
+
+Expected: native tests pass (`stringFormat` is used transitively in `lib/AstrOsMessaging` which has unit test coverage).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/AstrOsUtility/src/AstrOsStringUtils.hpp
+git commit -m "$(cat <<'EOF'
+fix: replace std::sprintf with bounded std::snprintf in stringFormat
+
+The preceding snprintf(nullptr, 0, ...) computes the exact needed size,
+but using sprintf on the output buffer offers no bounds protection if
+a future edit ever miscomputes size. Defense in depth; no behavior change
+when size is correct.
+
+Note: lib/Uuid/guid.h already uses snprintf — the code review's #28 flag
+for that file was stale. This commit addresses the real remaining sprintf
+site in the codebase.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: I2C `cmd` handle leak fixes
+
+**Files:**
+- Modify: `lib/I2cMaster/src/I2cMaster.cpp`
+
+### Step-by-step
+
+- [ ] **Step 1: Fix `DeviceExists` — add missing delete (lines 44-59)**
+
+Current:
+
+```cpp
+bool I2cMaster::DeviceExists(uint8_t addr)
+{
+    esp_err_t res = ESP_OK;
+
+    if (xSemaphoreTake(i2cBusMutext, pdMS_TO_TICKS(SEMAPHORE_TIMEOUT)) == pdTRUE)
+    {
+        i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+        i2c_master_start(cmd);
+        i2c_master_write_byte(cmd, (addr << 1) | I2C_MASTER_WRITE, 1 /* expect ack */);
+        i2c_master_stop(cmd);
+
+        res = i2c_master_cmd_begin(I2C_NUM_0, cmd, 10 / portTICK_PERIOD_MS);
+        xSemaphoreGive(i2cBusMutext);
+    }
+    return res == ESP_OK;
+}
+```
+
+Replace with:
+
+```cpp
+bool I2cMaster::DeviceExists(uint8_t addr)
+{
+    esp_err_t res = ESP_OK;
+
+    if (xSemaphoreTake(i2cBusMutext, pdMS_TO_TICKS(SEMAPHORE_TIMEOUT)) == pdTRUE)
+    {
+        i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+        i2c_master_start(cmd);
+        i2c_master_write_byte(cmd, (addr << 1) | I2C_MASTER_WRITE, 1 /* expect ack */);
+        i2c_master_stop(cmd);
+
+        res = i2c_master_cmd_begin(I2C_NUM_0, cmd, 10 / portTICK_PERIOD_MS);
+        i2c_cmd_link_delete(cmd);
+        xSemaphoreGive(i2cBusMutext);
+    }
+    return res == ESP_OK;
+}
+```
+
+- [ ] **Step 2: Fix `ReadWord` — remove stray create + double-delete (lines 190-243)**
+
+Current shape (abbreviated — see file for full context):
+
+```cpp
+        // ... first cmd: write register ...
+        i2c_cmd_link_delete(cmd);                     // line 202
+        if (err != ESP_OK) { ...return false; }
+        cmd = i2c_cmd_link_create();                  // line 209 — LEAK: never deleted
+        i2c_master_start(cmd);                        // line 210
+
+        uint8_t buffer1;
+        uint8_t buffer2;
+
+        cmd = i2c_cmd_link_create();                  // line 215 — overwrites leaked handle
+        i2c_master_start(cmd);
+        // ... read both bytes ...
+        err = i2c_master_cmd_begin(...);              // line 221
+        i2c_cmd_link_delete(cmd);                     // line 222
+        if (err != ESP_OK) { ...return false; }
+        *data = (buffer1 << 8) | buffer2;
+        i2c_cmd_link_delete(cmd);                     // line 233 — DOUBLE-FREE
+```
+
+Remove lines 209, 210, and 233. The cleaned function body (replacing lines 190-243) is:
+
+```cpp
+bool I2cMaster::ReadWord(uint8_t addr, uint8_t registerAddr, uint16_t *data)
+{
+    esp_err_t err = ESP_OK;
+
+    if (xSemaphoreTake(i2cBusMutext, pdMS_TO_TICKS(SEMAPHORE_TIMEOUT)) == pdTRUE)
+    {
+        i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+        i2c_master_start(cmd);
+        i2c_master_write_byte(cmd, (addr << 1) | I2C_MASTER_WRITE, ACK_CHECK_EN);
+        i2c_master_write_byte(cmd, registerAddr, ACK_CHECK_EN);
+        i2c_master_stop(cmd);
+        err = i2c_master_cmd_begin(I2C_NUM_0, cmd, 1000 / portTICK_PERIOD_MS);
+        i2c_cmd_link_delete(cmd);
+        if (err != ESP_OK)
+        {
+            ESP_LOGE("I2C", "Failed to write to device: %s", esp_err_to_name(err));
+            xSemaphoreGive(i2cBusMutext);
+            return false;
+        }
+
+        uint8_t buffer1;
+        uint8_t buffer2;
+
+        cmd = i2c_cmd_link_create();
+        i2c_master_start(cmd);
+        i2c_master_write_byte(cmd, (addr << 1) | I2C_MASTER_READ, ACK_CHECK_EN);
+        i2c_master_read_byte(cmd, &buffer1, (i2c_ack_type_t)ACK_VAL);
+        i2c_master_read_byte(cmd, &buffer2, (i2c_ack_type_t)NACK_VAL);
+        i2c_master_stop(cmd);
+        err = i2c_master_cmd_begin(I2C_NUM_0, cmd, 1000 / portTICK_PERIOD_MS);
+        i2c_cmd_link_delete(cmd);
+
+        if (err != ESP_OK)
+        {
+            ESP_LOGE("I2C", "Failed to read from device: %s", esp_err_to_name(err));
+            xSemaphoreGive(i2cBusMutext);
+            return false;
+        }
+
+        *data = (buffer1 << 8) | buffer2;
+
+        xSemaphoreGive(i2cBusMutext);
+    }
+
+    if (err != ESP_OK)
+    {
+        ESP_LOGE("I2C", "Failed to read from device: %s", esp_err_to_name(err));
+    }
+
+    return err == ESP_OK;
+}
+```
+
+- [ ] **Step 3: Fix `ReadTwoWords` — same pattern (lines 245-316)**
+
+The function has the same leak+double-free shape: stray create at 264-265 (leak) and duplicate delete at line 306. Replace the function body (lines 245-316) with:
+
+```cpp
+bool I2cMaster::ReadTwoWords(uint8_t addr, uint8_t registerAddr, uint16_t *data1, uint16_t *data2)
+{
+    esp_err_t err = ESP_OK;
+
+    if (xSemaphoreTake(i2cBusMutext, pdMS_TO_TICKS(SEMAPHORE_TIMEOUT)) == pdTRUE)
+    {
+        i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+        i2c_master_start(cmd);
+        i2c_master_write_byte(cmd, (addr << 1) | I2C_MASTER_WRITE, ACK_CHECK_EN);
+        i2c_master_write_byte(cmd, registerAddr, ACK_CHECK_EN);
+        i2c_master_stop(cmd);
+        err = i2c_master_cmd_begin(I2C_NUM_0, cmd, 1000 / portTICK_PERIOD_MS);
+        i2c_cmd_link_delete(cmd);
+        if (err != ESP_OK)
+        {
+            ESP_LOGE("I2C", "Failed to write to device: %s", esp_err_to_name(err));
+            xSemaphoreGive(i2cBusMutext);
+            return false;
+        }
+
+        uint8_t buffer1;
+        uint8_t buffer2;
+
+        cmd = i2c_cmd_link_create();
+        i2c_master_start(cmd);
+        i2c_master_write_byte(cmd, (addr << 1) | I2C_MASTER_READ, ACK_CHECK_EN);
+        i2c_master_read_byte(cmd, &buffer1, (i2c_ack_type_t)ACK_VAL);
+        i2c_master_read_byte(cmd, &buffer2, (i2c_ack_type_t)NACK_VAL);
+        i2c_master_stop(cmd);
+        err = i2c_master_cmd_begin(I2C_NUM_0, cmd, 1000 / portTICK_PERIOD_MS);
+        i2c_cmd_link_delete(cmd);
+
+        if (err != ESP_OK)
+        {
+            ESP_LOGE("I2C", "Failed to read from device:%s", esp_err_to_name(err));
+            xSemaphoreGive(i2cBusMutext);
+            return false;
+        }
+
+        *data1 = (buffer1 << 8) | buffer2;
+
+        cmd = i2c_cmd_link_create();
+        i2c_master_start(cmd);
+        i2c_master_write_byte(cmd, (addr << 1) | I2C_MASTER_READ, ACK_CHECK_EN);
+        i2c_master_read_byte(cmd, &buffer1, (i2c_ack_type_t)ACK_VAL);
+        i2c_master_read_byte(cmd, &buffer2, (i2c_ack_type_t)NACK_VAL);
+        i2c_master_stop(cmd);
+        err = i2c_master_cmd_begin(I2C_NUM_0, cmd, 1000 / portTICK_PERIOD_MS);
+        i2c_cmd_link_delete(cmd);
+
+        if (err != ESP_OK)
+        {
+            ESP_LOGE("I2C", "Failed to read from device:%s", esp_err_to_name(err));
+            xSemaphoreGive(i2cBusMutext);
+            return false;
+        }
+
+        *data2 = (buffer1 << 8) | buffer2;
+
+        xSemaphoreGive(i2cBusMutext);
+    }
+
+    if (err != ESP_OK)
+    {
+        ESP_LOGE("I2C", "Failed to read from device:%s", esp_err_to_name(err));
+    }
+
+    return err == ESP_OK;
+}
+```
+
+- [ ] **Step 4: Verify no other `i2c_cmd_link_create` sites have unpaired cleanup**
+
+Run the verification grep (via the Grep tool, not shell `grep`):
+
+- Pattern: `i2c_cmd_link_create|i2c_cmd_link_delete`
+- Path: `lib/I2cMaster/src/I2cMaster.cpp`
+
+Expected: every `i2c_cmd_link_create` (excluding the commented-out migration block starting at line 318) has a matching `i2c_cmd_link_delete` on every path. `WriteByte`, `WriteWord`, `WriteTwoWords`, `ReadByte` already satisfy this.
+
+- [ ] **Step 5: Build both envs**
+
+```
+pio run -e metro_s3
+pio run -e lolin_d32_pro
+```
+
+Expected: clean build; no warnings about unused handles or double-free.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/I2cMaster/src/I2cMaster.cpp
+git commit -m "$(cat <<'EOF'
+fix: eliminate I2C cmd-handle leaks and double-free in I2cMaster
+
+Three specific bugs fixed:
+- DeviceExists never called i2c_cmd_link_delete on its handle.
+- ReadWord leaked one cmd (line 209 create never deleted, overwritten by
+  another create at 215) and then double-freed another at line 233.
+- ReadTwoWords had the same leak-plus-double-free shape at 264/306.
+
+No change to control flow on the success path; error-path semantics
+preserved (log, give semaphore, return false).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Silent-error counters
+
+**Files:**
+- Modify: `src/main.cpp` (globals block around line 88, `maintenanceTimerCallback` at line 474, `astrosRxTask` at line 908, `espnowRecvCallback` at line 1632)
+
+- [ ] **Step 1: Add the counter globals near the other timer globals**
+
+In the globals block starting at `src/main.cpp:88`, after the existing `static esp_timer_handle_t ...;` declarations (around line 95), insert:
+
+```cpp
+// Silent-error counters — incremented from cross-task contexts (Wi-Fi driver task
+// for espnowRecvCallback, astrosRxTask on core 0). Read from maintenanceTimerCallback
+// (esp_timer task). std::atomic<uint32_t> is single-word on ESP32 and provides the
+// memory visibility we need without a mutex on the hot paths.
+static std::atomic<uint32_t> astrosRxOverflowCount{0};
+static std::atomic<uint32_t> espnowMallocFailureCount{0};
+```
+
+Verify `<atomic>` is already included in `main.cpp` (it should be — Phase B added it for other atomic globals). If not, add `#include <atomic>` with the other includes at the top.
+
+- [ ] **Step 2: Update `maintenanceTimerCallback` to log the counters**
+
+Current (line 474):
+
+```cpp
+static void maintenanceTimerCallback(void *arg)
+{
+    ESP_LOGI(TAG, "RAM left %lu", esp_get_free_heap_size());
+}
+```
+
+Replace with:
+
+```cpp
+static void maintenanceTimerCallback(void *arg)
+{
+    ESP_LOGI(TAG, "RAM left %lu", esp_get_free_heap_size());
+
+    uint32_t rxOverflow = astrosRxOverflowCount.load(std::memory_order_relaxed);
+    uint32_t espnowMallocFail = espnowMallocFailureCount.load(std::memory_order_relaxed);
+    if (rxOverflow != 0 || espnowMallocFail != 0)
+    {
+        ESP_LOGW(TAG, "err-counters rx-overflow=%" PRIu32 " espnow-malloc-fail=%" PRIu32,
+                 rxOverflow, espnowMallocFail);
+    }
+}
+```
+
+If `<cinttypes>` is not already included (it provides `PRIu32`), add `#include <cinttypes>` at the top of the file.
+
+- [ ] **Step 3: Increment on buffer overflow in `astrosRxTask`**
+
+Current (line 944-948):
+
+```cpp
+                    if (bufferIndex >= bufferLength)
+                    {
+                        ESP_LOGW("AstrOs RX", "Buffer overflow");
+                        bufferIndex = 0;
+                    }
+```
+
+Replace with:
+
+```cpp
+                    if (bufferIndex >= bufferLength)
+                    {
+                        ESP_LOGW("AstrOs RX", "Buffer overflow");
+                        astrosRxOverflowCount.fetch_add(1, std::memory_order_relaxed);
+                        bufferIndex = 0;
+                    }
+```
+
+- [ ] **Step 4: Increment on malloc failure in `espnowRecvCallback`**
+
+Current (line 1650-1655):
+
+```cpp
+    msg.data = (uint8_t *)malloc(len);
+    if (msg.data == NULL)
+    {
+        ESP_LOGE(TAG, "Malloc receive data fail");
+        return;
+    }
+```
+
+Replace with:
+
+```cpp
+    msg.data = (uint8_t *)malloc(len);
+    if (msg.data == NULL)
+    {
+        ESP_LOGE(TAG, "Malloc receive data fail");
+        espnowMallocFailureCount.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+```
+
+- [ ] **Step 5: Build both envs**
+
+```
+pio run -e metro_s3
+pio run -e lolin_d32_pro
+```
+
+Expected: clean build.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main.cpp
+git commit -m "$(cat <<'EOF'
+fix: add silent-error counters for RX overflow and ESP-NOW malloc failure
+
+Two sites previously dropped errors with only a log line, observable only
+if someone happened to be watching the serial monitor:
+- astrosRxTask buffer overflow (oversized incoming message discarded)
+- espnowRecvCallback malloc failure (incoming packet dropped)
+
+Counters are atomic<uint32_t> (single-word on ESP32, cross-task safe with
+relaxed ordering) and are logged as a single line from the existing 10-second
+maintenance timer when either is non-zero. Zero-count case is silent to
+avoid log noise on a healthy system.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `AstrOsStorageManager` error hardening
+
+**Files:**
+- Modify: `lib/AstrOsStorageManager/src/AstOsStorageManager.cpp` (note: filename is missing an 'r' — historical typo)
+- Modify: `lib/AstrOsStorageManager/include/AstrOsStorageManager.hpp` (signature change for `formatSdCard`)
+- Modify: `src/main.cpp` (single caller of `formatSdCard` — find via grep)
+
+### Step-by-step
+
+- [ ] **Step 1: Add `isPathSafe` helper — header declaration**
+
+In `lib/AstrOsStorageManager/include/AstrOsStorageManager.hpp`, in the class's private section (or public if other code calls it — private is preferred since it's a defensive check internal to the storage manager), declare:
+
+```cpp
+    // Returns true if the supplied (potentially externally-sourced) path is safe
+    // to combine with the mount prefix. Rejects ".." traversal, absolute paths,
+    // "//" collapse, and paths that would overflow the downstream buffer.
+    static bool isPathSafe(const std::string &path);
+```
+
+Place the declaration with the other private static helpers.
+
+- [ ] **Step 2: Add `isPathSafe` implementation**
+
+In `lib/AstrOsStorageManager/src/AstOsStorageManager.cpp`, near the top of the file with the other static helpers, add:
+
+```cpp
+bool AstrOsStorageManager::isPathSafe(const std::string &path)
+{
+    if (path.empty())
+    {
+        ESP_LOGE(TAG, "isPathSafe: empty path rejected");
+        return false;
+    }
+    if (path[0] == '/')
+    {
+        ESP_LOGE(TAG, "isPathSafe: absolute path rejected: %s", path.c_str());
+        return false;
+    }
+    if (path.find("..") != std::string::npos)
+    {
+        ESP_LOGE(TAG, "isPathSafe: traversal component rejected: %s", path.c_str());
+        return false;
+    }
+    if (path.find("//") != std::string::npos)
+    {
+        ESP_LOGE(TAG, "isPathSafe: double-slash rejected: %s", path.c_str());
+        return false;
+    }
+    // Cap at a conservative length leaving room for the mount prefix and null.
+    // The mount prefix is MOUNT_POINT (usually "/sdcard") plus a '/' separator.
+    constexpr size_t MAX_PATH_LEN = 128;
+    if (path.size() > MAX_PATH_LEN)
+    {
+        ESP_LOGE(TAG, "isPathSafe: path too long (%zu > %zu): %s",
+                 path.size(), MAX_PATH_LEN, path.c_str());
+        return false;
+    }
+    return true;
+}
+```
+
+- [ ] **Step 3: Gate every externally-sourced path call through `isPathSafe`**
+
+The path-constructing helper `setFilePath` is called by `saveFileSd`, `deleteFileSd`, `fileExistsSd`, `readFileSd`, `saveFileSpiffs`, `deleteFileSpiffs`, `fileExistsSpiffs`, `readFileSpiffs`, `listFilesSpiffs`. For each of the SD-card and SPIFFS entrypoints that take a `filename` or `folder` parameter from external input, insert `isPathSafe` at the top before `setFilePath`:
+
+Example for `saveFileSd` (around line 570):
+
+```cpp
+bool AstrOsStorageManager::saveFileSd(std::string filename, std::string data)
+{
+    if (!isPathSafe(filename))
+    {
+        return false;
+    }
+    FILE *fd = NULL;
+    std::string path = AstrOsStorageManager::setFilePath(filename);
+    // ... rest unchanged ...
+}
+```
+
+Do the same at the top of each of:
+- `saveFileSd`, `deleteFileSd`, `fileExistsSd`, `readFileSd` (SD card entrypoints)
+- `saveFileSpiffs`, `deleteFileSpiffs`, `fileExistsSpiffs`, `readFileSpiffs`, `listFilesSpiffs` (SPIFFS entrypoints)
+
+For `readFileSd` and `readFileSpiffs` which return `std::string` instead of `bool`, return `"error"` on reject (matches their existing `"error"` failure contract).
+
+For `listFilesSd` and `listFilesSpiffs` (list operations), also gate on `isPathSafe` — return empty vector on reject.
+
+- [ ] **Step 4: Check `mkdir` return values in `formatSdCard`**
+
+Current (lines 493-495):
+
+```cpp
+    mkdir(SCRIPTS_FOLDER, 0777);
+    mkdir(MAESTRO_FOLDER, 0777);
+    mkdir(GPIO_FOLDER, 0777);
+```
+
+Replace with:
+
+```cpp
+    for (const char *folder : {SCRIPTS_FOLDER, MAESTRO_FOLDER, GPIO_FOLDER})
+    {
+        if (mkdir(folder, 0777) != 0 && errno != EEXIST)
+        {
+            ESP_LOGE(TAG, "Failed to create folder %s: errno=%d (%s)",
+                     folder, errno, strerror(errno));
+            free(workbuf);
+            return ESP_FAIL;  // will become esp_err_t after Step 5
+        }
+    }
+```
+
+Add `#include <errno.h>` and `#include <string.h>` at the top of the file if not already present (likely already present).
+
+- [ ] **Step 5: Change `formatSdCard` signature to `esp_err_t`**
+
+In `lib/AstrOsStorageManager/include/AstrOsStorageManager.hpp` line 61, change:
+
+```cpp
+    bool formatSdCard();
+```
+
+to:
+
+```cpp
+    esp_err_t formatSdCard();
+```
+
+In `lib/AstrOsStorageManager/src/AstOsStorageManager.cpp` line 461, replace the function definition:
+
+```cpp
+esp_err_t AstrOsStorageManager::formatSdCard()
+{
+    char drv[3] = {'0', ':', 0};
+    const size_t workbuf_size = 4096;
+    void *workbuf = NULL;
+    ESP_LOGI(TAG, "Formatting the SD card");
+
+    size_t allocation_unit_size = 16 * 1024;
+
+    workbuf = ff_memalloc(workbuf_size);
+    if (workbuf == NULL)
+    {
+        ESP_LOGE(TAG, "Error formatting SD card: work-buffer allocation failed");
+        return ESP_ERR_NO_MEM;
+    }
+
+    size_t alloc_unit_size = esp_vfs_fat_get_allocation_unit_size(card->csd.sector_size, allocation_unit_size);
+
+    MKFS_PARM param;
+    param.fmt = FM_ANY;
+    param.au_size = alloc_unit_size;
+
+    FRESULT res = f_mkfs(drv, &param, workbuf, workbuf_size);
+    if (res != FR_OK)
+    {
+        ESP_LOGE(TAG, "Error formatting SD card: f_mkfs failed (%d)", res);
+        free(workbuf);
+        return ESP_FAIL;
+    }
+
+    free(workbuf);
+
+    for (const char *folder : {SCRIPTS_FOLDER, MAESTRO_FOLDER, GPIO_FOLDER})
+    {
+        if (mkdir(folder, 0777) != 0 && errno != EEXIST)
+        {
+            ESP_LOGE(TAG, "Failed to create folder %s: errno=%d (%s)",
+                     folder, errno, strerror(errno));
+            return ESP_FAIL;
+        }
+    }
+
+    ESP_LOGI(TAG, "Successfully formatted the SD card");
+    return ESP_OK;
+}
+```
+
+Note: the previous error path at line 488 returned `false` *without* freeing `workbuf` — that was a pre-existing leak. The replacement above fixes it.
+
+- [ ] **Step 6: Update the single `formatSdCard` caller in `main.cpp`**
+
+Find the caller via a Grep for `formatSdCard`. It lives in `handleFormatSD` (called from the service queue task). The caller currently expects `bool` — update it to handle `esp_err_t`:
+
+Locate the call site, currently of the form:
+
+```cpp
+    if (AstrOs_Storage.formatSdCard())
+    {
+        // success path
+    }
+    else
+    {
+        // failure path
+    }
+```
+
+Replace with:
+
+```cpp
+    esp_err_t formatErr = AstrOs_Storage.formatSdCard();
+    if (formatErr == ESP_OK)
+    {
+        // success path
+    }
+    else
+    {
+        ESP_LOGE(TAG, "formatSdCard failed: %s", esp_err_to_name(formatErr));
+        // failure path — surface distinct error if the interface response carries one
+    }
+```
+
+If `handleFormatSD` sends an interface response with a message field, include `esp_err_to_name(formatErr)` so the web UI sees which failure occurred. Read the current `handleFormatSD` body to adapt to the exact shape of the response it sends.
+
+- [ ] **Step 7: Audit `fopen`/`fclose` sites — confirm no regression**
+
+Grep for `fopen|fclose` in `lib/AstrOsStorageManager/src/AstOsStorageManager.cpp`. Current state (from pre-plan exploration):
+
+- Line 584 (`saveFileSd`): `if (!fd) return false;` ✓
+- Line 631 (`readFileSd`): `if (f == NULL) return "error";` ✓
+- Line 712 (`saveFileSpiffs`): `if (f == NULL) return false;` ✓
+- Line 804 (`readFileSpiffs`): `if (file == NULL) return "error";` ✓
+
+All are protected. This step is a confirmation audit — no change to files unless a new unprotected site is discovered during the audit. If so, add the `NULL` check before use.
+
+- [ ] **Step 8: Build both envs**
+
+```
+pio run -e metro_s3
+pio run -e lolin_d32_pro
+```
+
+Expected: clean build.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add lib/AstrOsStorageManager/ src/main.cpp
+git commit -m "$(cat <<'EOF'
+fix: AstrOsStorageManager error hardening — path safety, mkdir checks, format error codes
+
+Four code-review items consolidated into one pass:
+
+- Add isPathSafe helper rejecting .. traversal, absolute paths, //,
+  and overlong paths. Gate every externally-sourced path entrypoint
+  through it (SD and SPIFFS load/save/delete/exists/list).
+- Check mkdir return values in formatSdCard; previously ignored.
+- Convert formatSdCard bool→esp_err_t so callers can distinguish
+  work-buffer OOM from format failure.
+- Fix pre-existing workbuf leak on the f_mkfs-failed path.
+
+Update the single caller in main.cpp's handleFormatSD to match.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Animation dispatch refactor — drop `esp_timer`
+
+**Files:**
+- Modify: `src/main.cpp` (delete `animationTimer` global and `animationTimerCallback`; add `animationDispatchTask`; wire up task creation; remove timer setup)
+
+Port the existing `animationTimerCallback` body verbatim into a new FreeRTOS task, driven by `vTaskDelayUntil` using `AnimationCtrl.msTillNextServoCommand()` as the wake delta. Preserve all malloc/free ownership semantics.
+
+### Step-by-step
+
+- [ ] **Step 1: Remove the `animationTimer` global (line 92)**
+
+Delete line 92:
+
+```cpp
+static esp_timer_handle_t animationTimer;
+```
+
+- [ ] **Step 2: Remove the forward declaration of `animationTimerCallback` (line 150)**
+
+Delete line 150:
+
+```cpp
+static void animationTimerCallback(void *arg);
+```
+
+- [ ] **Step 3: Add forward declaration of the new task**
+
+In the task declarations section near the other `void <name>Task(void *arg);` forward decls, add:
+
+```cpp
+void animationDispatchTask(void *arg);
+```
+
+- [ ] **Step 4: Remove the `animationTimer` creation and start in `initTimers` (lines 363-367 and 386-388)**
+
+Delete the timer-args block for `animation`:
+
+```cpp
+    const esp_timer_create_args_t aTimerArgs = {.callback = &animationTimerCallback,
+                                                .arg = NULL,
+                                                .dispatch_method = ESP_TIMER_TASK,
+                                                .name = "animation",
+                                                .skip_unhandled_events = true};
+```
+
+And delete the create + start + log lines:
+
+```cpp
+    ESP_ERROR_CHECK(esp_timer_create(&aTimerArgs, &animationTimer));
+    ESP_ERROR_CHECK(esp_timer_start_once(animationTimer, 5 * 1000 * 1000));
+    ESP_LOGI("init_timer", "Started animation timer");
+```
+
+- [ ] **Step 5: Replace the `animationTimerCallback` body with `animationDispatchTask`**
+
+Delete the entire function body (lines 479-626, starting `static void animationTimerCallback` and ending at its closing `}`), and replace with the new task. Drop-in replacement (keep at approximately the same file location so diffs are tidy):
+
+```cpp
+void animationDispatchTask(void *arg)
+{
+    TickType_t lastWake = xTaskGetTickCount();
+    constexpr uint32_t MIN_WAKE_MS = 10;
+    constexpr uint32_t IDLE_WAKE_MS = 250;
+
+    while (1)
+    {
+        auto highWaterMark = uxTaskGetStackHighWaterMark(NULL);
+        if (highWaterMark < 500)
+        {
+            ESP_LOGW(TAG, "Animation Dispatch Stack HWM: %d", highWaterMark);
+        }
+
+        uint32_t nextDelayMs = IDLE_WAKE_MS;
+
+        if (AnimationCtrl.scriptIsLoaded())
+        {
+            auto cmd = AnimationCtrl.getNextCommandPtr();
+
+            if (cmd == nullptr)
+            {
+                // getNextCommandPtr returns nullptr only on mutex timeout, in which
+                // case it has also set scriptLoaded=false (halting the current
+                // sequence — see AnimationController.cpp for the safety rationale).
+                // We loop normally; on the next iteration scriptIsLoaded() returns
+                // false and we take the idle wake interval until a future queueScript
+                // resumes animation. Without this, a single transient mutex
+                // contention would require a device reboot to restore animation
+                // — bad, because third-party hardware may be in a non-safe state
+                // that a recovery script (not a power-cycle) needs to address.
+                ESP_LOGE(TAG, "Animation command pointer is null — script halted, dispatch task idling for recovery");
+                nextDelayMs = IDLE_WAKE_MS;
+            }
+            else
+            {
+                MODULE_TYPE ct = cmd->type;
+                std::string val = cmd->val;
+                int module = cmd->module;
+
+                switch (ct)
+                {
+                case MODULE_TYPE::NONE:
+                {
+                    ESP_LOGI(TAG, "NONE command queued, assume buffer?");
+                    break;
+                }
+                case MODULE_TYPE::KANGAROO:
+                case MODULE_TYPE::GENERIC_SERIAL:
+                {
+                    ESP_LOGI(TAG, "Serial command val: %s", val.c_str());
+
+                    // replace any occurances of \n with actual new line character
+                    std::string formatted;
+                    for (size_t i = 0; i < val.size(); i++)
+                    {
+                        if (val[i] == '\\' && i + 1 < val.size() && val[i + 1] == 'n')
+                        {
+                            formatted += '\n';
+                            i++;
+                        }
+                        else if (val[i] == '\\' && i + 1 < val.size() && val[i + 1] == 'r')
+                        {
+                            formatted += '\r';
+                            i++;
+                        }
+                        else
+                        {
+                            formatted += val[i];
+                        }
+                    }
+
+                    queue_serial_msg_t serialMsg;
+                    serialMsg.message_id = 0;
+                    serialMsg.data = (uint8_t *)malloc(formatted.size() + 1);
+                    memcpy(serialMsg.data, formatted.c_str(), formatted.size());
+                    serialMsg.data[formatted.size()] = '\0';
+
+                    if (module == 1)
+                    {
+                        if (xQueueSend(serialCh1Queue, &serialMsg, pdMS_TO_TICKS(2000)) != pdTRUE)
+                        {
+                            ESP_LOGW(TAG, "Send serial queue fail");
+                            free(serialMsg.data);
+                        }
+                    }
+                    else if (module == 2)
+                    {
+                        if (xQueueSend(serialCh2Queue, &serialMsg, pdMS_TO_TICKS(2000)) != pdTRUE)
+                        {
+                            ESP_LOGW(TAG, "Send serial queue fail");
+                            free(serialMsg.data);
+                        }
+                    }
+                    else
+                    {
+                        ESP_LOGE(TAG, "Invalid serial module %d", module);
+                        free(serialMsg.data);
+                    }
+                    break;
+                }
+                case MODULE_TYPE::MAESTRO:
+                {
+                    ESP_LOGI(TAG, "Maestro command val: %s", val.c_str());
+                    queue_msg_t servoMsg;
+                    servoMsg.message_id = module;
+                    servoMsg.data = (uint8_t *)malloc(val.size() + 1);
+                    memcpy(servoMsg.data, val.c_str(), val.size());
+                    servoMsg.data[val.size()] = '\0';
+
+                    if (xQueueSend(servoQueue, &servoMsg, pdMS_TO_TICKS(2000)) != pdTRUE)
+                    {
+                        ESP_LOGW(TAG, "Send servo queue fail");
+                        free(servoMsg.data);
+                    }
+                    break;
+                }
+                case MODULE_TYPE::I2C:
+                {
+                    ESP_LOGI(TAG, "I2C command val: %s", val.c_str());
+                    queue_msg_t i2cMsg;
+                    i2cMsg.message_id = 0;
+                    i2cMsg.data = (uint8_t *)malloc(val.size() + 1);
+                    memcpy(i2cMsg.data, val.c_str(), val.size());
+                    i2cMsg.data[val.size()] = '\0';
+
+                    if (xQueueSend(i2cQueue, &i2cMsg, pdMS_TO_TICKS(2000)) != pdTRUE)
+                    {
+                        ESP_LOGW(TAG, "Send i2c queue fail");
+                        free(i2cMsg.data);
+                    }
+                    break;
+                }
+                case MODULE_TYPE::GPIO:
+                {
+                    ESP_LOGI(TAG, "GPIO command val: %s", val.c_str());
+                    queue_msg_t gpioMsg;
+                    gpioMsg.data = (uint8_t *)malloc(val.size() + 1);
+                    memcpy(gpioMsg.data, val.c_str(), val.size());
+                    gpioMsg.data[val.size()] = '\0';
+
+                    if (xQueueSend(gpioQueue, &gpioMsg, pdMS_TO_TICKS(2000)) != pdTRUE)
+                    {
+                        ESP_LOGW(TAG, "Send gpio queue fail");
+                        free(gpioMsg.data);
+                    }
+                    break;
+                }
+                default:
+                    break;
+                }
+
+                uint32_t scriptDelay = AnimationCtrl.msTillNextServoCommand();
+                nextDelayMs = (scriptDelay < MIN_WAKE_MS) ? MIN_WAKE_MS : scriptDelay;
+            }
+        }
+        else
+        {
+            nextDelayMs = IDLE_WAKE_MS;
+        }
+
+        vTaskDelayUntil(&lastWake, pdMS_TO_TICKS(nextDelayMs));
+    }
+}
+```
+
+- [ ] **Step 6: Create the task during setup**
+
+Find the task creation cluster (near the other `xTaskCreatePinnedToCore` calls, around lines 195-215). Add:
+
+```cpp
+    xTaskCreatePinnedToCore(&animationDispatchTask, "animation_dispatch_task", 4096, NULL, 5, NULL, 1);
+```
+
+Pin to core 1 (same as most other I/O tasks), priority 5, stack 4 KB. The task takes no argument.
+
+- [ ] **Step 7: Verify no stale references to `animationTimer`**
+
+Run a Grep for `animationTimer` in `src/main.cpp`. Expected: zero matches after this task. If any remain (e.g., in a `servoMoveTimerCallback` or other callback), evaluate case-by-case — likely they were already unrelated references that only matched the global.
+
+- [ ] **Step 8: Build both envs**
+
+```
+pio run -e metro_s3
+pio run -e lolin_d32_pro
+```
+
+Expected: clean build.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/main.cpp
+git commit -m "$(cat <<'EOF'
+refactor: move animation dispatch off esp_timer onto a dedicated FreeRTOS task
+
+Animation dispatch previously ran in the shared esp_timer service task via
+animationTimerCallback — heavy malloc/memcpy/string-format/xQueueSend work
+on a stack the esp_timer task sizes for quick-return callbacks. Replace
+with animationDispatchTask pinned to core 1, 4 KB stack, loop driven by
+vTaskDelayUntil using msTillNextServoCommand() as the wake delta.
+
+Behavior preserved verbatim: malloc/free ownership, null-cmd recovery
+branch, 250 ms idle wake, all five dispatch channels. Drops one
+esp_timer handle from the system.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: QA test plan
+
+**Files:**
+- Create: `.docs/qa/code-review-phase-c.md`
+
+- [ ] **Step 1: Write the QA test plan**
+
+Create `.docs/qa/code-review-phase-c.md` with the following structure:
+
+```markdown
+# Phase C QA Test Plan
+
+**Prerequisites:**
+- A flashed master node and at least one padawan node.
+- SD card mounted with deployed scripts covering all five channel types (serial, servo/Maestro, I2C, GPIO, NONE).
+- Serial monitor open on both boards, `esp32_exception_decoder` filter active.
+- Web UI accessible for script deploy / panic-stop.
+
+## 1. Queue-depth smoke test (Task 1)
+
+**Goal:** Confirm bumped queue depths eliminate transient "Send X queue fail" warnings under normal animation load.
+
+1. Deploy and run a multi-channel animation script that exercises serial + servo + I2C + GPIO simultaneously.
+2. Play the script back-to-back 10 times.
+
+**Expected:** Zero `Send serial queue fail`, `Send servo queue fail`, `Send i2c queue fail`, `Send gpio queue fail` warnings across the 10 runs on either node.
+
+## 2. Animation dispatch refactor (Task 2)
+
+**Goal:** Confirm dispatch cadence, panic-stop responsiveness, and script chaining behave equivalently to the pre-refactor timer-driven implementation.
+
+1. **Cadence timing.** Run a script with known-interval commands (e.g. servo moves every 200 ms for 30 iterations). Timestamp each `ESP_LOGI "Maestro command val"` and compute actual inter-command deltas.
+   - **Expected:** 200 ms ± 10 ms per step. No drift across the 30 iterations.
+2. **Panic-stop mid-script.** Start a long-running script (30+ s). Issue panic-stop from the web UI mid-playback.
+   - **Expected:** Dispatch stops within one delay cycle (~250 ms at worst). No queued servo/serial/I2C/GPIO commands dispatched after the panic-stop log line.
+3. **Script chaining.** Queue script A (short). When it completes, queue script B. Repeat A then C with no gap.
+   - **Expected:** Each script plays to completion. No missed first command on the second script.
+4. **Idle to active.** Let the device sit idle (no script) for 2 minutes. Queue a script.
+   - **Expected:** Script begins within 250 ms of the queueScript call (the idle wake interval).
+5. **Animation Dispatch Stack HWM.** Monitor for `Animation Dispatch Stack HWM:` warnings throughout.
+   - **Expected:** No warnings (high-water-mark stays above 500 bytes).
+
+## 3. I2C leak fixes (Task 3)
+
+**Goal:** Confirm no heap regression when I2C operations fail repeatedly.
+
+1. Power the node with a PCA9685 board physically disconnected on the bus.
+2. Let it run for 5 minutes.
+3. Observe `RAM left` log from the maintenance timer at 10 s intervals.
+
+**Expected:** `RAM left` value stays within ±200 bytes of its starting value across the run. No unbounded decline.
+
+## 4. Button task stack (Task 4)
+
+**Goal:** Confirm 4 KB stack is adequate for the reset-button path.
+
+1. Flash the firmware. Leave the device powered with no further actions for 2 minutes.
+2. Press the reset button briefly (< 3 s).
+3. Press and hold for 4 s (medium press).
+4. Press and hold for 11 s (long press).
+
+**Expected:** No `button_listener_task Stack HWM:` warnings in any log. Each press produces its expected side effect (reboot, etc.).
+
+## 5. Storage manager error hardening (Task 5)
+
+**Goal:** Confirm path sanitization, mkdir checks, and format error codes behave as specified.
+
+1. **Path traversal rejection.** Deploy a script named `../foo.scr`.
+   - **Expected:** Deploy NAK or storage layer logs `isPathSafe: traversal component rejected`. No file written outside `/sdcard/scripts/`.
+2. **Absolute path rejection.** Deploy a script named `/etc/passwd`.
+   - **Expected:** Same as above, with `isPathSafe: absolute path rejected`.
+3. **Overlong path.** Deploy a script with a name of 200 characters.
+   - **Expected:** `isPathSafe: path too long` in log, deploy fails.
+4. **Full-SD deploy.** Fill the SD card to near capacity (within 1 KB). Deploy a new script.
+   - **Expected:** `fwrite` or `fopen` failure logged; storage layer returns error; caller surfaces a meaningful NAK to the web UI.
+5. **Format with no card present.** Remove the SD card and issue a format command from the web UI.
+   - **Expected:** `formatSdCard failed:` log line with distinct `ESP_ERR_NO_MEM` (work-buffer alloc) or `ESP_FAIL` (f_mkfs) error name.
+6. **Normal deploy regression.** Deploy, run, delete a valid script.
+   - **Expected:** All three operations succeed with no warnings.
+
+## 6. `stringFormat` snprintf (Task 6)
+
+**Goal:** Native unit tests still pass; no observable runtime regression.
+
+1. Run `pio test -e test`.
+
+**Expected:** All tests pass.
+
+## 7. Error counters (Task 7)
+
+**Goal:** Confirm counters increment on induced errors and show up in the maintenance log.
+
+1. **RX overflow.** From the connected host (via the AstrOs interface UART), send a message longer than 2000 bytes without a newline terminator.
+   - **Expected:** `AstrOs RX Buffer overflow` warning. Within 10 s, a maintenance log line of the form `err-counters rx-overflow=1 espnow-malloc-fail=0`.
+2. **ESP-NOW malloc failure.** Difficult to induce deliberately; verify indirectly by observing the counter stays at 0 during normal operation.
+   - **Expected:** `espnow-malloc-fail=0` in any counter log line during an un-stressed session.
+3. **No-error idle.** Leave the device idle with no induced errors for 60 s.
+   - **Expected:** No `err-counters` log lines emitted (both counters zero → log suppressed).
+
+## 8. Regression sweep
+
+Run these after all Phase C commits land, before merging:
+
+1. Full animation playback across all five dispatch channels.
+2. Master node polling of a padawan for 5 minutes, confirming no poll NAK escalations.
+3. OLED display updates during an active animation (shows timeout / countdown as expected).
+4. Fresh peer registration from the web UI.
+5. Panic-stop → queueScript recovery cycle.
+
+**Expected:** All behavior matches pre-Phase-C reference baseline. No new error logs, no heap decline over 10 minutes of mixed activity.
+```
+
+- [ ] **Step 2: Commit the QA plan**
+
+```bash
+git add .docs/qa/code-review-phase-c.md
+git commit -m "$(cat <<'EOF'
+docs: add QA test plan for code review Phase C
+
+Covers all eight tasks: queue-depth smoke test, animation dispatch
+cadence + panic-stop + chaining, I2C leak heap-stability, button
+stack HWM, storage path traversal + mkdir + format error codes,
+stringFormat native tests, error counters, and regression sweep.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Final verification
+
+- [ ] **All build environments green**
+
+```
+pio run -e metro_s3
+pio run -e lolin_d32_pro
+pio test -e test
+```
+
+Expected: all three succeed with no new warnings.
+
+- [ ] **No stale `animationTimer` references**
+
+Grep `src/main.cpp` for `animationTimer`. Expected: zero matches.
+
+- [ ] **No stale `sprintf` (bare) in util code**
+
+Grep `lib/AstrOsUtility` for `std::sprintf`. Expected: zero matches.
+
+- [ ] **Pre-commit hook runs clean on all commits**
+
+The project uses `clang-format` in `.githooks/pre-commit`. Every commit in this plan should have passed without manual touchup. Spot-check by running `git log --oneline fix/code-review-phase-c ^develop` and confirming each commit made it through.
+
+- [ ] **PR ready**
+
+Branch `fix/code-review-phase-c` contains 10 commits (9 implementation + 1 QA plan) plus the two documentation commits from the brainstorming phase. Title the PR `fix: code-review Phase C — resilience & defensive hardening`; link to `.docs/plans/20260414-0954-code-review-phase-c.md` and `.docs/qa/code-review-phase-c.md` in the body.

--- a/.docs/plans/20260415-0715-native-testable-foundation.md
+++ b/.docs/plans/20260415-0715-native-testable-foundation.md
@@ -1,0 +1,174 @@
+# Native-Testable Refactor: Foundation + AstrOsSerialMsgHandler Pilot
+
+## Context
+
+AstrOs.ESP currently has ~2 natively-testable libs (`lib/AstrOsMessaging`, `lib/AstrOsUtility`) and a pile of MIXED libs where algorithmic logic is tangled with ESP-IDF/FreeRTOS calls. The April 2026 code review (and the resulting Phase A/B/C work) has made it clear that several of those MIXED libs — protocol parsing, script event selection, peer registration FSM — would benefit from unit tests but can't be reached today because they pull in `esp_log.h`, FreeRTOS, or hardware drivers.
+
+Goal: **establish a convention for extracting pure logic into sibling libs that are unit-tested under `[env:test]`**, then pilot the pattern on `AstrOsSerialMsgHandler` — the lowest-risk, highest-ROI target. Animation and dispatch hot paths (recently tuned in Phase C) are explicitly out of scope for this plan; their extraction will be follow-up work once the pattern is proven.
+
+Two design principles guide the extraction:
+
+1. **Rich return values are the primary error channel.** Pure libs should return structs/enums describing what happened (`{ valid, reason, type, parts... }`) so the ESP-side caller logs at the boundary. This is the pattern `AstrOsMessaging::validateSerialMsg` already uses.
+2. **Injected logger struct as the fallback, not the default.** When a pure lib has diagnostics that *must* live next to the logic (complex internal state, tight loops, troubleshooting-only lines), it takes an optional `AstrOsLogger` struct of function pointers. Defaults to all-no-op. An ESP adapter in `lib/AstrOsUtility_ESP` provides `makeEspLogger()` wiring the pointers to `ESP_LOGx`.
+
+## Why not just use ESP_LOG everywhere and stub it on native?
+
+Tried that informally — the `esp_log.h` header drags in ESP-IDF registry headers that don't compile under `platform = native`. Stubbing them means maintaining a shim that has to track ESP-IDF version changes. The fn-ptr struct is ~15 lines, adds one indirect call per log site (no vtable, no heap), and decouples the pure lib from the ESP toolchain entirely.
+
+## Scope
+
+Foundation + one pilot extraction. ~8 tasks total, at the CLAUDE.md scope-guard boundary. If the task count creeps up during execution, split into two phases at the Part 1/Part 2 seam — Part 1 ships a foundation + `isPathSafe` proof point independently.
+
+**Branching:** this plan should branch off `develop` *after* the Phase C PR merges, to avoid stacking unrelated commits. It does not touch any files Phase C modified except `CLAUDE.md` (Task 8), so it stays cleanly independent.
+
+## Part 1 — Foundation
+
+### Task 1: Create `lib/AstrOsLogging` (PURE)
+
+- **New files:**
+  - `lib/AstrOsLogging/include/AstrOsLogger.hpp` — declares `struct AstrOsLogger` (function pointers for `trace`, `debug`, `info`, `warn`, `error`; each takes `const char* tag, const char* fmt, ...` and forwards via `vprintf`-style). Default construction zeroes the pointers; an inline helper `astros_log_warn(logger, tag, "fmt", args...)` no-ops when the pointer is null, invokes it otherwise.
+  - `lib/AstrOsLogging/README` — hard rule: "no ESP-IDF or FreeRTOS includes. Compiled under `[env:test]`."
+- **Why not a class:** Avoids vtable, allows aggregate-initialization at compile time, and makes the "default = silent" property trivial.
+- **Not yet used anywhere** — this task is purely introducing the type.
+
+### Task 2: Create ESP adapter in `lib/AstrOsUtility_ESP`
+
+- **New file:** `lib/AstrOsUtility_ESP/include/AstrOsLoggerEsp.h`
+- Exposes `AstrOsLogger makeEspLogger();` whose function pointers wrap `esp_log_writev()` at the corresponding level.
+- **New file:** `lib/AstrOsUtility_ESP/src/AstrOsLoggerEsp.cpp` — the tiny adapter itself.
+- Coexists with the existing `logError()` helper in `AstrOsUtility_ESP.h`; no need to touch that.
+
+### Task 3: Extend CI purity guard
+
+- **Modify:** `.github/workflows/pr-validation.yml` — the existing "AstrOsMessaging native-purity guard" job greps the lib for forbidden includes. Parameterise that check over a list of pure libs (`AstrOsMessaging`, `AstrOsUtility`, `AstrOsLogging`). Future extractions just append to the list.
+- Forbidden patterns: `#include <freertos/`, `#include <esp_`, `#include <driver/`, `#include <nvs_`, `#include <sdmmc_`, `#include <esp_vfs`, `#include <esp_now`, `#include <esp_wifi`.
+- Fails the job with the exact offending line + path.
+
+### Task 4: Move `isPathSafe` into `lib/AstrOsUtility` (proof point)
+
+- **Why first**: exercises the whole foundation pipeline (pure lib + purity guard + native test) against already-written, already-QA'd logic. Small, risk-free, and validates the flow before the bigger pilot.
+- **Modify:** `lib/AstrOsUtility/include/AstrOsPathUtils.hpp` (new) — `namespace AstrOsPathUtils { bool isPathSafe(const std::string&, std::string& reasonOut); }`. Returns the reject reason via out-param (or tuple) rather than an `ESP_LOGW` call — that's the "rich return" pattern.
+- **Modify:** `lib/AstrOsStorageManager/src/AstOsStorageManager.cpp` — delete the internal `isPathSafe`; call `AstrOsPathUtils::isPathSafe` and log `reasonOut` at `ESP_LOGW` at the boundary (same behaviour as today, just split). Update the header to drop the private declaration.
+- **New test:** `test/test_native/astros_path_utils_tests.cpp` — cases for each of the 5 reject conditions already enumerated in `.docs/qa/code-review-phase-c.md` §5 (empty, absolute, `..`, `//`, overlong).
+- Adds a test file to the `[env:test]` target.
+
+## Part 2 — Pilot: `AstrOsSerialMsgHandler` extraction
+
+### Task 5: Create `lib/AstrOsSerialProtocol` (PURE)
+
+- **New files:**
+  - `lib/AstrOsSerialProtocol/include/AstrOsSerialProtocol.hpp`
+  - `lib/AstrOsSerialProtocol/src/AstrOsSerialProtocol.cpp`
+  - `lib/AstrOsSerialProtocol/README` (purity rule, same as AstrOsMessaging)
+- **Shape of the API:**
+  ```cpp
+  struct DecodedCommand {
+      AstrOsInterfaceResponseType responseType;
+      std::string msgId;
+      std::string peerMac;   // empty = broadcast
+      std::string peerName;
+      std::string message;
+  };
+
+  struct DecodeReject {
+      std::string entry;            // the raw controller sub-string that failed
+      DecodeRejectReason reason;    // WRONG_PART_COUNT | EMPTY_DEST | EMPTY_VALUE | UNKNOWN_TYPE
+  };
+
+  struct DecodeResult {
+      std::vector<DecodedCommand> commands;
+      std::vector<DecodeReject> rejects;
+  };
+
+  DecodeResult decodeSerialMessage(
+      AstrOsSerialMessageType type,
+      const std::string& msgId,
+      const std::string& message,
+      bool isMaster);
+
+  AstrOsInterfaceResponseType mapResponseType(
+      AstrOsSerialMessageType type, bool isMaster);
+  ```
+- Ports the logic from the current `handleRegistrationSync`, `handleDeployConfig`, `handleDeployScript`, `handleBasicCommand`, and `getResponseType` in `lib/AstrOsSerialMsgHandler/src/AstrOsSerialMsgHandler.cpp:70-231`.
+- **Depends only on:** `lib/AstrOsMessaging` (for `AstrOsSerialMessageType`, separators) and `lib/AstrOsUtility` (for `AstrOsStringUtils::splitString`). Both already pure. No logger needed — the `rejects` vector is how the caller learns about skipped entries.
+
+### Task 6: Rewrite `AstrOsSerialMsgHandler` as a thin adapter
+
+- **Modify:** `lib/AstrOsSerialMsgHandler/src/AstrOsSerialMsgHandler.cpp`
+  - `handleMessage` validates the wire format (existing `msgService.validateSerialMsg`), then calls `AstrOsSerialProtocol::decodeSerialMessage`, then:
+    - Iterates `result.commands` and calls `sendToInterfaceQueue(cmd.responseType, cmd.msgId, cmd.peerMac, cmd.peerName, cmd.message)`.
+    - Iterates `result.rejects` and emits `ESP_LOGW(TAG, "Invalid %s: %s", reason, entry)` at the boundary.
+  - Delete `handleRegistrationSync`, `handleDeployConfig`, `handleDeployScript`, `handleBasicCommand`, `getResponseType` from both header and cpp.
+  - `sendToInterfaceQueue`, `sendRegistraionAck`, `sendPollAckNak`, `sendBasicAckNakResponse` stay — they own queue handles and malloc/memcpy/xQueueSend, which is the MIXED layer's actual responsibility.
+- **Modify:** `lib/AstrOsSerialMsgHandler/include/AstrOsSerialMsgHandler.hpp` — remove the five private member declarations.
+
+### Task 7: Native tests for `AstrOsSerialProtocol`
+
+- **New file:** `test/test_native/astros_serial_protocol_tests.cpp`
+- Test cases:
+  - `REGISTRATION_SYNC` produces one broadcast command with `REGISTRATION_SYNC` response type.
+  - `DEPLOY_CONFIG` master path: `00:00:00:00:00:00` → `SET_CONFIG`; padawan path: specific MAC → `SEND_CONFIG`.
+  - `DEPLOY_SCRIPT` reconstructs the `msgParts[2] + UNIT_SEPARATOR + msgParts[3]` payload correctly.
+  - `RUN_SCRIPT`, `PANIC_STOP`, `FORMAT_SD`, `RUN_COMMAND`, `SERVO_TEST` each map master↔padawan response types correctly via `mapResponseType`.
+  - Rejects: wrong part count (DEPLOY_CONFIG with 2 parts instead of 3), empty dest, empty value — each produces an entry in `rejects`, none in `commands`.
+  - Mixed valid + invalid controllers in the same message — valid ones land in `commands`, invalid in `rejects`.
+
+### Task 8: Docs + convention
+
+- **Modify:** `CLAUDE.md` — in the "Library layout" section, add a classification column (PURE / MIXED / HARDWARE-ONLY) to the lib descriptions, and a short "Adding a new extracted lib" subsection listing the three steps: create lib directory with `README` stating the purity rule, add lib name to the CI purity guard list, prefer rich return values over logger injection.
+- No change to `.docs/code-review/*` — this is pattern work, not review remediation.
+
+## Files touched
+
+**Created:**
+- `lib/AstrOsLogging/include/AstrOsLogger.hpp`
+- `lib/AstrOsLogging/README`
+- `lib/AstrOsUtility_ESP/include/AstrOsLoggerEsp.h`
+- `lib/AstrOsUtility_ESP/src/AstrOsLoggerEsp.cpp`
+- `lib/AstrOsUtility/include/AstrOsPathUtils.hpp`
+- `lib/AstrOsUtility/src/AstrOsPathUtils.cpp` (if impl needed; may be header-only)
+- `lib/AstrOsSerialProtocol/include/AstrOsSerialProtocol.hpp`
+- `lib/AstrOsSerialProtocol/src/AstrOsSerialProtocol.cpp`
+- `lib/AstrOsSerialProtocol/README`
+- `test/test_native/astros_path_utils_tests.cpp`
+- `test/test_native/astros_serial_protocol_tests.cpp`
+
+**Modified:**
+- `.github/workflows/pr-validation.yml` (purity guard extended over lib list)
+- `lib/AstrOsStorageManager/include/AstrOsStorageManager.hpp` (drop private `isPathSafe`)
+- `lib/AstrOsStorageManager/src/AstOsStorageManager.cpp` (delegate to `AstrOsPathUtils`)
+- `lib/AstrOsSerialMsgHandler/include/AstrOsSerialMsgHandler.hpp` (drop 5 private members)
+- `lib/AstrOsSerialMsgHandler/src/AstrOsSerialMsgHandler.cpp` (rewrite `handleMessage` as adapter)
+- `CLAUDE.md` (classification column + "Adding a new extracted lib" blurb)
+
+## Existing code to reuse
+
+- `lib/AstrOsUtility/include/AstrOsStringUtils.hpp::splitString` — pure, already used by the current handler.
+- `lib/AstrOsMessaging` — `AstrOsSerialMessageType`, separator constants, `validateSerialMsg`.
+- `lib/AstrOsUtility_ESP/include/AstrOsUtility_ESP.h::logError` — existing ESP-side helper; precedent for where the new `AstrOsLoggerEsp` adapter fits.
+- `.docs/qa/code-review-phase-c.md` §5 — authoritative list of `isPathSafe` reject cases; drives the native-test coverage.
+
+## Verification
+
+- **Native tests:** `pio test -e test` — all existing tests still pass; `astros_path_utils_tests` and `astros_serial_protocol_tests` pass. Expected: 2 new test files contributing ~15-20 test cases.
+- **Firmware builds:** `pio run -e lolin_d32_pro` and `pio run -e metro_s3` — clean build, no new warnings.
+- **CI purity guard:** Push a throwaway commit that adds `#include <esp_log.h>` to `lib/AstrOsLogging/include/AstrOsLogger.hpp`, confirm the purity-guard job fails with a pointer to that line. Revert.
+- **Runtime smoke (optional hardware):** Flash `metro_s3`, deploy a config and a script via the web UI, confirm the handler still dispatches correctly to interface queue. Inject a malformed controller record (e.g., a `DEPLOY_CONFIG` entry with only 2 `UNIT_SEPARATOR` parts) and confirm the `ESP_LOGW` at the boundary still fires with the reject reason.
+
+## Task checklist
+
+- [ ] Task 1: Create `lib/AstrOsLogging` pure lib + README
+- [ ] Task 2: Create `lib/AstrOsUtility_ESP` logger adapter
+- [ ] Task 3: Extend CI purity guard over a lib list
+- [ ] Task 4: Extract `isPathSafe` into `lib/AstrOsUtility` + native test
+- [ ] Task 5: Create `lib/AstrOsSerialProtocol` pure lib
+- [ ] Task 6: Rewrite `AstrOsSerialMsgHandler` as thin adapter
+- [ ] Task 7: Add native tests for `AstrOsSerialProtocol`
+- [ ] Task 8: Update CLAUDE.md with classification + "Adding a new extracted lib" blurb
+
+## What's explicitly not in this plan
+
+- `AnimationController` engine extraction — separate follow-up plan once the pilot lands.
+- `AstrOsEspNow` peer-registration FSM + fragmentation tests — separate follow-up plan.
+- `Modules/*` extraction (Maestro protocol negotiation, serial command parsing) — separate follow-up plan.
+- Any new logging injection inside `AstrOsSerialProtocol` — deliberately none, because the rich-return pattern (`DecodeResult` with `rejects`) makes it unnecessary. The injected-logger path is still available for later extractions where it's warranted.

--- a/.docs/qa/code-review-phase-c.md
+++ b/.docs/qa/code-review-phase-c.md
@@ -120,6 +120,11 @@ Run these after all Phase C commits land, before merging:
 3. OLED display updates during an active animation (shows timeout / countdown as expected).
 4. Fresh peer registration from the web UI.
 5. Panic-stop → queueScript recovery cycle.
+6. **Concurrent storage-reject + active animation.** While a long script is actively playing (30+ s), deploy a script with a path-traversal name (`../malicious.scr`) from the web UI. Confirm:
+   - The deploy NAKs (storage layer rejects) without perturbing the running animation.
+   - Dispatch cadence of the running script stays within its normal ±10 ms envelope.
+   - No `Animation Dispatch Stack HWM:` warnings triggered by the concurrent storage activity.
+   - The `isPathSafe: ... rejected` log line appears at level W (not E).
 
 **Expected:** All behavior matches pre-Phase-C reference baseline. No new error logs, no heap decline over 10 minutes of mixed activity.
 

--- a/.docs/qa/code-review-phase-c.md
+++ b/.docs/qa/code-review-phase-c.md
@@ -1,0 +1,137 @@
+# Phase C QA Test Plan
+
+Covers the Phase C code-review remediation work landing on branch `fix/code-review-phase-c`.
+
+**Prerequisites:**
+- A flashed master node and at least one padawan node.
+- SD card mounted with deployed scripts covering all five channel types (serial, servo/Maestro, I2C, GPIO, NONE).
+- Serial monitor open on both boards, `esp32_exception_decoder` filter active.
+- Web UI accessible for script deploy / panic-stop.
+
+---
+
+## 1. Queue-depth smoke test (Task 1)
+
+**Goal:** Confirm bumped queue depths eliminate transient "Send X queue fail" warnings under normal animation load.
+
+1. Deploy and run a multi-channel animation script that exercises serial + servo + I2C + GPIO simultaneously.
+2. Play the script back-to-back 10 times.
+
+**Expected:** Zero `Send serial queue fail`, `Send servo queue fail`, `Send i2c queue fail`, `Send gpio queue fail` warnings across the 10 runs on either node.
+
+---
+
+## 2. Animation dispatch refactor (Task 2)
+
+**Goal:** Confirm dispatch cadence, panic-stop responsiveness, and script chaining behave equivalently to the pre-refactor timer-driven implementation, now that dispatch runs from a dedicated FreeRTOS task using `vTaskDelay`.
+
+1. **Cadence timing.** Run a script with known-interval commands (e.g. servo moves every 200 ms for 30 iterations). Timestamp each `ESP_LOGI "Maestro command val"` and compute actual inter-command deltas.
+   - **Expected:** 200 ms ± 10 ms per step. No progressive drift across the 30 iterations.
+2. **Long-delay scripted pause.** Run a script with a single command followed by a ≥ 5 second scripted delay, then several commands at 100 ms intervals.
+   - **Expected:** First command fires, task sleeps for the 5 s, then the subsequent commands fire at their scripted 100 ms intervals — NOT a catch-up burst where the post-delay commands arrive simultaneously. (This validates the `vTaskDelay` choice over `vTaskDelayUntil`.)
+3. **Panic-stop mid-script.** Start a long-running script (30+ s). Issue panic-stop from the web UI mid-playback.
+   - **Expected:** Dispatch stops within one delay cycle (≤ 250 ms + the current scripted delay). No queued servo/serial/I2C/GPIO commands dispatched after the panic-stop log line.
+4. **Script chaining.** Queue script A (short). When it completes, queue script B. Repeat A then C with no gap.
+   - **Expected:** Each script plays to completion. No missed first command on the second script.
+5. **Idle to active.** Let the device sit idle (no script) for 2 minutes. Queue a script.
+   - **Expected:** Script begins within 250 ms of the queueScript call (the idle wake interval).
+6. **Animation Dispatch Stack HWM.** Monitor for `Animation Dispatch Stack HWM:` warnings throughout.
+   - **Expected:** No warnings (high-water-mark stays above 500 bytes). If warnings appear, bump the task's stack from 4096 to 5120 and re-test.
+
+---
+
+## 3. I2C leak fixes (Task 3)
+
+**Goal:** Confirm no heap regression when I2C operations fail repeatedly, and that no heap corruption occurs from the removed double-free in `ReadWord` / `ReadTwoWords`.
+
+1. Power the node with a PCA9685 board physically disconnected on the bus.
+2. Let it run for 5 minutes.
+3. Observe `RAM left` log from the maintenance timer at 10 s intervals.
+
+**Expected:** `RAM left` value stays within ±200 bytes of its starting value across the run. No unbounded decline. No `CORRUPT HEAP` or `LoadProhibited` crash logs (which the prior double-free could have triggered intermittently).
+
+---
+
+## 4. Button task stack (Task 4)
+
+**Goal:** Confirm 4 KB stack is adequate for the reset-button path.
+
+1. Flash the firmware. Leave the device powered with no further actions for 2 minutes.
+2. Press the reset button briefly (< 3 s).
+3. Press and hold for 4 s (medium press).
+4. Press and hold for 11 s (long press).
+
+**Expected:** No `button_listener_task Stack HWM:` warnings in any log. Each press produces its expected side effect (reboot, etc.).
+
+---
+
+## 5. Storage manager error hardening (Task 5)
+
+**Goal:** Confirm path sanitization, mkdir checks, and format error codes behave as specified.
+
+1. **Path traversal rejection.** Deploy a script named `../foo.scr`.
+   - **Expected:** Deploy NAK. Serial log shows `isPathSafe: traversal component rejected` at log level W (warning, not error). No file written outside `/sdcard/scripts/`.
+2. **Absolute path rejection.** Deploy a script named `/etc/passwd`.
+   - **Expected:** Same as above, with `isPathSafe: absolute path rejected`.
+3. **Double-slash rejection.** Deploy a script named `scripts//foo.scr`.
+   - **Expected:** `isPathSafe: double-slash rejected` at log level W.
+4. **Empty-path rejection.** Deploy with an empty filename (if the web UI allows, or inject via serial).
+   - **Expected:** `isPathSafe: empty path rejected` at log level W.
+5. **Overlong path.** Deploy a script with a name of 200 characters.
+   - **Expected:** `isPathSafe: path too long (...)` log line at level W, with the path truncated to 40 chars followed by `...` in the log output. Deploy NAKs.
+6. **Full-SD deploy.** Fill the SD card to near capacity (within 1 KB). Deploy a new script.
+   - **Expected:** `fwrite` or `fopen` failure logged; storage layer returns error; caller surfaces a meaningful NAK to the web UI.
+7. **Format with no card present.** Remove the SD card and issue a format command from the web UI.
+   - **Expected:** `formatSdCard failed:` log line from `handleFormatSD` showing a distinct `ESP_ERR_NO_MEM` (work-buffer alloc) or `ESP_FAIL` (f_mkfs) error name.
+8. **Normal deploy regression.** Deploy, run, delete a valid script.
+   - **Expected:** All three operations succeed with no warnings.
+
+---
+
+## 6. `stringFormat` snprintf (Task 6)
+
+**Goal:** Native unit tests still pass; no observable runtime regression.
+
+1. Run `pio test -e test`.
+
+**Expected:** All tests pass.
+
+---
+
+## 7. Error counters (Task 7)
+
+**Goal:** Confirm counters increment on induced errors and show up in the maintenance log.
+
+1. **RX overflow.** From the connected host (via the AstrOs interface UART), send a message longer than 2000 bytes without a newline terminator.
+   - **Expected:** `AstrOs RX Buffer overflow` warning immediately. Within 10 s, a maintenance log line of the form `err-counters rx-overflow=1 espnow-malloc-fail=0` at log level W.
+2. **ESP-NOW malloc failure.** Difficult to induce deliberately; verify indirectly by observing the counter stays at 0 during normal operation.
+   - **Expected:** `espnow-malloc-fail=0` in any counter log line during an un-stressed session.
+3. **No-error idle.** Leave the device idle with no induced errors for 60 s.
+   - **Expected:** No `err-counters` log lines emitted (both counters zero → log suppressed to avoid noise).
+
+---
+
+## 8. Regression sweep
+
+Run these after all Phase C commits land, before merging:
+
+1. Full animation playback across all five dispatch channels.
+2. Master node polling of a padawan for 5 minutes, confirming no poll NAK escalations.
+3. OLED display updates during an active animation (shows timeout / countdown as expected).
+4. Fresh peer registration from the web UI.
+5. Panic-stop → queueScript recovery cycle.
+
+**Expected:** All behavior matches pre-Phase-C reference baseline. No new error logs, no heap decline over 10 minutes of mixed activity.
+
+---
+
+## Rollback
+
+If any P0/P1 regression is identified during QA, the Phase C branch is reverse-proof as a sequence of independent commits. The revert order (most-likely-source-first) is:
+
+1. Animation dispatch refactor (commits `0f23180` + `ee94c17`) — safety-critical; first suspect if animation behavior differs.
+2. Storage manager error hardening (commits `e6e9685` + `b806450`) — first suspect if deploy / format flows regress.
+3. I2C leak fixes (commit `6b0cbc8`) — first suspect if servo / OLED behavior degrades.
+4. Error counters / queue depths / stack bump / stringFormat — low-risk; unlikely to cause a regression.
+
+Use `git revert <sha>` rather than reset-hard, since the branch is already pushed or will be.

--- a/lib/AstrOsStorageManager/include/AstrOsStorageManager.hpp
+++ b/lib/AstrOsStorageManager/include/AstrOsStorageManager.hpp
@@ -16,6 +16,7 @@ private:
     bool saveGpioConfig(std::string config);
     esp_err_t mountSdCard();
     std::string setFilePath(std::string filename);
+    static bool isPathSafe(const std::string &path);
     bool saveFileSd(std::string filename, std::string data);
     bool deleteFileSd(std::string filename);
     bool fileExistsSd(std::string filename);
@@ -58,7 +59,7 @@ public:
 
     std::vector<std::string> listFiles(std::string folder);
 
-    bool formatSdCard();
+    esp_err_t formatSdCard();
 };
 
 extern AstrOsStorageManager AstrOs_Storage;

--- a/lib/AstrOsStorageManager/src/AstOsStorageManager.cpp
+++ b/lib/AstrOsStorageManager/src/AstOsStorageManager.cpp
@@ -517,6 +517,12 @@ esp_err_t AstrOsStorageManager::formatSdCard()
     void *workbuf = NULL;
     ESP_LOGI(TAG, "Formatting the SD card");
 
+    if (card == nullptr)
+    {
+        ESP_LOGE(TAG, "Error formatting SD card: card not mounted");
+        return ESP_ERR_INVALID_STATE;
+    }
+
     size_t allocation_unit_size = 16 * 1024;
 
     workbuf = ff_memalloc(workbuf_size);

--- a/lib/AstrOsStorageManager/src/AstOsStorageManager.cpp
+++ b/lib/AstrOsStorageManager/src/AstOsStorageManager.cpp
@@ -52,28 +52,31 @@ bool AstrOsStorageManager::isPathSafe(const std::string &path)
 {
     if (path.empty())
     {
-        ESP_LOGE(TAG, "isPathSafe: empty path rejected");
+        ESP_LOGW(TAG, "isPathSafe: empty path rejected");
         return false;
     }
     if (path[0] == '/')
     {
-        ESP_LOGE(TAG, "isPathSafe: absolute path rejected: %s", path.c_str());
+        ESP_LOGW(TAG, "isPathSafe: absolute path rejected: %s", path.c_str());
         return false;
     }
+    // Conservative: rejects any path containing ".." as a substring, not just
+    // at component boundaries. False positives are benign given current naming
+    // conventions.
     if (path.find("..") != std::string::npos)
     {
-        ESP_LOGE(TAG, "isPathSafe: traversal component rejected: %s", path.c_str());
+        ESP_LOGW(TAG, "isPathSafe: traversal component rejected: %s", path.c_str());
         return false;
     }
     if (path.find("//") != std::string::npos)
     {
-        ESP_LOGE(TAG, "isPathSafe: double-slash rejected: %s", path.c_str());
+        ESP_LOGW(TAG, "isPathSafe: double-slash rejected: %s", path.c_str());
         return false;
     }
     constexpr size_t MAX_PATH_LEN = 128;
     if (path.size() > MAX_PATH_LEN)
     {
-        ESP_LOGE(TAG, "isPathSafe: path too long (%zu > %zu): %s", path.size(), MAX_PATH_LEN, path.c_str());
+        ESP_LOGW(TAG, "isPathSafe: path too long (%zu > %zu): %.40s...", path.size(), MAX_PATH_LEN, path.c_str());
         return false;
     }
     return true;
@@ -544,6 +547,9 @@ esp_err_t AstrOsStorageManager::formatSdCard()
         if (mkdir(folder, 0777) != 0 && errno != EEXIST)
         {
             ESP_LOGE(TAG, "Failed to create folder %s: errno=%d (%s)", folder, errno, strerror(errno));
+            // Card is formatted at this point; mkdir failure leaves it without
+            // the expected directory structure. Return ESP_FAIL so the caller
+            // can request a retry.
             return ESP_FAIL;
         }
     }

--- a/lib/AstrOsStorageManager/src/AstOsStorageManager.cpp
+++ b/lib/AstrOsStorageManager/src/AstOsStorageManager.cpp
@@ -4,10 +4,12 @@
 #include <AstrOsUtility_ESP.h>
 #include <NvsManager.h>
 
+#include <errno.h>
 #include <esp_log.h>
 #include <nvs_flash.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <string.h>
 
 #include <string>
 #include <vector>
@@ -45,6 +47,37 @@ static const char *TAG = "StorageManager";
 static sdmmc_card_t *card;
 
 AstrOsStorageManager AstrOs_Storage;
+
+bool AstrOsStorageManager::isPathSafe(const std::string &path)
+{
+    if (path.empty())
+    {
+        ESP_LOGE(TAG, "isPathSafe: empty path rejected");
+        return false;
+    }
+    if (path[0] == '/')
+    {
+        ESP_LOGE(TAG, "isPathSafe: absolute path rejected: %s", path.c_str());
+        return false;
+    }
+    if (path.find("..") != std::string::npos)
+    {
+        ESP_LOGE(TAG, "isPathSafe: traversal component rejected: %s", path.c_str());
+        return false;
+    }
+    if (path.find("//") != std::string::npos)
+    {
+        ESP_LOGE(TAG, "isPathSafe: double-slash rejected: %s", path.c_str());
+        return false;
+    }
+    constexpr size_t MAX_PATH_LEN = 128;
+    if (path.size() > MAX_PATH_LEN)
+    {
+        ESP_LOGE(TAG, "isPathSafe: path too long (%zu > %zu): %s", path.size(), MAX_PATH_LEN, path.c_str());
+        return false;
+    }
+    return true;
+}
 
 AstrOsStorageManager::AstrOsStorageManager() {}
 AstrOsStorageManager::~AstrOsStorageManager()
@@ -408,7 +441,10 @@ int AstrOsStorageManager::loadEspNowPeerConfigs(espnow_peer_t *config)
 
 bool AstrOsStorageManager::saveFile(std::string filename, std::string data)
 {
-
+    if (!isPathSafe(filename))
+    {
+        return false;
+    }
 #ifdef USE_SPIFFS
     return AstrOsStorageManager::saveFileSpiffs(filename, data);
 #else
@@ -418,7 +454,10 @@ bool AstrOsStorageManager::saveFile(std::string filename, std::string data)
 
 bool AstrOsStorageManager::deleteFile(std::string filename)
 {
-
+    if (!isPathSafe(filename))
+    {
+        return false;
+    }
 #ifdef USE_SPIFFS
     return AstrOsStorageManager::deleteFileSpiffs(filename);
 #else
@@ -428,7 +467,10 @@ bool AstrOsStorageManager::deleteFile(std::string filename)
 
 std::string AstrOsStorageManager::readFile(std::string filename)
 {
-
+    if (!isPathSafe(filename))
+    {
+        return "error";
+    }
 #ifdef USE_SPIFFS
     return AstrOsStorageManager::readFileSpiffs(filename);
 #else
@@ -438,7 +480,10 @@ std::string AstrOsStorageManager::readFile(std::string filename)
 
 bool AstrOsStorageManager::fileExists(std::string filename)
 {
-
+    if (!isPathSafe(filename))
+    {
+        return false;
+    }
 #ifdef USE_SPIFFS
     return AstrOsStorageManager::fileExistsSpiffs(filename);
 #else
@@ -448,6 +493,10 @@ bool AstrOsStorageManager::fileExists(std::string filename)
 
 std::vector<std::string> AstrOsStorageManager::listFiles(std::string folder)
 {
+    if (!isPathSafe(folder))
+    {
+        return {};
+    }
 #ifdef USE_SPIFFS
     return AstrOsStorageManager::listFilesSpiffs(folder);
 #else
@@ -458,7 +507,7 @@ std::vector<std::string> AstrOsStorageManager::listFiles(std::string folder)
 #pragma endregion ESP - NOW
 #pragma region SD CARD
 
-bool AstrOsStorageManager::formatSdCard()
+esp_err_t AstrOsStorageManager::formatSdCard()
 {
     char drv[3] = {'0', ':', 0};
     const size_t workbuf_size = 4096;
@@ -470,14 +519,13 @@ bool AstrOsStorageManager::formatSdCard()
     workbuf = ff_memalloc(workbuf_size);
     if (workbuf == NULL)
     {
-        ESP_LOGE(TAG, "Error formatting SD card: ESP_ERR_NO_MEM");
-        return false;
+        ESP_LOGE(TAG, "Error formatting SD card: work-buffer allocation failed");
+        return ESP_ERR_NO_MEM;
     }
 
     size_t alloc_unit_size = esp_vfs_fat_get_allocation_unit_size(card->csd.sector_size, allocation_unit_size);
 
     MKFS_PARM param;
-
     param.fmt = FM_ANY;
     param.au_size = alloc_unit_size;
 
@@ -485,18 +533,23 @@ bool AstrOsStorageManager::formatSdCard()
     if (res != FR_OK)
     {
         ESP_LOGE(TAG, "Error formatting SD card: f_mkfs failed (%d)", res);
-        return false;
+        free(workbuf);
+        return ESP_FAIL;
     }
 
     free(workbuf);
 
-    mkdir(SCRIPTS_FOLDER, 0777);
-    mkdir(MAESTRO_FOLDER, 0777);
-    mkdir(GPIO_FOLDER, 0777);
+    for (const char *folder : {SCRIPTS_FOLDER, MAESTRO_FOLDER, GPIO_FOLDER})
+    {
+        if (mkdir(folder, 0777) != 0 && errno != EEXIST)
+        {
+            ESP_LOGE(TAG, "Failed to create folder %s: errno=%d (%s)", folder, errno, strerror(errno));
+            return ESP_FAIL;
+        }
+    }
 
     ESP_LOGI(TAG, "Successfully formatted the SD card");
-
-    return true;
+    return ESP_OK;
 }
 
 esp_err_t AstrOsStorageManager::mountSdCard()

--- a/lib/AstrOsUtility/src/AstrOsStringUtils.hpp
+++ b/lib/AstrOsUtility/src/AstrOsStringUtils.hpp
@@ -155,8 +155,9 @@ public:
         {
             return std::string();
         }
-        std::string output(static_cast<size_t>(size), '\0');
+        std::string output(static_cast<size_t>(size) + 1, '\0');
         std::snprintf(&output[0], static_cast<size_t>(size) + 1, format.c_str(), std::forward<Args>(args)...);
+        output.resize(static_cast<size_t>(size));
         return output;
     }
 };

--- a/lib/AstrOsUtility/src/AstrOsStringUtils.hpp
+++ b/lib/AstrOsUtility/src/AstrOsStringUtils.hpp
@@ -150,9 +150,13 @@ public:
 
     template <typename... Args> static std::string stringFormat(const std::string &format, Args &&...args)
     {
-        auto size = std::snprintf(nullptr, 0, format.c_str(), std::forward<Args>(args)...);
-        std::string output(size + 1, '\0');
-        std::snprintf(&output[0], size + 1, format.c_str(), std::forward<Args>(args)...);
+        int size = std::snprintf(nullptr, 0, format.c_str(), std::forward<Args>(args)...);
+        if (size < 0)
+        {
+            return std::string();
+        }
+        std::string output(static_cast<size_t>(size), '\0');
+        std::snprintf(&output[0], static_cast<size_t>(size) + 1, format.c_str(), std::forward<Args>(args)...);
         return output;
     }
 };

--- a/lib/AstrOsUtility/src/AstrOsStringUtils.hpp
+++ b/lib/AstrOsUtility/src/AstrOsStringUtils.hpp
@@ -152,7 +152,7 @@ public:
     {
         auto size = std::snprintf(nullptr, 0, format.c_str(), std::forward<Args>(args)...);
         std::string output(size + 1, '\0');
-        std::sprintf(&output[0], format.c_str(), std::forward<Args>(args)...);
+        std::snprintf(&output[0], size + 1, format.c_str(), std::forward<Args>(args)...);
         return output;
     }
 };

--- a/lib/I2cMaster/src/I2cMaster.cpp
+++ b/lib/I2cMaster/src/I2cMaster.cpp
@@ -43,7 +43,9 @@ esp_err_t I2cMaster::Init(gpio_num_t sda, gpio_num_t scl)
 
 bool I2cMaster::DeviceExists(uint8_t addr)
 {
-    esp_err_t res = ESP_OK;
+    // Initialized to a failure sentinel so a mutex timeout below
+    // isn't misreported as "device present".
+    esp_err_t res = ESP_ERR_TIMEOUT;
 
     if (xSemaphoreTake(i2cBusMutext, pdMS_TO_TICKS(SEMAPHORE_TIMEOUT)) == pdTRUE)
     {
@@ -56,12 +58,17 @@ bool I2cMaster::DeviceExists(uint8_t addr)
         i2c_cmd_link_delete(cmd);
         xSemaphoreGive(i2cBusMutext);
     }
+    else
+    {
+        ESP_LOGW("I2C", "DeviceExists: bus mutex timeout for addr 0x%02x", addr);
+    }
+
     return res == ESP_OK;
 }
 
 bool I2cMaster::WriteByte(uint8_t addr, uint8_t registerAddr, uint8_t byte)
 {
-    esp_err_t err = ESP_OK;
+    esp_err_t err = ESP_ERR_TIMEOUT;
 
     if (xSemaphoreTake(i2cBusMutext, pdMS_TO_TICKS(SEMAPHORE_TIMEOUT)) == pdTRUE)
     {
@@ -75,6 +82,10 @@ bool I2cMaster::WriteByte(uint8_t addr, uint8_t registerAddr, uint8_t byte)
         i2c_cmd_link_delete(cmd);
         xSemaphoreGive(i2cBusMutext);
     }
+    else
+    {
+        ESP_LOGW("I2C", "WriteByte: bus mutex timeout for addr 0x%02x", addr);
+    }
 
     if (err != ESP_OK)
     {
@@ -86,7 +97,7 @@ bool I2cMaster::WriteByte(uint8_t addr, uint8_t registerAddr, uint8_t byte)
 
 bool I2cMaster::WriteWord(uint8_t addr, uint8_t registerAddr, uint16_t word)
 {
-    esp_err_t err = ESP_OK;
+    esp_err_t err = ESP_ERR_TIMEOUT;
 
     if (xSemaphoreTake(i2cBusMutext, pdMS_TO_TICKS(SEMAPHORE_TIMEOUT)) == pdTRUE)
     {
@@ -102,6 +113,10 @@ bool I2cMaster::WriteWord(uint8_t addr, uint8_t registerAddr, uint16_t word)
 
         xSemaphoreGive(i2cBusMutext);
     }
+    else
+    {
+        ESP_LOGW("I2C", "WriteWord: bus mutex timeout for addr 0x%02x", addr);
+    }
 
     if (err != ESP_OK)
     {
@@ -114,7 +129,7 @@ bool I2cMaster::WriteWord(uint8_t addr, uint8_t registerAddr, uint16_t word)
 bool I2cMaster::WriteTwoWords(uint8_t addr, uint8_t registerAddr, uint16_t word1, uint16_t word2)
 {
 
-    esp_err_t err = ESP_OK;
+    esp_err_t err = ESP_ERR_TIMEOUT;
 
     if (xSemaphoreTake(i2cBusMutext, pdMS_TO_TICKS(SEMAPHORE_TIMEOUT)) == pdTRUE)
     {
@@ -133,6 +148,10 @@ bool I2cMaster::WriteTwoWords(uint8_t addr, uint8_t registerAddr, uint16_t word1
 
         xSemaphoreGive(i2cBusMutext);
     }
+    else
+    {
+        ESP_LOGW("I2C", "WriteTwoWords: bus mutex timeout for addr 0x%02x", addr);
+    }
 
     if (err != ESP_OK)
     {
@@ -144,7 +163,7 @@ bool I2cMaster::WriteTwoWords(uint8_t addr, uint8_t registerAddr, uint16_t word1
 
 bool I2cMaster::ReadByte(uint8_t addr, uint8_t registerAddr, uint8_t *data)
 {
-    esp_err_t err = ESP_OK;
+    esp_err_t err = ESP_ERR_TIMEOUT;
 
     if (xSemaphoreTake(i2cBusMutext, pdMS_TO_TICKS(SEMAPHORE_TIMEOUT)) == pdTRUE)
     {
@@ -179,6 +198,10 @@ bool I2cMaster::ReadByte(uint8_t addr, uint8_t registerAddr, uint8_t *data)
 
         xSemaphoreGive(i2cBusMutext);
     }
+    else
+    {
+        ESP_LOGW("I2C", "ReadByte: bus mutex timeout for addr 0x%02x", addr);
+    }
 
     if (err != ESP_OK)
     {
@@ -190,7 +213,7 @@ bool I2cMaster::ReadByte(uint8_t addr, uint8_t registerAddr, uint8_t *data)
 
 bool I2cMaster::ReadWord(uint8_t addr, uint8_t registerAddr, uint16_t *data)
 {
-    esp_err_t err = ESP_OK;
+    esp_err_t err = ESP_ERR_TIMEOUT;
 
     if (xSemaphoreTake(i2cBusMutext, pdMS_TO_TICKS(SEMAPHORE_TIMEOUT)) == pdTRUE)
     {
@@ -230,6 +253,10 @@ bool I2cMaster::ReadWord(uint8_t addr, uint8_t registerAddr, uint16_t *data)
 
         xSemaphoreGive(i2cBusMutext);
     }
+    else
+    {
+        ESP_LOGW("I2C", "ReadWord: bus mutex timeout for addr 0x%02x", addr);
+    }
 
     if (err != ESP_OK)
     {
@@ -241,7 +268,7 @@ bool I2cMaster::ReadWord(uint8_t addr, uint8_t registerAddr, uint16_t *data)
 
 bool I2cMaster::ReadTwoWords(uint8_t addr, uint8_t registerAddr, uint16_t *data1, uint16_t *data2)
 {
-    esp_err_t err = ESP_OK;
+    esp_err_t err = ESP_ERR_TIMEOUT;
 
     if (xSemaphoreTake(i2cBusMutext, pdMS_TO_TICKS(SEMAPHORE_TIMEOUT)) == pdTRUE)
     {
@@ -298,6 +325,10 @@ bool I2cMaster::ReadTwoWords(uint8_t addr, uint8_t registerAddr, uint16_t *data1
         *data2 = (buffer1 << 8) | buffer2;
 
         xSemaphoreGive(i2cBusMutext);
+    }
+    else
+    {
+        ESP_LOGW("I2C", "ReadTwoWords: bus mutex timeout for addr 0x%02x", addr);
     }
 
     if (err != ESP_OK)

--- a/lib/I2cMaster/src/I2cMaster.cpp
+++ b/lib/I2cMaster/src/I2cMaster.cpp
@@ -53,6 +53,7 @@ bool I2cMaster::DeviceExists(uint8_t addr)
         i2c_master_stop(cmd);
 
         res = i2c_master_cmd_begin(I2C_NUM_0, cmd, 10 / portTICK_PERIOD_MS);
+        i2c_cmd_link_delete(cmd);
         xSemaphoreGive(i2cBusMutext);
     }
     return res == ESP_OK;
@@ -206,9 +207,6 @@ bool I2cMaster::ReadWord(uint8_t addr, uint8_t registerAddr, uint16_t *data)
             xSemaphoreGive(i2cBusMutext);
             return false;
         }
-        cmd = i2c_cmd_link_create();
-        i2c_master_start(cmd);
-
         uint8_t buffer1;
         uint8_t buffer2;
 
@@ -230,7 +228,6 @@ bool I2cMaster::ReadWord(uint8_t addr, uint8_t registerAddr, uint16_t *data)
 
         *data = (buffer1 << 8) | buffer2;
 
-        i2c_cmd_link_delete(cmd);
         xSemaphoreGive(i2cBusMutext);
     }
 
@@ -261,9 +258,6 @@ bool I2cMaster::ReadTwoWords(uint8_t addr, uint8_t registerAddr, uint16_t *data1
             xSemaphoreGive(i2cBusMutext);
             return false;
         }
-        cmd = i2c_cmd_link_create();
-        i2c_master_start(cmd);
-
         uint8_t buffer1;
         uint8_t buffer2;
 
@@ -303,7 +297,6 @@ bool I2cMaster::ReadTwoWords(uint8_t addr, uint8_t registerAddr, uint16_t *data1
 
         *data2 = (buffer1 << 8) | buffer2;
 
-        i2c_cmd_link_delete(cmd);
         xSemaphoreGive(i2cBusMutext);
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -485,7 +485,6 @@ static void maintenanceTimerCallback(void *arg)
 
 void animationDispatchTask(void *arg)
 {
-    TickType_t lastWake = xTaskGetTickCount();
     constexpr uint32_t MIN_WAKE_MS = 10;
     constexpr uint32_t IDLE_WAKE_MS = 250;
 
@@ -542,12 +541,12 @@ void animationDispatchTask(void *arg)
                         if (val[i] == '\\' && i + 1 < val.size() && val[i + 1] == 'n')
                         {
                             formatted += '\n';
-                            i++;
+                            i++; // skip the 'n'
                         }
                         else if (val[i] == '\\' && i + 1 < val.size() && val[i + 1] == 'r')
                         {
                             formatted += '\r';
-                            i++;
+                            i++; // skip the 'r'
                         }
                         else
                         {
@@ -635,6 +634,8 @@ void animationDispatchTask(void *arg)
                     break;
                 }
 
+                // AnimationController already clamps its return value to a small
+                // minimum, but keep a local floor in case that contract changes.
                 uint32_t scriptDelay = AnimationCtrl.msTillNextServoCommand();
                 nextDelayMs = (scriptDelay < MIN_WAKE_MS) ? MIN_WAKE_MS : scriptDelay;
             }
@@ -644,7 +645,11 @@ void animationDispatchTask(void *arg)
             nextDelayMs = IDLE_WAKE_MS;
         }
 
-        vTaskDelayUntil(&lastWake, pdMS_TO_TICKS(nextDelayMs));
+        // vTaskDelay (not vTaskDelayUntil): script delays are data-driven and
+        // variable. The pre-refactor esp_timer_start_once(delay * 1000) scheduled
+        // each re-arm relative to now; vTaskDelay preserves that contract, while
+        // vTaskDelayUntil would produce catch-up bursts after long scripted waits.
+        vTaskDelay(pdMS_TO_TICKS(nextDelayMs));
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,6 +98,7 @@ static esp_timer_handle_t servoMoveTimer;
 // memory visibility we need without a mutex on the hot paths.
 static std::atomic<uint32_t> astrosRxOverflowCount{0};
 static std::atomic<uint32_t> espnowMallocFailureCount{0};
+static std::atomic<uint32_t> dispatchMallocFailureCount{0};
 
 #define SERVO_MOVE_INTERVAL 500 // 500ms
 
@@ -477,9 +478,12 @@ static void maintenanceTimerCallback(void *arg)
 
     uint32_t rxOverflow = astrosRxOverflowCount.load(std::memory_order_relaxed);
     uint32_t espnowMallocFail = espnowMallocFailureCount.load(std::memory_order_relaxed);
-    if (rxOverflow != 0 || espnowMallocFail != 0)
+    uint32_t dispatchMallocFail = dispatchMallocFailureCount.load(std::memory_order_relaxed);
+    if (rxOverflow != 0 || espnowMallocFail != 0 || dispatchMallocFail != 0)
     {
-        ESP_LOGW(TAG, "err-counters rx-overflow=%" PRIu32 " espnow-malloc-fail=%" PRIu32, rxOverflow, espnowMallocFail);
+        ESP_LOGW(TAG,
+                 "err-counters rx-overflow=%" PRIu32 " espnow-malloc-fail=%" PRIu32 " dispatch-malloc-fail=%" PRIu32,
+                 rxOverflow, espnowMallocFail, dispatchMallocFail);
     }
 }
 
@@ -557,6 +561,12 @@ void animationDispatchTask(void *arg)
                     queue_serial_msg_t serialMsg;
                     serialMsg.message_id = 0;
                     serialMsg.data = (uint8_t *)malloc(formatted.size() + 1);
+                    if (serialMsg.data == NULL)
+                    {
+                        ESP_LOGE(TAG, "Malloc serial dispatch data fail");
+                        dispatchMallocFailureCount.fetch_add(1, std::memory_order_relaxed);
+                        break;
+                    }
                     memcpy(serialMsg.data, formatted.c_str(), formatted.size());
                     serialMsg.data[formatted.size()] = '\0';
 
@@ -589,6 +599,12 @@ void animationDispatchTask(void *arg)
                     queue_msg_t servoMsg;
                     servoMsg.message_id = module;
                     servoMsg.data = (uint8_t *)malloc(val.size() + 1);
+                    if (servoMsg.data == NULL)
+                    {
+                        ESP_LOGE(TAG, "Malloc servo dispatch data fail");
+                        dispatchMallocFailureCount.fetch_add(1, std::memory_order_relaxed);
+                        break;
+                    }
                     memcpy(servoMsg.data, val.c_str(), val.size());
                     servoMsg.data[val.size()] = '\0';
 
@@ -605,6 +621,12 @@ void animationDispatchTask(void *arg)
                     queue_msg_t i2cMsg;
                     i2cMsg.message_id = 0;
                     i2cMsg.data = (uint8_t *)malloc(val.size() + 1);
+                    if (i2cMsg.data == NULL)
+                    {
+                        ESP_LOGE(TAG, "Malloc i2c dispatch data fail");
+                        dispatchMallocFailureCount.fetch_add(1, std::memory_order_relaxed);
+                        break;
+                    }
                     memcpy(i2cMsg.data, val.c_str(), val.size());
                     i2cMsg.data[val.size()] = '\0';
 
@@ -620,6 +642,12 @@ void animationDispatchTask(void *arg)
                     ESP_LOGI(TAG, "GPIO command val: %s", val.c_str());
                     queue_msg_t gpioMsg;
                     gpioMsg.data = (uint8_t *)malloc(val.size() + 1);
+                    if (gpioMsg.data == NULL)
+                    {
+                        ESP_LOGE(TAG, "Malloc gpio dispatch data fail");
+                        dispatchMallocFailureCount.fetch_add(1, std::memory_order_relaxed);
+                        break;
+                    }
                     memcpy(gpioMsg.data, val.c_str(), val.size());
                     gpioMsg.data[val.size()] = '\0';
 
@@ -873,6 +901,12 @@ void interfaceResponseQueueTask(void *arg)
                 queue_svc_cmd_t cmd;
                 cmd.cmd = SERVICE_COMMAND::FORMAT_SD;
                 cmd.data = (uint8_t *)malloc(id.size() + 1); // dummy data
+                if (cmd.data == NULL)
+                {
+                    ESP_LOGE(TAG, "Malloc FORMAT_SD command data fail");
+                    dispatchMallocFailureCount.fetch_add(1, std::memory_order_relaxed);
+                    break;
+                }
                 memccpy(cmd.data, id.c_str(), 0, id.size());
                 cmd.data[id.size()] = '\0';
                 cmd.dataSize = id.size() + 1;
@@ -1040,6 +1074,12 @@ void serviceQueueTask(void *arg)
                 queue_msg_t serialMsg;
                 serialMsg.message_id = 1;
                 serialMsg.data = (uint8_t *)malloc(msg.dataSize + 1);
+                if (serialMsg.data == NULL)
+                {
+                    ESP_LOGE(TAG, "Malloc ASTROS_INTERFACE_MESSAGE data fail");
+                    dispatchMallocFailureCount.fetch_add(1, std::memory_order_relaxed);
+                    break;
+                }
                 memcpy(serialMsg.data, msg.data, msg.dataSize);
                 serialMsg.data[msg.dataSize] = '\n';
                 serialMsg.dataSize = msg.dataSize + 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -636,8 +636,13 @@ void animationDispatchTask(void *arg)
 
                 // AnimationController already clamps its return value to a small
                 // minimum, but keep a local floor in case that contract changes.
-                uint32_t scriptDelay = AnimationCtrl.msTillNextServoCommand();
-                nextDelayMs = (scriptDelay < MIN_WAKE_MS) ? MIN_WAKE_MS : scriptDelay;
+                // msTillNextServoCommand returns signed int; guard against a
+                // negative sentinel wrapping to ~4 billion ms (~49 days) on the
+                // unsigned cast.
+                int rawDelay = AnimationCtrl.msTillNextServoCommand();
+                uint32_t scriptDelay =
+                    (rawDelay < static_cast<int>(MIN_WAKE_MS)) ? MIN_WAKE_MS : static_cast<uint32_t>(rawDelay);
+                nextDelayMs = scriptDelay;
             }
         }
         else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -233,14 +233,16 @@ void init(void)
     io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
     gpio_config(&io_conf);
 
+    // Dispatch queues sized for fan-in from animationTimerCallback + producer bursts.
+    // Control queues stay at QUEUE_LENGTH (5) since they carry low-rate coordination.
     animationQueue = xQueueCreate(QUEUE_LENGTH, sizeof(queue_ani_cmd_t));
     serviceQueue = xQueueCreate(QUEUE_LENGTH, sizeof(queue_svc_cmd_t));
     interfaceResponseQueue = xQueueCreate(QUEUE_LENGTH, sizeof(astros_interface_response_t));
-    serialCh1Queue = xQueueCreate(QUEUE_LENGTH, sizeof(queue_serial_msg_t));
-    serialCh2Queue = xQueueCreate(QUEUE_LENGTH, sizeof(queue_serial_msg_t));
-    servoQueue = xQueueCreate(QUEUE_LENGTH, sizeof(queue_msg_t));
-    i2cQueue = xQueueCreate(QUEUE_LENGTH, sizeof(queue_msg_t));
-    gpioQueue = xQueueCreate(QUEUE_LENGTH, sizeof(queue_msg_t));
+    serialCh1Queue = xQueueCreate(10, sizeof(queue_serial_msg_t));
+    serialCh2Queue = xQueueCreate(10, sizeof(queue_serial_msg_t));
+    servoQueue = xQueueCreate(20, sizeof(queue_msg_t));
+    i2cQueue = xQueueCreate(16, sizeof(queue_msg_t));
+    gpioQueue = xQueueCreate(10, sizeof(queue_msg_t));
     espnowQueue = xQueueCreate(QUEUE_LENGTH, sizeof(queue_espnow_msg_t));
 
     maestroModulesMutex = xSemaphoreCreateMutex();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,7 +90,6 @@ static esp_timer_handle_t pollingTimer;
 static bool polling = false;
 
 static esp_timer_handle_t maintenanceTimer;
-static esp_timer_handle_t animationTimer;
 static esp_timer_handle_t servoMoveTimer;
 
 // Silent-error counters — incremented from cross-task contexts (Wi-Fi driver task
@@ -155,7 +154,6 @@ static void loadGpioConfig();
 // timers
 static void initTimers(void);
 static void pollingTimerCallback(void *arg);
-static void animationTimerCallback(void *arg);
 static void maintenanceTimerCallback(void *arg);
 static void servoMoveTimerCallback(void *arg);
 
@@ -172,6 +170,7 @@ void astrosRxTask(void *arg);
 void serviceQueueTask(void *arg);
 void interfaceResponseQueueTask(void *arg);
 void animationQueueTask(void *arg);
+void animationDispatchTask(void *arg);
 void serialCh1QueueTask(void *arg);
 void serialCh2QueueTask(void *arg);
 void servoQueueTask(void *arg);
@@ -207,6 +206,7 @@ void app_main()
     xTaskCreatePinnedToCore(&buttonListenerTask, "button_listener_task", 4096, (void *)serviceQueue, 5, NULL, 1);
     xTaskCreatePinnedToCore(&serviceQueueTask, "service_queue_task", 3072, (void *)serviceQueue, 6, NULL, 1);
     xTaskCreatePinnedToCore(&animationQueueTask, "animation_queue_task", 4096, (void *)animationQueue, 7, NULL, 1);
+    xTaskCreatePinnedToCore(&animationDispatchTask, "animation_dispatch_task", 4096, NULL, 5, NULL, 1);
     xTaskCreatePinnedToCore(&interfaceResponseQueueTask, "interface_queue_task", 4096, (void *)interfaceResponseQueue,
                             10, NULL, 1);
     xTaskCreatePinnedToCore(&serialCh1QueueTask, "serial_ch1_queue_task", 4096, (void *)serialCh1Queue, 9, NULL, 1);
@@ -241,7 +241,7 @@ void init(void)
     io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
     gpio_config(&io_conf);
 
-    // Dispatch queues sized for fan-in from animationTimerCallback + producer bursts.
+    // Dispatch queues sized for fan-in from the animation dispatch path + producer bursts.
     // Control queues stay at QUEUE_LENGTH (5) since they carry low-rate coordination.
     animationQueue = xQueueCreate(QUEUE_LENGTH, sizeof(queue_ani_cmd_t));
     serviceQueue = xQueueCreate(QUEUE_LENGTH, sizeof(queue_svc_cmd_t));
@@ -370,12 +370,6 @@ static void initTimers(void)
                                                 .name = "polling",
                                                 .skip_unhandled_events = true};
 
-    const esp_timer_create_args_t aTimerArgs = {.callback = &animationTimerCallback,
-                                                .arg = NULL,
-                                                .dispatch_method = ESP_TIMER_TASK,
-                                                .name = "animation",
-                                                .skip_unhandled_events = true};
-
     const esp_timer_create_args_t mTimerArgs = {.callback = &maintenanceTimerCallback,
                                                 .arg = NULL,
                                                 .dispatch_method = ESP_TIMER_TASK,
@@ -392,10 +386,6 @@ static void initTimers(void)
     ESP_ERROR_CHECK(esp_timer_create(&pTimerArgs, &pollingTimer));
     ESP_ERROR_CHECK(esp_timer_start_periodic(pollingTimer, 2 * 1000 * 1000));
     ESP_LOGI("init_timer", "Started polling timer");
-
-    ESP_ERROR_CHECK(esp_timer_create(&aTimerArgs, &animationTimer));
-    ESP_ERROR_CHECK(esp_timer_start_once(animationTimer, 5 * 1000 * 1000));
-    ESP_LOGI("init_timer", "Started animation timer");
 
     ESP_ERROR_CHECK(esp_timer_create(&mTimerArgs, &maintenanceTimer));
     ESP_ERROR_CHECK(esp_timer_start_periodic(maintenanceTimer, 10 * 1000 * 1000));
@@ -493,152 +483,168 @@ static void maintenanceTimerCallback(void *arg)
     }
 }
 
-static void animationTimerCallback(void *arg)
+void animationDispatchTask(void *arg)
 {
-    esp_timer_stop(animationTimer);
+    TickType_t lastWake = xTaskGetTickCount();
+    constexpr uint32_t MIN_WAKE_MS = 10;
+    constexpr uint32_t IDLE_WAKE_MS = 250;
 
-    if (AnimationCtrl.scriptIsLoaded())
+    while (1)
     {
-        auto cmd = AnimationCtrl.getNextCommandPtr();
-
-        if (cmd == nullptr)
+        auto highWaterMark = uxTaskGetStackHighWaterMark(NULL);
+        if (highWaterMark < 500)
         {
-            // getNextCommandPtr returns nullptr only on mutex timeout, in which
-            // case it has also set scriptLoaded=false (halting the current
-            // sequence — see AnimationController.cpp for the safety rationale).
-            // Re-arm the timer so the subsystem stays alive; on the next tick
-            // scriptIsLoaded() will return false and the callback will take the
-            // else-branch below, keeping the timer running idle until a future
-            // queueScript can resume animation. Without this, a single transient
-            // mutex contention would require a device reboot to restore animation
-            // — bad, because third-party hardware may be in a non-safe state that
-            // a recovery script (not a power-cycle) needs to address.
-            ESP_LOGE(TAG, "Animation command pointer is null — script halted, timer re-armed for recovery");
-            ESP_ERROR_CHECK(esp_timer_start_once(animationTimer, 250 * 1000));
-            return;
+            ESP_LOGW(TAG, "Animation Dispatch Stack HWM: %d", highWaterMark);
         }
 
-        MODULE_TYPE ct = cmd->type;
-        std::string val = cmd->val;
-        int module = cmd->module;
+        uint32_t nextDelayMs = IDLE_WAKE_MS;
 
-        switch (ct)
+        if (AnimationCtrl.scriptIsLoaded())
         {
-        case MODULE_TYPE::NONE:
-        {
-            ESP_LOGI(TAG, "NONE command queued, assume buffer?");
-            break;
-        }
-        case MODULE_TYPE::KANGAROO:
-        case MODULE_TYPE::GENERIC_SERIAL:
-        {
-            ESP_LOGI(TAG, "Serial command val: %s", val.c_str());
+            auto cmd = AnimationCtrl.getNextCommandPtr();
 
-            // replace any occurances of \n with actual new line character
-            std::string formatted;
-            for (size_t i = 0; i < val.size(); i++)
+            if (cmd == nullptr)
             {
-                if (val[i] == '\\' && i + 1 < val.size() && val[i + 1] == 'n')
-                {
-                    formatted += '\n';
-                    i++; // skip the 'n'
-                }
-                else if (val[i] == '\\' && i + 1 < val.size() && val[i + 1] == 'r')
-                {
-                    formatted += '\r';
-                    i++; // skip the 'r'
-                }
-                else
-                {
-                    formatted += val[i];
-                }
-            }
-
-            queue_serial_msg_t serialMsg;
-            serialMsg.message_id = 0;
-            serialMsg.data = (uint8_t *)malloc(formatted.size() + 1);
-            memcpy(serialMsg.data, formatted.c_str(), formatted.size());
-            serialMsg.data[formatted.size()] = '\0';
-
-            if (module == 1)
-            {
-                if (xQueueSend(serialCh1Queue, &serialMsg, pdMS_TO_TICKS(2000)) != pdTRUE)
-                {
-                    ESP_LOGW(TAG, "Send serial queue fail");
-                    free(serialMsg.data);
-                }
-            }
-            else if (module == 2)
-            {
-                if (xQueueSend(serialCh2Queue, &serialMsg, pdMS_TO_TICKS(2000)) != pdTRUE)
-                {
-                    ESP_LOGW(TAG, "Send serial queue fail");
-                    free(serialMsg.data);
-                }
+                // getNextCommandPtr returns nullptr only on mutex timeout, in which
+                // case it has also set scriptLoaded=false (halting the current
+                // sequence — see AnimationController.cpp for the safety rationale).
+                // We loop normally; on the next iteration scriptIsLoaded() returns
+                // false and we take the idle wake interval until a future queueScript
+                // resumes animation. Without this, a single transient mutex
+                // contention would require a device reboot to restore animation
+                // — bad, because third-party hardware may be in a non-safe state
+                // that a recovery script (not a power-cycle) needs to address.
+                ESP_LOGE(TAG, "Animation command pointer is null — script halted, dispatch task idling for recovery");
+                nextDelayMs = IDLE_WAKE_MS;
             }
             else
             {
-                ESP_LOGE(TAG, "Invalid serial module %d", module);
-                free(serialMsg.data);
+                MODULE_TYPE ct = cmd->type;
+                std::string val = cmd->val;
+                int module = cmd->module;
+
+                switch (ct)
+                {
+                case MODULE_TYPE::NONE:
+                {
+                    ESP_LOGI(TAG, "NONE command queued, assume buffer?");
+                    break;
+                }
+                case MODULE_TYPE::KANGAROO:
+                case MODULE_TYPE::GENERIC_SERIAL:
+                {
+                    ESP_LOGI(TAG, "Serial command val: %s", val.c_str());
+
+                    // replace any occurances of \n with actual new line character
+                    std::string formatted;
+                    for (size_t i = 0; i < val.size(); i++)
+                    {
+                        if (val[i] == '\\' && i + 1 < val.size() && val[i + 1] == 'n')
+                        {
+                            formatted += '\n';
+                            i++;
+                        }
+                        else if (val[i] == '\\' && i + 1 < val.size() && val[i + 1] == 'r')
+                        {
+                            formatted += '\r';
+                            i++;
+                        }
+                        else
+                        {
+                            formatted += val[i];
+                        }
+                    }
+
+                    queue_serial_msg_t serialMsg;
+                    serialMsg.message_id = 0;
+                    serialMsg.data = (uint8_t *)malloc(formatted.size() + 1);
+                    memcpy(serialMsg.data, formatted.c_str(), formatted.size());
+                    serialMsg.data[formatted.size()] = '\0';
+
+                    if (module == 1)
+                    {
+                        if (xQueueSend(serialCh1Queue, &serialMsg, pdMS_TO_TICKS(2000)) != pdTRUE)
+                        {
+                            ESP_LOGW(TAG, "Send serial queue fail");
+                            free(serialMsg.data);
+                        }
+                    }
+                    else if (module == 2)
+                    {
+                        if (xQueueSend(serialCh2Queue, &serialMsg, pdMS_TO_TICKS(2000)) != pdTRUE)
+                        {
+                            ESP_LOGW(TAG, "Send serial queue fail");
+                            free(serialMsg.data);
+                        }
+                    }
+                    else
+                    {
+                        ESP_LOGE(TAG, "Invalid serial module %d", module);
+                        free(serialMsg.data);
+                    }
+                    break;
+                }
+                case MODULE_TYPE::MAESTRO:
+                {
+                    ESP_LOGI(TAG, "Maestro command val: %s", val.c_str());
+                    queue_msg_t servoMsg;
+                    servoMsg.message_id = module;
+                    servoMsg.data = (uint8_t *)malloc(val.size() + 1);
+                    memcpy(servoMsg.data, val.c_str(), val.size());
+                    servoMsg.data[val.size()] = '\0';
+
+                    if (xQueueSend(servoQueue, &servoMsg, pdMS_TO_TICKS(2000)) != pdTRUE)
+                    {
+                        ESP_LOGW(TAG, "Send servo queue fail");
+                        free(servoMsg.data);
+                    }
+                    break;
+                }
+                case MODULE_TYPE::I2C:
+                {
+                    ESP_LOGI(TAG, "I2C command val: %s", val.c_str());
+                    queue_msg_t i2cMsg;
+                    i2cMsg.message_id = 0;
+                    i2cMsg.data = (uint8_t *)malloc(val.size() + 1);
+                    memcpy(i2cMsg.data, val.c_str(), val.size());
+                    i2cMsg.data[val.size()] = '\0';
+
+                    if (xQueueSend(i2cQueue, &i2cMsg, pdMS_TO_TICKS(2000)) != pdTRUE)
+                    {
+                        ESP_LOGW(TAG, "Send i2c queue fail");
+                        free(i2cMsg.data);
+                    }
+                    break;
+                }
+                case MODULE_TYPE::GPIO:
+                {
+                    ESP_LOGI(TAG, "GPIO command val: %s", val.c_str());
+                    queue_msg_t gpioMsg;
+                    gpioMsg.data = (uint8_t *)malloc(val.size() + 1);
+                    memcpy(gpioMsg.data, val.c_str(), val.size());
+                    gpioMsg.data[val.size()] = '\0';
+
+                    if (xQueueSend(gpioQueue, &gpioMsg, pdMS_TO_TICKS(2000)) != pdTRUE)
+                    {
+                        ESP_LOGW(TAG, "Send gpio queue fail");
+                        free(gpioMsg.data);
+                    }
+                    break;
+                }
+                default:
+                    break;
+                }
+
+                uint32_t scriptDelay = AnimationCtrl.msTillNextServoCommand();
+                nextDelayMs = (scriptDelay < MIN_WAKE_MS) ? MIN_WAKE_MS : scriptDelay;
             }
-            break;
         }
-        case MODULE_TYPE::MAESTRO:
+        else
         {
-            ESP_LOGI(TAG, "Maestro command val: %s", val.c_str());
-            queue_msg_t servoMsg;
-            servoMsg.message_id = module;
-            servoMsg.data = (uint8_t *)malloc(val.size() + 1);
-            memcpy(servoMsg.data, val.c_str(), val.size());
-            servoMsg.data[val.size()] = '\0';
-
-            if (xQueueSend(servoQueue, &servoMsg, pdMS_TO_TICKS(2000)) != pdTRUE)
-            {
-                ESP_LOGW(TAG, "Send servo queue fail");
-                free(servoMsg.data);
-            }
-            break;
-        }
-        case MODULE_TYPE::I2C:
-        {
-            ESP_LOGI(TAG, "I2C command val: %s", val.c_str());
-            queue_msg_t i2cMsg;
-            i2cMsg.message_id = 0;
-            i2cMsg.data = (uint8_t *)malloc(val.size() + 1);
-            memcpy(i2cMsg.data, val.c_str(), val.size());
-            i2cMsg.data[val.size()] = '\0';
-
-            if (xQueueSend(i2cQueue, &i2cMsg, pdMS_TO_TICKS(2000)) != pdTRUE)
-            {
-                ESP_LOGW(TAG, "Send i2c queue fail");
-                free(i2cMsg.data);
-            }
-            break;
-        }
-        case MODULE_TYPE::GPIO:
-        {
-            ESP_LOGI(TAG, "GPIO command val: %s", val.c_str());
-            queue_msg_t gpioMsg;
-            gpioMsg.data = (uint8_t *)malloc(val.size() + 1);
-            memcpy(gpioMsg.data, val.c_str(), val.size());
-            gpioMsg.data[val.size()] = '\0';
-
-            if (xQueueSend(gpioQueue, &gpioMsg, pdMS_TO_TICKS(2000)) != pdTRUE)
-            {
-                ESP_LOGW(TAG, "Send gpio queue fail");
-                free(gpioMsg.data);
-            }
-            break;
-        }
-        default:
-            break;
+            nextDelayMs = IDLE_WAKE_MS;
         }
 
-        ESP_ERROR_CHECK(esp_timer_start_once(animationTimer, AnimationCtrl.msTillNextServoCommand() * 1000));
-    }
-    else
-    {
-        ESP_ERROR_CHECK(esp_timer_start_once(animationTimer, 250 * 1000));
+        vTaskDelayUntil(&lastWake, pdMS_TO_TICKS(nextDelayMs));
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -641,6 +641,7 @@ void animationDispatchTask(void *arg)
                 {
                     ESP_LOGI(TAG, "GPIO command val: %s", val.c_str());
                     queue_msg_t gpioMsg;
+                    gpioMsg.message_id = 0;
                     gpioMsg.data = (uint8_t *)malloc(val.size() + 1);
                     if (gpioMsg.data == NULL)
                     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1852,7 +1852,13 @@ static void handleFormatSD(std::string id)
 {
     auto cfig = AstrOs_Storage.readFile("config.txt");
 
-    auto success = AstrOs_Storage.formatSdCard();
+    esp_err_t formatErr = AstrOs_Storage.formatSdCard();
+    bool success = (formatErr == ESP_OK);
+
+    if (!success)
+    {
+        ESP_LOGE(TAG, "formatSdCard failed: %s", esp_err_to_name(formatErr));
+    }
 
     if (cfig != "error")
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -196,7 +196,7 @@ void app_main()
     init();
 
     // core 1
-    xTaskCreatePinnedToCore(&buttonListenerTask, "button_listener_task", 2048, (void *)serviceQueue, 5, NULL, 1);
+    xTaskCreatePinnedToCore(&buttonListenerTask, "button_listener_task", 4096, (void *)serviceQueue, 5, NULL, 1);
     xTaskCreatePinnedToCore(&serviceQueueTask, "service_queue_task", 3072, (void *)serviceQueue, 6, NULL, 1);
     xTaskCreatePinnedToCore(&animationQueueTask, "animation_queue_task", 4096, (void *)animationQueue, 7, NULL, 1);
     xTaskCreatePinnedToCore(&interfaceResponseQueueTask, "interface_queue_task", 4096, (void *)interfaceResponseQueue,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include <stdio.h>
 
 #include <atomic>
+#include <cinttypes>
 #include <driver/rmt.h>
 #include <driver/uart.h>
 #include <esp_event.h>
@@ -91,6 +92,13 @@ static bool polling = false;
 static esp_timer_handle_t maintenanceTimer;
 static esp_timer_handle_t animationTimer;
 static esp_timer_handle_t servoMoveTimer;
+
+// Silent-error counters — incremented from cross-task contexts (Wi-Fi driver task
+// for espnowRecvCallback, astrosRxTask on core 0). Read from maintenanceTimerCallback
+// (esp_timer task). std::atomic<uint32_t> is single-word on ESP32 and provides the
+// memory visibility we need without a mutex on the hot paths.
+static std::atomic<uint32_t> astrosRxOverflowCount{0};
+static std::atomic<uint32_t> espnowMallocFailureCount{0};
 
 #define SERVO_MOVE_INTERVAL 500 // 500ms
 
@@ -476,6 +484,13 @@ static void pollingTimerCallback(void *arg)
 static void maintenanceTimerCallback(void *arg)
 {
     ESP_LOGI(TAG, "RAM left %lu", esp_get_free_heap_size());
+
+    uint32_t rxOverflow = astrosRxOverflowCount.load(std::memory_order_relaxed);
+    uint32_t espnowMallocFail = espnowMallocFailureCount.load(std::memory_order_relaxed);
+    if (rxOverflow != 0 || espnowMallocFail != 0)
+    {
+        ESP_LOGW(TAG, "err-counters rx-overflow=%" PRIu32 " espnow-malloc-fail=%" PRIu32, rxOverflow, espnowMallocFail);
+    }
 }
 
 static void animationTimerCallback(void *arg)
@@ -946,6 +961,7 @@ void astrosRxTask(void *arg)
                     if (bufferIndex >= bufferLength)
                     {
                         ESP_LOGW("AstrOs RX", "Buffer overflow");
+                        astrosRxOverflowCount.fetch_add(1, std::memory_order_relaxed);
                         bufferIndex = 0;
                     }
                 }
@@ -1653,6 +1669,7 @@ static void espnowRecvCallback(const esp_now_recv_info_t *recv_info, const uint8
     if (msg.data == NULL)
     {
         ESP_LOGE(TAG, "Malloc receive data fail");
+        espnowMallocFailureCount.fetch_add(1, std::memory_order_relaxed);
         return;
     }
     memcpy(msg.data, data, len);


### PR DESCRIPTION
## Summary
  - Animation dispatch off `esp_timer` onto dedicated FreeRTOS task (`vTaskDelay`, relative-from-now — no catch-up
  bursts after scripted delays)
  - I2C cmd-handle leaks + double-free fixes in `DeviceExists`, `ReadWord`, `ReadTwoWords`
  - `AstrOsStorageManager` hardening: `isPathSafe` gate on 5 public entrypoints, `formatSdCard` returns `esp_err_t`
  with distinct error codes, workbuf leak fix
  - Bounded `snprintf` in `stringFormat` (replaces unbounded `sprintf`)
  - Silent-error counters (`std::atomic<uint32_t>`) for RX overflow + ESP-NOW malloc failure, logged from maintenance
  timer when non-zero
  - Queue depth bumps (serial/gpio 5→10, i2c 5→16, servo 5→20) to absorb bursty frames
  - `button_listener_task` stack 2048→4096

  ## Deferred to a future "internal panic-stop + script corruption handling" feature
  FF-1 dispatch-failure propagation, `std::stoi`→`strtol` migration (#14), and script validation on deploy — all
  entangled with cross-node halt semantics.

  ## Test plan
  - [ ] `pio test -e test` (native) passes
  - [ ] `pio run -e lolin_d32_pro` + `pio run -e metro_s3` build clean
  - [ ] Hardware QA per `.docs/qa/code-review-phase-c.md` (8 sections + regression sweep)
  - [ ] Confirm no `Animation Dispatch Stack HWM:` warnings under mixed load
  - [ ] Panic-stop mid-script halts within one delay cycle