### PR TITLE
Feature/native testable foundation

### DIFF
--- a/.docs/code-review/code-review-20260415.md
+++ b/.docs/code-review/code-review-20260415.md
@@ -1,0 +1,391 @@
+# AstrOs.ESP — Comprehensive Code Review
+
+**Date:** April 15, 2026
+**Scope:** Full codebase — `src/`, `lib/`, `components/`, build configuration
+**Platform:** ESP-IDF / PlatformIO, targeting ESP32 (lolin_d32_pro) and ESP32-S3 (metro_s3)
+
+---
+
+## Executive Summary
+
+AstrOs.ESP is an ESP-IDF C/C++ firmware that orchestrates animatronics hardware via ESP-NOW mesh networking, serial communication, I2C peripherals (PCA9685 servo drivers, OLED display), and GPIO. The application creates **12 FreeRTOS tasks** pinned across two cores, **9 message queues**, and **3 ESP timers** to coordinate animation playback, peer discovery, and hardware control.
+
+Compared to the April 11, 2026 review, several critical issues have been resolved:
+- AnimationController now uses `std::unique_ptr<CommandTemplate>` (was raw pointers)
+- AnimationController now uses `std::atomic` for shared flags (was unprotected bools)
+- AnimationController semaphore properly deleted in destructor
+- AnimationController uses bounded timeouts (`pdMS_TO_TICKS(5000)`) instead of `portMAX_DELAY`
+- `maestroModules` map is now protected by `maestroModulesMutex`
+- Global state variables (`discoveryMode`, `displayTimeout`, `isMasterNode`) are now `std::atomic`
+- `pollingTimerCallback` fingerprint is now stack-allocated
+- Queue consumers properly free malloc'd pointers
+- No pthread/FreeRTOS synchronization mixing (standardized on FreeRTOS)
+
+Remaining issues are documented below, organized by severity.
+
+### Issue Count by Severity
+
+| Severity | Count | Categories |
+|----------|-------|------------|
+| P0 — Critical | 5 | Memory leaks, race condition, buffer overflow, unsafe parsing |
+| P1 — High | 6 | Resource leaks, semaphore leaks, deprecated API, ISR cleanup |
+| P2 — Medium | 5 | Timeout inconsistency, RX overflow handling, unbounded fragmentation, stack concerns |
+| P3 — Low | 3 | Minor buffer risks, silent error paths, mutex timeout mismatch |
+
+---
+
+## P0 — Critical
+
+### 1. `astrosRxTask()` — two permanent malloc leaks with no NULL checks
+
+**File:** `src/main.cpp` — `astrosRxTask()`
+
+```cpp
+uint8_t *data = (uint8_t *)malloc(RX_BUF_SIZE + 1);      // ~1025 bytes
+uint8_t *commandBuffer = (uint8_t *)malloc(bufferLength);  // 2000 bytes
+```
+
+Neither allocation is checked for NULL. The task runs an infinite `while(1)` loop so the buffers are never freed — a permanent ~3KB heap loss per boot. While the task never exits (so technically the memory is "in use"), the missing NULL check is the real risk: if either malloc returns NULL (heap pressure), the task will immediately crash on dereference.
+
+**Fix:** Add NULL checks. If allocation fails, log an error and `vTaskDelete(NULL)` to avoid a crash. These buffers are effectively permanent so the leak is tolerable, but the NULL check is mandatory.
+
+---
+
+### 2. Unsafe `std::stoi()` in `handleServoTest()`
+
+**File:** `src/main.cpp` — `handleServoTest()`
+
+```cpp
+int idx = std::stoi(parts[1]);
+int servo = std::stoi(parts[2]);
+int ms = std::stoi(parts[3]);
+```
+
+`std::stoi()` throws `std::invalid_argument` or `std::out_of_range` on malformed input. On ESP-IDF with exceptions effectively disabled, an uncaught exception terminates the calling FreeRTOS task with no recovery.
+
+This is reachable from serial input — a malformed servo test command from the interface will crash the task.
+
+**Fix:** Replace with `strtol()` + `errno` checking, or use the `safeStoi()` wrapper already present in `lib/AstrOsUtility/src/AstrOsFileUtils.hpp`. The safe wrapper already exists in the codebase — just use it.
+
+---
+
+### 3. Unsafe `std::stoi()` in AnimationCommand parsing
+
+**File:** `lib/AnimationController/src/AnimationCommand.cpp` — `parseCommandType()`
+
+```cpp
+this->commandType = static_cast<MODULE_TYPE>(std::stoi(script.at(0)));
+this->duration = std::stoi(script.at(1));
+this->module = std::stoi(script.at(2));
+```
+
+Same issue as #2. A malformed animation script (received over serial or ESP-NOW from an external source) will crash the animation task via uncaught exception.
+
+The `parts.size()` pre-check prevents `at()` from throwing, but `stoi()` itself can still throw on non-numeric strings.
+
+**Fix:** Replace with `strtol()` + `errno` or the existing `safeStoi()` utility.
+
+---
+
+### 4. ESP-NOW callbacks access `peers` without mutex
+
+**File:** `lib/AstrOsEspNow/src/AstrOsEspNowService.cpp`
+
+`espnowSendCallback()` and `espnowRecvCallback()` are called from the Wi-Fi driver task on core 0. They enqueue messages that reference peers, but do not hold `peersMutex` while accessing the `peers` vector. All other code paths properly acquire the semaphore.
+
+An ESP-NOW receive that triggers a `push_back()` on `peers` (via the handler chain) concurrent with an iteration in `pollPadawans()` can invalidate iterators and crash.
+
+**Fix:** Ensure any peers vector access in callback paths is either protected by `peersMutex` or deferred to a task that holds it.
+
+---
+
+### 5. No `payloadSize` bounds check in `parsePacket()`
+
+**File:** `lib/AstrOsEspNow/src/AstrOsEspNowMessageService.cpp`
+
+When parsing incoming ESP-NOW packets, the header's `payloadSize` field is trusted without validation. A malicious or corrupted packet claiming `payloadSize = 500` with only 180 bytes of actual data causes an out-of-bounds read from the receive buffer.
+
+**Fix:** Validate `payloadSize <= ASTROS_PACKET_PAYLOAD_SIZE` (180) before reading payload bytes.
+
+---
+
+## P1 — High
+
+### 6. SPIFFS `esp_vfs_spiffs_unregister()` missing on error paths
+
+**File:** `lib/AstrOsStorageManager/src/AstrOsStorageManager.cpp`
+
+Five SPIFFS functions (`saveFileSpiffs`, `deleteFileSpiffs`, `fileExistsSpiffs`, `readFileSpiffs`, `listFilesSpiffs`) call `esp_vfs_spiffs_register()` at entry but skip `esp_vfs_spiffs_unregister()` on early error returns (e.g., `fopen` failure, `stat` failure). Each leaked registration holds a VFS mount slot.
+
+**Fix:** Use a cleanup-on-exit pattern (goto cleanup, or RAII wrapper) to ensure `esp_vfs_spiffs_unregister()` is always called.
+
+---
+
+### 7. Semaphores never deleted in hardware modules
+
+**Files:**
+- `lib/I2cMaster/src/I2cMaster.cpp` — `i2cBusMutext` (note: typo in variable name)
+- `lib/Modules/src/SerialModule.cpp` — `serialMutex`
+- `lib/Modules/src/I2cModule.cpp` — `i2cMutex`
+- `lib/Modules/src/MaestroModule.cpp` — private mutex
+
+All four modules create FreeRTOS semaphores in their constructors or `Init()` but never call `vSemaphoreDelete()` in their destructors. Since these are effectively singletons that live for the program's lifetime, this is not a runtime leak — but it prevents safe re-instantiation and is a pattern defect.
+
+**Fix:** Add `vSemaphoreDelete()` in each destructor, guarded by a NULL check.
+
+---
+
+### 8. MaestroModule `sendQueueMsg()` race condition
+
+**File:** `lib/Modules/src/MaestroModule.cpp` — `sendQueueMsg()`
+
+If `xSemaphoreTake()` fails (timeout), the code falls through and continues to allocate and `xQueueSend` without holding the mutex. This means queue message data can be corrupted if another task is simultaneously modifying the same state.
+
+**Fix:** Return early (with error log) if the semaphore take fails. Do not proceed to queue operations without the lock.
+
+---
+
+### 9. `stringToMac()` returns `new uint8_t[6]` — caller must `delete[]`
+
+**File:** `lib/AstrOsUtility/src/AstrOsStringUtils.hpp`
+
+```cpp
+uint8_t *mac = new uint8_t[6];
+```
+
+Returns a heap-allocated array. The caller is responsible for `delete[]`, but this contract is not documented and easy to miss. Every call site must be audited.
+
+**Fix:** Change to accept a caller-provided `uint8_t mac[6]` buffer, or return `std::array<uint8_t, 6>` by value.
+
+---
+
+### 10. SoftwareSerial ISR handler not removed on deletion
+
+**File:** `lib/SoftwareSerial/include/SoftwareSerial.h` — `sw_del()`
+
+The `sw_del()` function frees RX/TX buffers but never calls `gpio_isr_handler_remove()` or `gpio_uninstall_isr_service()`. The ISR remains registered and will fire on the now-freed buffer memory, causing a use-after-free crash.
+
+**Fix:** Remove the ISR handler before freeing buffers.
+
+---
+
+### 11. Deprecated I2C driver API
+
+**File:** `lib/I2cMaster/src/I2cMaster.cpp`
+
+Uses the legacy `i2c_cmd_link_create()` / `i2c_master_write_byte()` / `i2c_cmd_link_delete()` API, which is deprecated in ESP-IDF 5.x. Commented-out code at end of file shows an abandoned migration attempt.
+
+**Impact:** Low urgency if staying on IDF 4.x, but will be a build-breaking issue on IDF 5.x. Pca9685 `SetFrequency()` also ignores `WriteByte()` return values.
+
+**Fix:** Plan migration to `i2c_master_bus_handle_t` / `i2c_master_transmit()` API when upgrading framework.
+
+---
+
+## P2 — Medium
+
+### 12. `maestroModulesMutex` timeout inconsistency
+
+**File:** `src/main.cpp`
+
+| Call site | Timeout |
+|-----------|---------|
+| `servoMoveTimerCallback()` | 100 ms |
+| `servoQueueTask()` | 1000 ms |
+| `loadMaestroConfigs()` | 1000 ms |
+| `handleServoTest()` | 1000 ms |
+
+The servo move timer uses a 100ms timeout while all other sites use 1000ms. If the map is being modified during module load (a slow NVS operation), the timer will repeatedly fail to acquire the mutex, silently skipping servo update cycles.
+
+**Fix:** Standardize on a single timeout (e.g., 500ms), or accept the skipped cycles and document why the timer is intentionally shorter.
+
+---
+
+### 13. `astrosRxTask()` silently drops overflowed messages
+
+**File:** `src/main.cpp` — `astrosRxTask()`
+
+When received data exceeds the 2000-byte buffer, the overflow counter is incremented (good) but the entire message is silently discarded with no feedback to the sender.
+
+**Fix:** Consider sending a NAK response to the interface or logging the discarded message length so the root cause is diagnosable.
+
+---
+
+### 14. Unbounded ESP-NOW packet fragmentation
+
+**Files:** `lib/AstrOsEspNow/src/AstrOsEspNowMessageService.cpp`, `lib/AstrOsEspNow/src/PacketTracker.cpp`
+
+There is no maximum message size limit on fragmentation. A multi-megabyte message will be fragmented into thousands of packets, each stored in an `std::unordered_map<msgId, vector<PacketData>>` until expiration (1 second). This allows heap exhaustion via a single large message.
+
+**Fix:** Add a max message size constant (e.g., 8KB) and reject messages that would exceed it. Also cap the number of entries in PacketTracker.
+
+---
+
+### 15. `NvsManager.c` — `setKeyId()` assumes peer index < 100
+
+**File:** `lib/AstrOsStorageManager/src/NvsManager.c`
+
+```cpp
+char nameConfig[] = "p-00-name";
+setKeyId(nameConfig, i, 2);
+```
+
+If peer index exceeds 99, `setKeyId` writes a 3+ digit number into a 2-character slot, overflowing the stack buffer. Current deployments likely have fewer than 100 peers, but no runtime check enforces it.
+
+**Fix:** Validate `i < 100` before the call, or use `snprintf` for the full key.
+
+---
+
+### 16. `MaestroModule` assumes null-terminated command data
+
+**File:** `lib/Modules/src/MaestroModule.cpp`
+
+```cpp
+std::string(reinterpret_cast<char*>(cmd))
+```
+
+This constructs a `std::string` from a `uint8_t*` pointer, relying on null termination. If the queue message data is not null-terminated (e.g., due to a truncation bug elsewhere), this reads past the buffer.
+
+**Fix:** Use the length-bounded constructor: `std::string(reinterpret_cast<char*>(cmd), len)`.
+
+---
+
+## P3 — Low
+
+### 17. `guid.h` — `sprintf` without bounds checking
+
+**File:** `lib/Uuid/guid.h`
+
+Uses a 64-byte stack buffer with `sprintf`. Current format strings fit, but there's no `snprintf` protection against future changes.
+
+**Fix:** Replace with `snprintf(buf, sizeof(buf), ...)`.
+
+---
+
+### 18. `espnowRecvCallback()` — malloc failure silently drops message
+
+**File:** `src/main.cpp`
+
+When `malloc` fails for the ESP-NOW receive buffer, the atomic error counter is incremented (good), but no error is queued or logged beyond the counter. In a heap-pressure scenario, the only signal is a counter that must be manually observed.
+
+**Fix:** Acceptable as-is given the counter exists. Consider also logging an `ESP_LOGE` on first failure (rate-limited).
+
+---
+
+### 19. `sscanf` in `stringToMac()` — no field width limits
+
+**File:** `lib/AstrOsUtility/src/AstrOsStringUtils.hpp`
+
+Minor: `sscanf` format string `%02x` does not strictly limit input width. Unlikely to be exploitable given the input is a pre-split string, but `%2x` would be more defensive.
+
+---
+
+## Architecture & Task Layout Reference
+
+### FreeRTOS Tasks (12 total)
+
+| Task | Stack | Priority | Core | Purpose |
+|------|-------|----------|------|---------|
+| buttonListenerTask | 4096 | 5 | 1 | GPIO polling (reset button) |
+| serviceQueueTask | 3072 | 6 | 1 | Service commands (FORMAT_SD, discovery mode) |
+| animationQueueTask | 4096 | 7 | 1 | Animation script loading |
+| animationDispatchTask | 4096 | 5 | 1 | Core dispatch: animation frames → hardware queues |
+| interfaceResponseQueueTask | 4096 | 10 | 1 | Route interface responses to serial |
+| serialCh1QueueTask | 4096 | 9 | 1 | Serial channel 1 TX |
+| serialCh2QueueTask | 4096 | 9 | 1 | Serial channel 2 TX |
+| servoQueueTask | 4096 | 10 | 1 | Route servo commands to MaestroModule |
+| i2cQueueTask | 3072 | 8 | 1 | Route I2C commands |
+| gpioQueueTask | 3072 | 8 | 1 | Route GPIO commands |
+| astrosRxTask | 4096 | 9 | 0 | UART0 RX buffering |
+| espnowQueueTask | 4096 | 10 | 0 | ESP-NOW message dispatch |
+
+### Queues (9 total)
+
+| Queue | Depth | Payload | Producers | Consumer |
+|-------|-------|---------|-----------|----------|
+| animationQueue | 5 | queue_ani_cmd_t | Script loader | animationQueueTask |
+| serviceQueue | 5 | queue_svc_cmd_t | Button, interface response | serviceQueueTask |
+| interfaceResponseQueue | 5 | astros_interface_response_t | EspNow, SerialMsgHandler | interfaceResponseQueueTask |
+| serialCh1Queue | 10 | queue_serial_msg_t | animationDispatch, service | serialCh1QueueTask |
+| serialCh2Queue | 10 | queue_serial_msg_t | animationDispatch, maestro | serialCh2QueueTask |
+| servoQueue | 20 | queue_msg_t | animationDispatch | servoQueueTask |
+| i2cQueue | 16 | queue_msg_t | animationDispatch, display | i2cQueueTask |
+| gpioQueue | 10 | queue_msg_t | animationDispatch | gpioQueueTask |
+| espnowQueue | 5 | queue_espnow_msg_t | pollingTimer, WiFi RX | espnowQueueTask |
+
+### Timers (3 total)
+
+| Timer | Period | Type | Purpose |
+|-------|--------|------|---------|
+| pollingTimer | 2 s | Periodic | Heartbeat, discovery, display timeout |
+| maintenanceTimer | 10 s | Periodic | Log free heap + error counters |
+| servoMoveTimer | 300 ms | Periodic | Servo position updates |
+
+---
+
+## Positive Observations
+
+The codebase demonstrates several strong patterns:
+
+- **Queue ownership handoff** is correct across all 9 queues — every consumer properly frees malloc'd pointers, and every producer frees on send failure
+- **`std::atomic`** used for all cross-task shared state (`discoveryMode`, `displayTimeout`, `isMasterNode`, error counters) with appropriate memory ordering
+- **`std::unique_ptr`** for `CommandTemplate` in AnimationController — eliminates prior raw-pointer ownership ambiguity
+- **`std::shared_ptr`** for `MaestroModule` instances — safe snapshot pattern in timer callbacks
+- **Bounded mutex timeouts** throughout AnimationController (5s) — no `portMAX_DELAY` deadlock risk
+- **Stack high-water mark monitoring** in every task at 500-byte threshold
+- **Core pinning** — I/O tasks on core 1, ESP-NOW receive on core 0
+- **Error counters** for malloc failures and RX overflows — observable via maintenance timer
+- **ESP-NOW packet fragmentation** correctly respects the 250-byte limit (20B header + 180B payload)
+- **`safeStoi()` utility exists** in `AstrOsFileUtils.hpp` using `strtol` + `errno` — just needs to be used consistently
+- **No try/catch** blocks anywhere in the codebase (correct for ESP-IDF)
+- **Consistent FreeRTOS synchronization** — no pthread mixing
+
+---
+
+## Recommendations Summary
+
+| # | Priority | Category | Issue | Recommended Fix |
+|---|----------|----------|-------|-----------------|
+| 1 | P0 | Memory | `astrosRxTask` malloc without NULL check | Add NULL checks; `vTaskDelete(NULL)` on failure |
+| 2 | P0 | Safety | `std::stoi()` in `handleServoTest()` | Replace with existing `safeStoi()` utility |
+| 3 | P0 | Safety | `std::stoi()` in `AnimationCommand` | Replace with existing `safeStoi()` utility |
+| 4 | P0 | Thread | ESP-NOW callbacks access peers without mutex | Protect or defer to mutex-holding task |
+| 5 | P0 | Buffer | `parsePacket()` trusts `payloadSize` | Validate ≤ `ASTROS_PACKET_PAYLOAD_SIZE` |
+| 6 | P1 | Resource | SPIFFS unregister missing on error paths | Add cleanup-on-exit pattern |
+| 7 | P1 | Resource | 4 modules never delete semaphores | `vSemaphoreDelete()` in destructors |
+| 8 | P1 | Thread | `MaestroModule::sendQueueMsg()` race | Return early if semaphore take fails |
+| 9 | P1 | Memory | `stringToMac()` returns `new[]` | Accept caller buffer or return `std::array` |
+| 10 | P1 | Resource | SoftwareSerial ISR not removed on delete | `gpio_isr_handler_remove()` before free |
+| 11 | P1 | API | Deprecated I2C driver | Plan migration to IDF 5.x API |
+| 12 | P2 | Thread | Mutex timeout inconsistency (100ms vs 1s) | Standardize or document intent |
+| 13 | P2 | Error | RX overflow silently drops messages | Log discarded message details |
+| 14 | P2 | Security | Unbounded packet fragmentation | Add max message size limit |
+| 15 | P2 | Buffer | NVS `setKeyId` assumes index < 100 | Validate or use `snprintf` |
+| 16 | P2 | Buffer | MaestroModule assumes null-terminated data | Use length-bounded `std::string` constructor |
+| 17 | P3 | Safety | `guid.h` uses `sprintf` | Replace with `snprintf` |
+| 18 | P3 | Error | ESP-NOW malloc failure silent | Rate-limited `ESP_LOGE` on first failure |
+| 19 | P3 | Safety | `sscanf` no field width limit | Use `%2x` instead of `%02x` |
+
+---
+
+## Changes Since April 11, 2026 Review
+
+The following items from the previous review have been **resolved**:
+
+| Previous # | Issue | Resolution |
+|------------|-------|------------|
+| P0-1 | `pollingTimerCallback` fingerprint leak | Now stack-allocated `char fingerprint[37]` |
+| P0-2 | Interface queue consumer never frees char* | Consumer now frees all 4 pointers |
+| P0-3 | Serial queue consumer never frees data | All queue consumers now free properly |
+| P0-4 | DisplayService queue failure leak | Fixed |
+| P0-5 | CommandTemplate raw pointer ownership | Now returns `std::unique_ptr<CommandTemplate>` |
+| P0-6 | AnimationController semaphore never deleted | Destructor now calls `vSemaphoreDelete()` |
+| P0-7 | Global state without synchronization | All globals now `std::atomic` |
+| P0-8 | Unprotected maestroModules map | Now protected by `maestroModulesMutex` |
+| P0-10 | AnimationController flags read outside mutex | Now `std::atomic<bool>` / `std::atomic<int>` |
+| P0-11 | ESP-NOW peer name overflow | Now bounds-checked with `std::min(name.length(), 15)` |
+| P1-15 | `portMAX_DELAY` deadlock risk | AnimationController now uses `pdMS_TO_TICKS(5000)` |
+| P1-17 | Mixed FreeRTOS/pthread sync primitives | Standardized on FreeRTOS |
+| P2-19 | Queue depth too small | Queues resized: servo=20, i2c=16, serial=10, gpio=10 |
+| P2-20 | `button_listener_task` 2048 bytes | Increased to 4096 |
+| P2-25 | Mixed malloc/new style | Standardized within modules |
+| P3-27 | Non-atomic boolean flags | Now `std::atomic<bool>` |

--- a/.docs/plans/20260415-0715-native-testable-foundation.md
+++ b/.docs/plans/20260415-0715-native-testable-foundation.md
@@ -161,10 +161,10 @@ Foundation + one pilot extraction. ~8 tasks total, at the CLAUDE.md scope-guard 
 - [x] Task 2: Create `lib/AstrOsUtility_ESP` logger adapter
 - [x] Task 3: Extend CI purity guard over a lib list
 - [x] Task 4: Extract `isPathSafe` into `lib/AstrOsUtility` + native test
-- [ ] Task 5: Create `lib/AstrOsSerialProtocol` pure lib
-- [ ] Task 6: Rewrite `AstrOsSerialMsgHandler` as thin adapter
-- [ ] Task 7: Add native tests for `AstrOsSerialProtocol`
-- [ ] Task 8: Update CLAUDE.md with classification + "Adding a new extracted lib" blurb
+- [x] Task 5: Create `lib/AstrOsSerialProtocol` pure lib
+- [x] Task 6: Rewrite `AstrOsSerialMsgHandler` as thin adapter
+- [x] Task 7: Add native tests for `AstrOsSerialProtocol`
+- [x] Task 8: Update CLAUDE.md with classification + "Adding a new extracted lib" blurb
 
 ## What's explicitly not in this plan
 

--- a/.docs/plans/20260415-0715-native-testable-foundation.md
+++ b/.docs/plans/20260415-0715-native-testable-foundation.md
@@ -157,10 +157,10 @@ Foundation + one pilot extraction. ~8 tasks total, at the CLAUDE.md scope-guard 
 
 ## Task checklist
 
-- [ ] Task 1: Create `lib/AstrOsLogging` pure lib + README
-- [ ] Task 2: Create `lib/AstrOsUtility_ESP` logger adapter
-- [ ] Task 3: Extend CI purity guard over a lib list
-- [ ] Task 4: Extract `isPathSafe` into `lib/AstrOsUtility` + native test
+- [x] Task 1: Create `lib/AstrOsLogging` pure lib + README
+- [x] Task 2: Create `lib/AstrOsUtility_ESP` logger adapter
+- [x] Task 3: Extend CI purity guard over a lib list
+- [x] Task 4: Extract `isPathSafe` into `lib/AstrOsUtility` + native test
 - [ ] Task 5: Create `lib/AstrOsSerialProtocol` pure lib
 - [ ] Task 6: Rewrite `AstrOsSerialMsgHandler` as thin adapter
 - [ ] Task 7: Add native tests for `AstrOsSerialProtocol`

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -15,8 +15,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  messaging-purity:
-    name: AstrOsMessaging native-purity guard
+  native-purity:
+    name: Native-purity guard for PURE libs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,15 +24,35 @@ jobs:
       - name: Check for forbidden ESP-IDF / FreeRTOS / driver includes
         run: |
           set -euo pipefail
-          # The lib/AstrOsMessaging/README rule: this library is unit-tested
-          # on the native host, so it must not pull in any ESP-IDF, FreeRTOS,
-          # or low-level driver headers. Catch violations as early as possible.
-          if grep -rEn '#include[[:space:]]*[<"](freertos/|esp_|driver/)' lib/AstrOsMessaging/; then
-            echo "::error::lib/AstrOsMessaging contains forbidden ESP-IDF/FreeRTOS/driver includes (see lines above)."
-            echo "::error::This library must remain native-test compatible. Move ESP-specific code to a different lib."
+          # PURE libs are unit-tested on the native host under [env:test], so
+          # they must not pull in any ESP-IDF, FreeRTOS, or low-level driver
+          # headers. To add a new PURE lib: append its path here AND state the
+          # purity rule in the lib's README. Catch violations as early as
+          # possible — broken purity shows up at `pio test -e test` time
+          # otherwise, which is a much noisier failure mode.
+          PURE_LIBS=(
+            lib/AstrOsMessaging
+            lib/AstrOsUtility
+            lib/AstrOsLogging
+          )
+          PATTERN='#include[[:space:]]*[<"](freertos/|esp_|driver/|nvs_|sdmmc_)'
+          status=0
+          for path in "${PURE_LIBS[@]}"; do
+            if [ ! -d "$path" ]; then
+              echo "::error::PURE lib path not found: $path"
+              status=1
+              continue
+            fi
+            if grep -rEn "$PATTERN" "$path"; then
+              echo "::error::$path contains forbidden ESP-IDF/FreeRTOS/driver includes (see lines above)."
+              status=1
+            fi
+          done
+          if [ "$status" -ne 0 ]; then
+            echo "::error::PURE libs must remain native-test compatible. Move ESP-specific code to a different lib."
             exit 1
           fi
-          echo "messaging purity OK"
+          echo "PURE lib purity OK"
 
   clang-format:
     name: clang-format (changed files only)

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -34,6 +34,7 @@ jobs:
             lib/AstrOsMessaging
             lib/AstrOsUtility
             lib/AstrOsLogging
+            lib/AstrOsSerialProtocol
           )
           PATTERN='#include[[:space:]]*[<"](freertos/|esp_|driver/|nvs_|sdmmc_)'
           status=0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,17 +65,34 @@ The actual behavior lives in `lib/`. When tracing a feature, start at `main.cpp`
 
 ### Library layout (what each thing owns)
 
-- **`lib/AstrOsMessaging`** — wire-format serializers/parsers for messages exchanged over serial and ESP-NOW. **Must stay free of ESP-IDF/FreeRTOS includes** (see its `README`) because it is unit-tested on the native host. Treat this as a hard rule: no `freertos/*`, no `esp_*`, no `driver/*` in this lib.
-- **`lib/AstrOsEspNow`** — ESP-NOW mesh: peer registration, polling (master → padawans), fragmentation (respects the 250 B ESP-NOW payload limit via a 20 B header + 180 B payload scheme), callbacks for send/recv.
-- **`lib/AstrOsSerialMsgHandler`** — owns the UART protocol handler that bridges the serial interface queue and the interface-response queue.
-- **`lib/AnimationController`** — loads scripts, computes the next command, pushes commands onto the hardware queues. Uses a FreeRTOS mutex (`animationMutex`) around `scriptEvents`.
-- **`lib/AstrOsStorageManager`** — NVS for config + FAT/SD for scripts. Exposes the `AstrOs_Storage` singleton. Peer configs, service config (name, master MAC, fingerprint), and controller fingerprint live here.
-- **`lib/Modules`** — hardware abstractions: `SerialModule`, `I2cModule`, `GpioModule`, `MaestroModule`. Each one owns a queue-consumer loop for its hardware.
-- **`lib/Pca9685`** — PCA9685 servo driver sitting on top of `I2cMaster`. Two boards expected at `0x40` and `0x41`.
-- **`lib/I2cMaster`** — serialises bus access with a FreeRTOS semaphore (1000 ms timeout). Uses the legacy ESP-IDF I²C API.
-- **`lib/AstrOsDisplay`** — SSD1306 OLED rendering. Talks to hardware by pushing `queue_msg_t` entries into the `i2cQueue`.
-- **`lib/SoftwareSerial`, `lib/Uuid`, `lib/AstrOsUtility*`** — support libs.
-- **`components/ssd1306`, `components/mdns`** — ESP-IDF components (not PlatformIO libs). Kept here rather than as `idf_component.yml` dependencies.
+Each lib is classified **PURE** (no ESP-IDF/FreeRTOS/driver includes; compiles under `[env:test]`), **MIXED** (algorithmic logic plus ESP-IDF/FreeRTOS wiring), or **HARDWARE-ONLY** (driver code that can only build on-target).
+
+| Lib | Class | Summary |
+|---|---|---|
+| `lib/AstrOsMessaging` | PURE | Wire-format serializers/parsers for serial + ESP-NOW. |
+| `lib/AstrOsSerialProtocol` | PURE | Decodes validated UART messages into `DecodedCommand` / `DecodeReject` records. |
+| `lib/AstrOsUtility` | PURE | String, path (`AstrOsPathUtils`), servo, and file utilities. |
+| `lib/AstrOsLogging` | PURE | `AstrOsLogger` fn-ptr struct for optional diagnostics injection into PURE libs. |
+| `lib/AstrOsUtility_ESP` | MIXED | ESP-side helpers — `logError`, `makeEspLogger`. |
+| `lib/AstrOsSerialMsgHandler` | MIXED | Thin adapter: validates, calls `AstrOsSerialProtocol`, hands responses to the interface-response queue. |
+| `lib/AstrOsEspNow` | MIXED | ESP-NOW mesh: peer registration, polling (master → padawans), fragmentation (respects the 250 B ESP-NOW payload limit via a 20 B header + 180 B payload scheme), callbacks for send/recv. |
+| `lib/AnimationController` | MIXED | Loads scripts, computes the next command, pushes commands onto hardware queues. Uses a FreeRTOS mutex (`animationMutex`) around `scriptEvents`. |
+| `lib/AstrOsStorageManager` | MIXED | NVS for config + FAT/SD for scripts. Exposes `AstrOs_Storage` singleton. Peer configs, service config, controller fingerprint. |
+| `lib/Modules` | MIXED | Hardware abstractions: `SerialModule`, `I2cModule`, `GpioModule`, `MaestroModule`. Each owns a queue-consumer loop. |
+| `lib/AstrOsDisplay` | MIXED | SSD1306 OLED rendering. Pushes `queue_msg_t` entries into the `i2cQueue`. |
+| `lib/Pca9685` | HARDWARE-ONLY | PCA9685 servo driver on top of `I2cMaster`. Two boards at `0x40`/`0x41`. |
+| `lib/I2cMaster` | HARDWARE-ONLY | Serialises bus access with a FreeRTOS semaphore (1000 ms timeout). Legacy ESP-IDF I²C API. |
+| `lib/SoftwareSerial`, `lib/Uuid` | HARDWARE-ONLY | Support libs. |
+| `components/ssd1306`, `components/mdns` | — | ESP-IDF components (not PlatformIO libs). Kept here rather than as `idf_component.yml` dependencies. |
+
+### Adding a new extracted (PURE) lib
+
+When pulling pure logic out of a MIXED lib, follow this pattern (piloted on `AstrOsSerialProtocol`):
+
+1. **Create the lib directory** with `include/`, `src/`, and a `README` stating the purity rule and listing the forbidden include prefixes.
+2. **Register it with the CI purity guard** — append the path to the `PURE_LIBS` array in `.github/workflows/pr-validation.yml` (`native-purity` job).
+3. **Prefer rich return values over logger injection** — return a struct describing what happened (e.g., `{ commands, rejects }` or `{ valid, reason }`) and let the MIXED caller log at the boundary with `ESP_LOGW`/`ESP_LOGE`. Only reach for `lib/AstrOsLogging`'s `AstrOsLogger` struct when diagnostics truly must live next to the logic (tight loops, complex internal state).
+4. **Add native tests** under `test/test_native/` — the `[env:test]` target auto-discovers them.
 
 ### Runtime roles: master vs padawan
 

--- a/lib/AstrOsLogging/README
+++ b/lib/AstrOsLogging/README
@@ -1,0 +1,31 @@
+AstrOsLogging
+=============
+
+Logger abstraction used by PURE libs (those compiled under `[env:test]` with
+`platform = native`). This library MUST remain free of ESP-IDF and FreeRTOS
+includes. Specifically, do not include any of:
+
+    freertos/*, esp_*, driver/*, nvs_*, sdmmc_*, esp_vfs*, esp_now*, esp_wifi*
+
+The purity rule is enforced by the CI purity guard in
+`.github/workflows/pr-validation.yml`.
+
+Usage
+-----
+
+Pure libs that need to log diagnostics accept an optional `AstrOsLogger`
+struct of function pointers. A default-constructed `AstrOsLogger` has all
+null pointers, so `astros_log_*` calls become no-ops on the native host.
+
+On-target code wires the logger through the ESP adapter in
+`lib/AstrOsUtility_ESP/include/AstrOsLoggerEsp.h` (`makeEspLogger()`), which
+forwards each level to `esp_log_writev()`.
+
+Preferred error-channel pattern
+-------------------------------
+
+When a pure lib can surface an error as data, prefer a rich return value
+(e.g. `{ valid, reason, ... }`) over invoking the logger. Reserve the logger
+for lines that truly must live next to the logic (tight loops, complex
+internal state, troubleshooting-only messages). See `AstrOsSerialProtocol`
+for an example of the rich-return pattern.

--- a/lib/AstrOsLogging/include/AstrOsLogger.hpp
+++ b/lib/AstrOsLogging/include/AstrOsLogger.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstdarg>
+#include <cstddef>
+
+// AstrOsLogger
+// ------------
+// A plain struct of function pointers used by PURE libs to emit diagnostics
+// without pulling in ESP-IDF's logging headers. Default construction leaves
+// every pointer null, in which case the astros_log_* helpers below become
+// no-ops — this is the intended behaviour under [env:test].
+//
+// On-target code obtains a populated logger from
+// lib/AstrOsUtility_ESP/include/AstrOsLoggerEsp.h (makeEspLogger), which
+// wires each pointer to esp_log_writev() at the matching level.
+//
+// Signature matches esp_log_writev so the ESP adapter is a direct forward.
+struct AstrOsLogger
+{
+    using LogFn = void (*)(const char *tag, const char *fmt, va_list args);
+
+    LogFn trace = nullptr;
+    LogFn debug = nullptr;
+    LogFn info = nullptr;
+    LogFn warn = nullptr;
+    LogFn error = nullptr;
+};
+
+namespace astros_logging_detail
+{
+    inline void dispatch(AstrOsLogger::LogFn fn, const char *tag, const char *fmt, ...)
+    {
+        if (fn == nullptr)
+        {
+            return;
+        }
+        va_list args;
+        va_start(args, fmt);
+        fn(tag, fmt, args);
+        va_end(args);
+    }
+} // namespace astros_logging_detail
+
+// printf-style helpers. Safe to call with a default-constructed logger —
+// a null function pointer short-circuits the call.
+#define astros_log_trace(logger, tag, ...) ::astros_logging_detail::dispatch((logger).trace, (tag), __VA_ARGS__)
+#define astros_log_debug(logger, tag, ...) ::astros_logging_detail::dispatch((logger).debug, (tag), __VA_ARGS__)
+#define astros_log_info(logger, tag, ...) ::astros_logging_detail::dispatch((logger).info, (tag), __VA_ARGS__)
+#define astros_log_warn(logger, tag, ...) ::astros_logging_detail::dispatch((logger).warn, (tag), __VA_ARGS__)
+#define astros_log_error(logger, tag, ...) ::astros_logging_detail::dispatch((logger).error, (tag), __VA_ARGS__)

--- a/lib/AstrOsMessaging/src/AstrOsSerialMessageService.cpp
+++ b/lib/AstrOsMessaging/src/AstrOsSerialMessageService.cpp
@@ -43,7 +43,7 @@ AstrOsSerialMessageService::~AstrOsSerialMessageService() {}
 /// @return is valid
 astros_serial_msg_validation_t AstrOsSerialMessageService::validateSerialMsg(std::string msg)
 {
-    astros_serial_msg_validation_t result{"", AstrOsSerialMessageType::UNKNOWN, false};
+    astros_serial_msg_validation_t result{"", "", AstrOsSerialMessageType::UNKNOWN, false};
 
     auto msgParts = AstrOsStringUtils::splitString(msg, GROUP_SEPARATOR);
 
@@ -70,6 +70,7 @@ astros_serial_msg_validation_t AstrOsSerialMessageService::validateSerialMsg(std
 
     result.valid = true;
     result.msgId = parts[2];
+    result.payload = msgParts.size() > 1 ? msgParts[1] : "";
     result.type = type;
 
     return result;

--- a/lib/AstrOsMessaging/src/AstrOsSerialMessageService.hpp
+++ b/lib/AstrOsMessaging/src/AstrOsSerialMessageService.hpp
@@ -75,6 +75,9 @@ typedef struct
 typedef struct
 {
     std::string msgId;
+    // Payload group (everything after GROUP_SEPARATOR). Empty when the
+    // validated message carries no payload, e.g. REGISTRATION_SYNC.
+    std::string payload;
     AstrOsSerialMessageType type;
     bool valid;
 } astros_serial_msg_validation_t;

--- a/lib/AstrOsSerialMsgHandler/include/AstrOsSerialMsgHandler.hpp
+++ b/lib/AstrOsSerialMsgHandler/include/AstrOsSerialMsgHandler.hpp
@@ -18,13 +18,6 @@ private:
 
     AstrOsSerialMessageService msgService;
 
-    void handleRegistrationSync(std::string msgId);
-    void handleDeployConfig(std::string msgId, std::string message);
-    void handleDeployScript(std::string msgId, std::string message);
-
-    void handleBasicCommand(AstrOsSerialMessageType type, std::string msgId, std::string message);
-
-    AstrOsInterfaceResponseType getResponseType(AstrOsSerialMessageType type, bool isMaster);
     void sendToInterfaceQueue(AstrOsInterfaceResponseType responseType, std::string msgId, std::string peerMac,
                               std::string peerName, std::string message);
 

--- a/lib/AstrOsSerialMsgHandler/src/AstrOsSerialMsgHandler.cpp
+++ b/lib/AstrOsSerialMsgHandler/src/AstrOsSerialMsgHandler.cpp
@@ -53,7 +53,9 @@ void AstrOsSerialMsgHandler::handleMessage(std::string message)
 
     for (const auto &rej : decoded.rejects)
     {
-        ESP_LOGW(TAG, "Invalid %s: %s", AstrOsSerialProtocol::describeRejectReason(rej.reason), rej.entry.c_str());
+        ESP_LOGE(TAG, "Rejected controller record (%s) for message type %d: %s",
+                 AstrOsSerialProtocol::describeRejectReason(rej.reason), static_cast<int>(validation.type),
+                 rej.entry.c_str());
     }
 }
 

--- a/lib/AstrOsSerialMsgHandler/src/AstrOsSerialMsgHandler.cpp
+++ b/lib/AstrOsSerialMsgHandler/src/AstrOsSerialMsgHandler.cpp
@@ -44,8 +44,7 @@ void AstrOsSerialMsgHandler::handleMessage(std::string message)
     // The pure decoder owns all of the field splitting and
     // per-controller validation. Everything ESP-specific (queue handoff,
     // logging) stays here at the boundary.
-    auto decoded =
-        AstrOsSerialProtocol::decodeSerialMessage(validation.type, validation.msgId, message, /*isMaster*/ true);
+    auto decoded = AstrOsSerialProtocol::decodeSerialMessage(validation.type, validation.msgId, validation.payload);
 
     for (const auto &cmd : decoded.commands)
     {

--- a/lib/AstrOsSerialMsgHandler/src/AstrOsSerialMsgHandler.cpp
+++ b/lib/AstrOsSerialMsgHandler/src/AstrOsSerialMsgHandler.cpp
@@ -2,7 +2,7 @@
 #include <AstrOsInterfaceResponseMsg.hpp>
 #include <AstrOsMessaging.hpp>
 #include <AstrOsSerialMsgHandler.hpp>
-#include <AstrOsStringUtils.hpp>
+#include <AstrOsSerialProtocol.hpp>
 #include <AstrOsUtility.h>
 #include <esp_log.h>
 #include <string.h>
@@ -33,200 +33,28 @@ void AstrOsSerialMsgHandler::handleMessage(std::string message)
         return;
     }
 
-    switch (validation.type)
-    {
-    case AstrOsSerialMessageType::REGISTRATION_SYNC:
-    {
-        this->handleRegistrationSync(validation.msgId);
-        break;
-    }
-    case AstrOsSerialMessageType::DEPLOY_CONFIG:
-    {
-        this->handleDeployConfig(validation.msgId, message);
-        break;
-    }
-    case AstrOsSerialMessageType::DEPLOY_SCRIPT:
-    {
-        this->handleDeployScript(validation.msgId, message);
-        break;
-    }
-    case AstrOsSerialMessageType::RUN_SCRIPT:
-    case AstrOsSerialMessageType::PANIC_STOP:
-    case AstrOsSerialMessageType::FORMAT_SD:
-    case AstrOsSerialMessageType::RUN_COMMAND:
-    case AstrOsSerialMessageType::SERVO_TEST:
-    {
-        this->handleBasicCommand(validation.type, validation.msgId, message);
-        break;
-    }
-    default:
+    if (validation.type == AstrOsSerialMessageType::UNKNOWN)
     {
         ESP_LOGE(TAG, "Unknown/Invalid message type: %d", static_cast<int>(validation.type));
-        break;
+        return;
     }
-    }
-}
 
-void AstrOsSerialMsgHandler::handleRegistrationSync(std::string msgId)
-{
-    ESP_LOGD(TAG, "Received REGISTRATION_SYNC message");
+    ESP_LOGD(TAG, "Received serial message type: %d", static_cast<int>(validation.type));
 
-    this->sendToInterfaceQueue(AstrOsInterfaceResponseType::REGISTRATION_SYNC, msgId, "", "", "");
-}
+    // The pure decoder owns all of the field splitting and
+    // per-controller validation. Everything ESP-specific (queue handoff,
+    // logging) stays here at the boundary.
+    auto decoded =
+        AstrOsSerialProtocol::decodeSerialMessage(validation.type, validation.msgId, message, /*isMaster*/ true);
 
-void AstrOsSerialMsgHandler::handleDeployConfig(std::string msgId, std::string message)
-{
-    ESP_LOGD(TAG, "Received DEPLOY_CONFIG message");
-
-    auto parts = AstrOsStringUtils::splitString(message, GROUP_SEPARATOR);
-    auto controllers = AstrOsStringUtils::splitString(parts[1], RECORD_SEPARATOR);
-
-    for (auto controller : controllers)
+    for (const auto &cmd : decoded.commands)
     {
-        auto msgParts = AstrOsStringUtils::splitString(controller, UNIT_SEPARATOR);
-        if (msgParts.size() != 3)
-        {
-            ESP_LOGE(TAG, "Invalid config: %s", controller.c_str());
-            continue;
-        }
-
-        if (msgParts[0] == "00:00:00:00:00:00")
-        {
-            auto responseType = this->getResponseType(AstrOsSerialMessageType::DEPLOY_CONFIG, true);
-            this->sendToInterfaceQueue(responseType, msgId, "", "", msgParts[2]);
-        }
-        else
-        {
-            auto responseType = this->getResponseType(AstrOsSerialMessageType::DEPLOY_CONFIG, false);
-            this->sendToInterfaceQueue(responseType, msgId, msgParts[0], "", msgParts[2]);
-        }
+        this->sendToInterfaceQueue(cmd.responseType, cmd.msgId, cmd.peerMac, cmd.peerName, cmd.message);
     }
-}
 
-void AstrOsSerialMsgHandler::handleDeployScript(std::string msgId, std::string message)
-{
-    ESP_LOGD(TAG, "Received DEPLOY_SCRIPT message");
-
-    auto parts = AstrOsStringUtils::splitString(message, GROUP_SEPARATOR);
-    auto controllers = AstrOsStringUtils::splitString(parts[1], RECORD_SEPARATOR);
-
-    for (auto controller : controllers)
+    for (const auto &rej : decoded.rejects)
     {
-        auto msgParts = AstrOsStringUtils::splitString(controller, UNIT_SEPARATOR);
-        if (msgParts.size() != 4)
-        {
-            ESP_LOGE(TAG, "Invalid script: %s", controller.c_str());
-            continue;
-        }
-
-        auto script = msgParts[2] + UNIT_SEPARATOR + msgParts[3];
-
-        if (msgParts[0] == "00:00:00:00:00:00")
-        {
-            auto responseType = this->getResponseType(AstrOsSerialMessageType::DEPLOY_SCRIPT, true);
-            this->sendToInterfaceQueue(responseType, msgId, "", "", script);
-        }
-        else
-        {
-            auto responseType = this->getResponseType(AstrOsSerialMessageType::DEPLOY_SCRIPT, false);
-            this->sendToInterfaceQueue(responseType, msgId, msgParts[0], "", script);
-        }
-    }
-}
-
-/// @brief Handles basic serial commands. Basic serial commands are commands that have a
-///        simple stucture of Address|Controller|Command and and don't require command formatting.
-/// @param msgId
-/// @param message
-void AstrOsSerialMsgHandler::handleBasicCommand(AstrOsSerialMessageType type, std::string msgId, std::string message)
-{
-    ESP_LOGD(TAG, "Received message type: %d", static_cast<int>(type));
-
-    auto parts = AstrOsStringUtils::splitString(message, GROUP_SEPARATOR);
-    auto controllers = AstrOsStringUtils::splitString(parts[1], RECORD_SEPARATOR);
-
-    for (auto controller : controllers)
-    {
-        auto msgParts = AstrOsStringUtils::splitString(controller, UNIT_SEPARATOR);
-
-        if (msgParts.size() != 3)
-        {
-            ESP_LOGE(TAG, "Invalid command: %s", controller.c_str());
-            continue;
-        }
-
-        if (msgParts[0].empty())
-        {
-            ESP_LOGW(TAG, "Empty command destination: %s", controller.c_str());
-            continue;
-        }
-
-        if (msgParts[2].empty())
-        {
-            ESP_LOGW(TAG, "Empty command value: %s", controller.c_str());
-            continue;
-        }
-
-        if (msgParts[0] == "00:00:00:00:00:00")
-        {
-            auto responseType = this->getResponseType(type, true);
-            this->sendToInterfaceQueue(responseType, msgId, "", "", msgParts[2]);
-        }
-        else
-        {
-            auto responseType = this->getResponseType(type, false);
-            this->sendToInterfaceQueue(responseType, msgId, msgParts[0], "", msgParts[2]);
-        }
-    }
-}
-
-AstrOsInterfaceResponseType AstrOsSerialMsgHandler::getResponseType(AstrOsSerialMessageType type, bool isMaster)
-{
-    if (isMaster)
-    {
-        switch (type)
-        {
-        case AstrOsSerialMessageType::REGISTRATION_SYNC:
-            return AstrOsInterfaceResponseType::REGISTRATION_SYNC;
-        case AstrOsSerialMessageType::DEPLOY_CONFIG:
-            return AstrOsInterfaceResponseType::SET_CONFIG;
-        case AstrOsSerialMessageType::DEPLOY_SCRIPT:
-            return AstrOsInterfaceResponseType::SAVE_SCRIPT;
-        case AstrOsSerialMessageType::RUN_SCRIPT:
-            return AstrOsInterfaceResponseType::SCRIPT_RUN;
-        case AstrOsSerialMessageType::PANIC_STOP:
-            return AstrOsInterfaceResponseType::PANIC_STOP;
-        case AstrOsSerialMessageType::FORMAT_SD:
-            return AstrOsInterfaceResponseType::FORMAT_SD;
-        case AstrOsSerialMessageType::RUN_COMMAND:
-            return AstrOsInterfaceResponseType::COMMAND;
-        case AstrOsSerialMessageType::SERVO_TEST:
-            return AstrOsInterfaceResponseType::SERVO_TEST;
-        default:
-            return AstrOsInterfaceResponseType::UNKNOWN;
-        }
-    }
-    else
-    {
-        switch (type)
-        {
-        case AstrOsSerialMessageType::DEPLOY_CONFIG:
-            return AstrOsInterfaceResponseType::SEND_CONFIG;
-        case AstrOsSerialMessageType::DEPLOY_SCRIPT:
-            return AstrOsInterfaceResponseType::SEND_SCRIPT;
-        case AstrOsSerialMessageType::RUN_SCRIPT:
-            return AstrOsInterfaceResponseType::SEND_SCRIPT_RUN;
-        case AstrOsSerialMessageType::PANIC_STOP:
-            return AstrOsInterfaceResponseType::SEND_PANIC_STOP;
-        case AstrOsSerialMessageType::FORMAT_SD:
-            return AstrOsInterfaceResponseType::SEND_FORMAT_SD;
-        case AstrOsSerialMessageType::RUN_COMMAND:
-            return AstrOsInterfaceResponseType::SEND_COMMAND;
-        case AstrOsSerialMessageType::SERVO_TEST:
-            return AstrOsInterfaceResponseType::SEND_SERVO_TEST;
-        default:
-            return AstrOsInterfaceResponseType::UNKNOWN;
-        }
+        ESP_LOGW(TAG, "Invalid %s: %s", AstrOsSerialProtocol::describeRejectReason(rej.reason), rej.entry.c_str());
     }
 }
 

--- a/lib/AstrOsSerialProtocol/README
+++ b/lib/AstrOsSerialProtocol/README
@@ -1,0 +1,26 @@
+AstrOsSerialProtocol
+====================
+
+Pure, native-testable decoder for the serial protocol spoken between the
+master node and the AstrOs web interface. Accepts the validated message
+fields (type, msgId, payload) and produces a DecodeResult containing
+zero-or-more DecodedCommand entries plus any DecodeReject records for
+malformed controller sub-strings.
+
+Purity rule
+-----------
+
+This library is unit-tested on the native host under [env:test], so it
+must not include any of:
+
+    freertos/*, esp_*, driver/*, nvs_*, sdmmc_*, esp_vfs*, esp_now*, esp_wifi*
+
+Enforced by the CI purity guard in .github/workflows/pr-validation.yml.
+
+Error-channel convention
+------------------------
+
+Skipped controller sub-strings are reported via DecodeResult::rejects
+rather than a logger. The ESP-side caller (AstrOsSerialMsgHandler)
+re-emits each reject as ESP_LOGW at the boundary. No logger injection
+is required here.

--- a/lib/AstrOsSerialProtocol/README
+++ b/lib/AstrOsSerialProtocol/README
@@ -2,10 +2,11 @@ AstrOsSerialProtocol
 ====================
 
 Pure, native-testable decoder for the serial protocol spoken between the
-master node and the AstrOs web interface. Accepts the validated message
-fields (type, msgId, payload) and produces a DecodeResult containing
-zero-or-more DecodedCommand entries plus any DecodeReject records for
-malformed controller sub-strings.
+master node and the AstrOs web interface. Takes the three fields populated
+by AstrOsSerialMessageService::validateSerialMsg — `type`, `msgId`, and the
+payload group (everything after GROUP_SEPARATOR) — and produces a
+DecodeResult containing zero-or-more DecodedCommand entries plus any
+DecodeReject records for malformed controller sub-strings.
 
 Purity rule
 -----------

--- a/lib/AstrOsSerialProtocol/include/AstrOsSerialProtocol.hpp
+++ b/lib/AstrOsSerialProtocol/include/AstrOsSerialProtocol.hpp
@@ -14,6 +14,7 @@ namespace AstrOsSerialProtocol
         EMPTY_DEST,
         EMPTY_VALUE,
         UNKNOWN_TYPE,
+        EMPTY_PAYLOAD,
     };
 
     struct DecodedCommand
@@ -37,16 +38,17 @@ namespace AstrOsSerialProtocol
         std::vector<DecodeReject> rejects;
     };
 
-    // Decodes an already-validated serial message payload. `type` and
-    // `msgId` come from AstrOsSerialMessageService::validateSerialMsg;
-    // `message` is the full raw message (the decoder re-splits on
-    // GROUP_SEPARATOR internally). `isMaster` routes each command through
-    // the master-side or padawan-side response-type table.
+    // Decodes an already-validated serial message. All three inputs —
+    // `type`, `msgId`, and `payload` — come from the fields populated by
+    // AstrOsSerialMessageService::validateSerialMsg. `payload` is the
+    // group after GROUP_SEPARATOR (the RECORD_SEPARATOR-joined controller
+    // records) and is empty for messages that carry no payload, e.g.
+    // REGISTRATION_SYNC.
     //
     // Pure: no I/O, no allocations outside the returned vectors, no
     // FreeRTOS/ESP dependencies.
-    DecodeResult decodeSerialMessage(AstrOsSerialMessageType type, const std::string &msgId, const std::string &message,
-                                     bool isMaster);
+    DecodeResult decodeSerialMessage(AstrOsSerialMessageType type, const std::string &msgId,
+                                     const std::string &payload);
 
     // Master-vs-padawan response-type lookup. Returns UNKNOWN for any
     // (type, isMaster) combination the handler does not forward — this

--- a/lib/AstrOsSerialProtocol/include/AstrOsSerialProtocol.hpp
+++ b/lib/AstrOsSerialProtocol/include/AstrOsSerialProtocol.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <AstrOsInterfaceResponseMsg.hpp>
+#include <AstrOsSerialMessageService.hpp>
+
+namespace AstrOsSerialProtocol
+{
+    enum class DecodeRejectReason
+    {
+        WRONG_PART_COUNT,
+        EMPTY_DEST,
+        EMPTY_VALUE,
+        UNKNOWN_TYPE,
+    };
+
+    struct DecodedCommand
+    {
+        AstrOsInterfaceResponseType responseType = AstrOsInterfaceResponseType::UNKNOWN;
+        std::string msgId;
+        std::string peerMac;  // empty string = broadcast
+        std::string peerName; // always empty today; kept for future peer-name routing
+        std::string message;
+    };
+
+    struct DecodeReject
+    {
+        std::string entry;
+        DecodeRejectReason reason = DecodeRejectReason::WRONG_PART_COUNT;
+    };
+
+    struct DecodeResult
+    {
+        std::vector<DecodedCommand> commands;
+        std::vector<DecodeReject> rejects;
+    };
+
+    // Decodes an already-validated serial message payload. `type` and
+    // `msgId` come from AstrOsSerialMessageService::validateSerialMsg;
+    // `message` is the full raw message (the decoder re-splits on
+    // GROUP_SEPARATOR internally). `isMaster` routes each command through
+    // the master-side or padawan-side response-type table.
+    //
+    // Pure: no I/O, no allocations outside the returned vectors, no
+    // FreeRTOS/ESP dependencies.
+    DecodeResult decodeSerialMessage(AstrOsSerialMessageType type, const std::string &msgId, const std::string &message,
+                                     bool isMaster);
+
+    // Master-vs-padawan response-type lookup. Returns UNKNOWN for any
+    // (type, isMaster) combination the handler does not forward — this
+    // matches the previous private getResponseType() behaviour exactly.
+    AstrOsInterfaceResponseType mapResponseType(AstrOsSerialMessageType type, bool isMaster);
+
+    // Human-readable label for a reject reason, suitable for use as a
+    // format argument (e.g. ESP_LOGW(TAG, "Invalid %s: %s", ...)). Strings
+    // are process-lifetime; callers must not free them.
+    const char *describeRejectReason(DecodeRejectReason reason);
+} // namespace AstrOsSerialProtocol

--- a/lib/AstrOsSerialProtocol/src/AstrOsSerialProtocol.cpp
+++ b/lib/AstrOsSerialProtocol/src/AstrOsSerialProtocol.cpp
@@ -8,18 +8,16 @@ namespace AstrOsSerialProtocol
     {
         constexpr const char *kBroadcastMac = "00:00:00:00:00:00";
 
-        // Pulls the payload group out of a validated serial message. The
-        // wire format is `header GS payload`; `validateSerialMsg` has
-        // already confirmed the header is well-formed, so parts[1] is the
-        // payload group.
-        std::vector<std::string> extractControllers(const std::string &message)
+        // Splits the validated payload group on RECORD_SEPARATOR to
+        // produce one entry per controller record. The payload has
+        // already been separated from the header by validateSerialMsg.
+        std::vector<std::string> extractControllers(const std::string &payload)
         {
-            auto parts = AstrOsStringUtils::splitString(message, GROUP_SEPARATOR);
-            if (parts.size() < 2)
+            if (payload.empty())
             {
                 return {};
             }
-            return AstrOsStringUtils::splitString(parts[1], RECORD_SEPARATOR);
+            return AstrOsStringUtils::splitString(payload, RECORD_SEPARATOR);
         }
 
         void appendCommand(DecodeResult &result, AstrOsInterfaceResponseType responseType, const std::string &msgId,
@@ -51,9 +49,9 @@ namespace AstrOsSerialProtocol
             appendCommand(result, AstrOsInterfaceResponseType::REGISTRATION_SYNC, msgId, "", "", "");
         }
 
-        void decodeDeployConfig(DecodeResult &result, const std::string &msgId, const std::string &message)
+        void decodeDeployConfig(DecodeResult &result, const std::string &msgId, const std::string &payload)
         {
-            for (const auto &controller : extractControllers(message))
+            for (const auto &controller : extractControllers(payload))
             {
                 auto msgParts = AstrOsStringUtils::splitString(controller, UNIT_SEPARATOR);
                 if (msgParts.size() != 3)
@@ -69,9 +67,9 @@ namespace AstrOsSerialProtocol
             }
         }
 
-        void decodeDeployScript(DecodeResult &result, const std::string &msgId, const std::string &message)
+        void decodeDeployScript(DecodeResult &result, const std::string &msgId, const std::string &payload)
         {
-            for (const auto &controller : extractControllers(message))
+            for (const auto &controller : extractControllers(payload))
             {
                 auto msgParts = AstrOsStringUtils::splitString(controller, UNIT_SEPARATOR);
                 if (msgParts.size() != 4)
@@ -89,9 +87,9 @@ namespace AstrOsSerialProtocol
         }
 
         void decodeBasicCommand(DecodeResult &result, AstrOsSerialMessageType type, const std::string &msgId,
-                                const std::string &message)
+                                const std::string &payload)
         {
-            for (const auto &controller : extractControllers(message))
+            for (const auto &controller : extractControllers(payload))
             {
                 auto msgParts = AstrOsStringUtils::splitString(controller, UNIT_SEPARATOR);
 
@@ -167,12 +165,20 @@ namespace AstrOsSerialProtocol
         }
     }
 
-    DecodeResult decodeSerialMessage(AstrOsSerialMessageType type, const std::string &msgId, const std::string &message,
-                                     bool isMaster)
+    DecodeResult decodeSerialMessage(AstrOsSerialMessageType type, const std::string &msgId, const std::string &payload)
     {
-        (void)isMaster; // retained for future per-role branching; DEPLOY_* and
-                        // basic commands infer role from the per-controller mac.
         DecodeResult result;
+
+        // Every type except REGISTRATION_SYNC expects a non-empty payload
+        // group. Without one, the per-controller decoders would silently
+        // produce zero commands and zero rejects — surfacing a reject here
+        // keeps the boundary caller informed.
+        if (payload.empty() && type != AstrOsSerialMessageType::REGISTRATION_SYNC &&
+            type != AstrOsSerialMessageType::UNKNOWN)
+        {
+            appendReject(result, "", DecodeRejectReason::EMPTY_PAYLOAD);
+            return result;
+        }
 
         switch (type)
         {
@@ -180,20 +186,20 @@ namespace AstrOsSerialProtocol
             decodeRegistrationSync(result, msgId);
             break;
         case AstrOsSerialMessageType::DEPLOY_CONFIG:
-            decodeDeployConfig(result, msgId, message);
+            decodeDeployConfig(result, msgId, payload);
             break;
         case AstrOsSerialMessageType::DEPLOY_SCRIPT:
-            decodeDeployScript(result, msgId, message);
+            decodeDeployScript(result, msgId, payload);
             break;
         case AstrOsSerialMessageType::RUN_SCRIPT:
         case AstrOsSerialMessageType::PANIC_STOP:
         case AstrOsSerialMessageType::FORMAT_SD:
         case AstrOsSerialMessageType::RUN_COMMAND:
         case AstrOsSerialMessageType::SERVO_TEST:
-            decodeBasicCommand(result, type, msgId, message);
+            decodeBasicCommand(result, type, msgId, payload);
             break;
         default:
-            appendReject(result, message, DecodeRejectReason::UNKNOWN_TYPE);
+            appendReject(result, payload, DecodeRejectReason::UNKNOWN_TYPE);
             break;
         }
 
@@ -212,6 +218,8 @@ namespace AstrOsSerialProtocol
             return "empty value";
         case DecodeRejectReason::UNKNOWN_TYPE:
             return "unknown message type";
+        case DecodeRejectReason::EMPTY_PAYLOAD:
+            return "empty payload";
         }
         return "unknown";
     }

--- a/lib/AstrOsSerialProtocol/src/AstrOsSerialProtocol.cpp
+++ b/lib/AstrOsSerialProtocol/src/AstrOsSerialProtocol.cpp
@@ -1,0 +1,218 @@
+#include "AstrOsSerialProtocol.hpp"
+
+#include <AstrOsStringUtils.hpp>
+
+namespace AstrOsSerialProtocol
+{
+    namespace
+    {
+        constexpr const char *kBroadcastMac = "00:00:00:00:00:00";
+
+        // Pulls the payload group out of a validated serial message. The
+        // wire format is `header GS payload`; `validateSerialMsg` has
+        // already confirmed the header is well-formed, so parts[1] is the
+        // payload group.
+        std::vector<std::string> extractControllers(const std::string &message)
+        {
+            auto parts = AstrOsStringUtils::splitString(message, GROUP_SEPARATOR);
+            if (parts.size() < 2)
+            {
+                return {};
+            }
+            return AstrOsStringUtils::splitString(parts[1], RECORD_SEPARATOR);
+        }
+
+        void appendCommand(DecodeResult &result, AstrOsInterfaceResponseType responseType, const std::string &msgId,
+                           const std::string &peerMac, const std::string &peerName, const std::string &message)
+        {
+            DecodedCommand cmd;
+            cmd.responseType = responseType;
+            cmd.msgId = msgId;
+            cmd.peerMac = peerMac;
+            cmd.peerName = peerName;
+            cmd.message = message;
+            result.commands.push_back(std::move(cmd));
+        }
+
+        void appendReject(DecodeResult &result, const std::string &entry, DecodeRejectReason reason)
+        {
+            DecodeReject rej;
+            rej.entry = entry;
+            rej.reason = reason;
+            result.rejects.push_back(std::move(rej));
+        }
+
+        void decodeRegistrationSync(DecodeResult &result, const std::string &msgId)
+        {
+            // Historical quirk: handleRegistrationSync hardcoded
+            // REGISTRATION_SYNC for both roles, bypassing mapResponseType
+            // (which returns UNKNOWN for REG_SYNC on a padawan). Preserve
+            // that bypass here so on-wire behaviour is bit-identical.
+            appendCommand(result, AstrOsInterfaceResponseType::REGISTRATION_SYNC, msgId, "", "", "");
+        }
+
+        void decodeDeployConfig(DecodeResult &result, const std::string &msgId, const std::string &message)
+        {
+            for (const auto &controller : extractControllers(message))
+            {
+                auto msgParts = AstrOsStringUtils::splitString(controller, UNIT_SEPARATOR);
+                if (msgParts.size() != 3)
+                {
+                    appendReject(result, controller, DecodeRejectReason::WRONG_PART_COUNT);
+                    continue;
+                }
+
+                const bool broadcast = (msgParts[0] == kBroadcastMac);
+                const auto responseType = mapResponseType(AstrOsSerialMessageType::DEPLOY_CONFIG, broadcast);
+                const std::string peerMac = broadcast ? "" : msgParts[0];
+                appendCommand(result, responseType, msgId, peerMac, "", msgParts[2]);
+            }
+        }
+
+        void decodeDeployScript(DecodeResult &result, const std::string &msgId, const std::string &message)
+        {
+            for (const auto &controller : extractControllers(message))
+            {
+                auto msgParts = AstrOsStringUtils::splitString(controller, UNIT_SEPARATOR);
+                if (msgParts.size() != 4)
+                {
+                    appendReject(result, controller, DecodeRejectReason::WRONG_PART_COUNT);
+                    continue;
+                }
+
+                const std::string script = msgParts[2] + UNIT_SEPARATOR + msgParts[3];
+                const bool broadcast = (msgParts[0] == kBroadcastMac);
+                const auto responseType = mapResponseType(AstrOsSerialMessageType::DEPLOY_SCRIPT, broadcast);
+                const std::string peerMac = broadcast ? "" : msgParts[0];
+                appendCommand(result, responseType, msgId, peerMac, "", script);
+            }
+        }
+
+        void decodeBasicCommand(DecodeResult &result, AstrOsSerialMessageType type, const std::string &msgId,
+                                const std::string &message)
+        {
+            for (const auto &controller : extractControllers(message))
+            {
+                auto msgParts = AstrOsStringUtils::splitString(controller, UNIT_SEPARATOR);
+
+                if (msgParts.size() != 3)
+                {
+                    appendReject(result, controller, DecodeRejectReason::WRONG_PART_COUNT);
+                    continue;
+                }
+                if (msgParts[0].empty())
+                {
+                    appendReject(result, controller, DecodeRejectReason::EMPTY_DEST);
+                    continue;
+                }
+                if (msgParts[2].empty())
+                {
+                    appendReject(result, controller, DecodeRejectReason::EMPTY_VALUE);
+                    continue;
+                }
+
+                const bool broadcast = (msgParts[0] == kBroadcastMac);
+                const auto responseType = mapResponseType(type, broadcast);
+                const std::string peerMac = broadcast ? "" : msgParts[0];
+                appendCommand(result, responseType, msgId, peerMac, "", msgParts[2]);
+            }
+        }
+    } // namespace
+
+    AstrOsInterfaceResponseType mapResponseType(AstrOsSerialMessageType type, bool isMaster)
+    {
+        if (isMaster)
+        {
+            switch (type)
+            {
+            case AstrOsSerialMessageType::REGISTRATION_SYNC:
+                return AstrOsInterfaceResponseType::REGISTRATION_SYNC;
+            case AstrOsSerialMessageType::DEPLOY_CONFIG:
+                return AstrOsInterfaceResponseType::SET_CONFIG;
+            case AstrOsSerialMessageType::DEPLOY_SCRIPT:
+                return AstrOsInterfaceResponseType::SAVE_SCRIPT;
+            case AstrOsSerialMessageType::RUN_SCRIPT:
+                return AstrOsInterfaceResponseType::SCRIPT_RUN;
+            case AstrOsSerialMessageType::PANIC_STOP:
+                return AstrOsInterfaceResponseType::PANIC_STOP;
+            case AstrOsSerialMessageType::FORMAT_SD:
+                return AstrOsInterfaceResponseType::FORMAT_SD;
+            case AstrOsSerialMessageType::RUN_COMMAND:
+                return AstrOsInterfaceResponseType::COMMAND;
+            case AstrOsSerialMessageType::SERVO_TEST:
+                return AstrOsInterfaceResponseType::SERVO_TEST;
+            default:
+                return AstrOsInterfaceResponseType::UNKNOWN;
+            }
+        }
+
+        switch (type)
+        {
+        case AstrOsSerialMessageType::DEPLOY_CONFIG:
+            return AstrOsInterfaceResponseType::SEND_CONFIG;
+        case AstrOsSerialMessageType::DEPLOY_SCRIPT:
+            return AstrOsInterfaceResponseType::SEND_SCRIPT;
+        case AstrOsSerialMessageType::RUN_SCRIPT:
+            return AstrOsInterfaceResponseType::SEND_SCRIPT_RUN;
+        case AstrOsSerialMessageType::PANIC_STOP:
+            return AstrOsInterfaceResponseType::SEND_PANIC_STOP;
+        case AstrOsSerialMessageType::FORMAT_SD:
+            return AstrOsInterfaceResponseType::SEND_FORMAT_SD;
+        case AstrOsSerialMessageType::RUN_COMMAND:
+            return AstrOsInterfaceResponseType::SEND_COMMAND;
+        case AstrOsSerialMessageType::SERVO_TEST:
+            return AstrOsInterfaceResponseType::SEND_SERVO_TEST;
+        default:
+            return AstrOsInterfaceResponseType::UNKNOWN;
+        }
+    }
+
+    DecodeResult decodeSerialMessage(AstrOsSerialMessageType type, const std::string &msgId, const std::string &message,
+                                     bool isMaster)
+    {
+        (void)isMaster; // retained for future per-role branching; DEPLOY_* and
+                        // basic commands infer role from the per-controller mac.
+        DecodeResult result;
+
+        switch (type)
+        {
+        case AstrOsSerialMessageType::REGISTRATION_SYNC:
+            decodeRegistrationSync(result, msgId);
+            break;
+        case AstrOsSerialMessageType::DEPLOY_CONFIG:
+            decodeDeployConfig(result, msgId, message);
+            break;
+        case AstrOsSerialMessageType::DEPLOY_SCRIPT:
+            decodeDeployScript(result, msgId, message);
+            break;
+        case AstrOsSerialMessageType::RUN_SCRIPT:
+        case AstrOsSerialMessageType::PANIC_STOP:
+        case AstrOsSerialMessageType::FORMAT_SD:
+        case AstrOsSerialMessageType::RUN_COMMAND:
+        case AstrOsSerialMessageType::SERVO_TEST:
+            decodeBasicCommand(result, type, msgId, message);
+            break;
+        default:
+            appendReject(result, message, DecodeRejectReason::UNKNOWN_TYPE);
+            break;
+        }
+
+        return result;
+    }
+
+    const char *describeRejectReason(DecodeRejectReason reason)
+    {
+        switch (reason)
+        {
+        case DecodeRejectReason::WRONG_PART_COUNT:
+            return "wrong part count";
+        case DecodeRejectReason::EMPTY_DEST:
+            return "empty destination";
+        case DecodeRejectReason::EMPTY_VALUE:
+            return "empty value";
+        case DecodeRejectReason::UNKNOWN_TYPE:
+            return "unknown message type";
+        }
+        return "unknown";
+    }
+} // namespace AstrOsSerialProtocol

--- a/lib/AstrOsStorageManager/include/AstrOsStorageManager.hpp
+++ b/lib/AstrOsStorageManager/include/AstrOsStorageManager.hpp
@@ -16,7 +16,6 @@ private:
     bool saveGpioConfig(std::string config);
     esp_err_t mountSdCard();
     std::string setFilePath(std::string filename);
-    static bool isPathSafe(const std::string &path);
     bool saveFileSd(std::string filename, std::string data);
     bool deleteFileSd(std::string filename);
     bool fileExistsSd(std::string filename);

--- a/lib/AstrOsStorageManager/src/AstOsStorageManager.cpp
+++ b/lib/AstrOsStorageManager/src/AstOsStorageManager.cpp
@@ -1,4 +1,5 @@
 #include <AstrOsEspNowUtility.h>
+#include <AstrOsPathUtils.hpp>
 #include <AstrOsStorageManager.hpp>
 #include <AstrOsUtility.h>
 #include <AstrOsUtility_ESP.h>
@@ -48,39 +49,22 @@ static sdmmc_card_t *card;
 
 AstrOsStorageManager AstrOs_Storage;
 
-bool AstrOsStorageManager::isPathSafe(const std::string &path)
+namespace
 {
-    if (path.empty())
+    // Boundary helper: delegates to the pure check and emits the
+    // QA-documented ESP_LOGW line when the path is rejected. Keeps log
+    // output bit-compatible with the pre-extraction implementation.
+    bool isPathSafeAndLog(const std::string &path)
     {
-        ESP_LOGW(TAG, "isPathSafe: empty path rejected");
-        return false;
+        std::string reason;
+        if (!AstrOsPathUtils::isPathSafe(path, reason))
+        {
+            ESP_LOGW(TAG, "isPathSafe: %s", reason.c_str());
+            return false;
+        }
+        return true;
     }
-    if (path[0] == '/')
-    {
-        ESP_LOGW(TAG, "isPathSafe: absolute path rejected: %s", path.c_str());
-        return false;
-    }
-    // Conservative: rejects any path containing ".." as a substring, not just
-    // at component boundaries. False positives are benign given current naming
-    // conventions.
-    if (path.find("..") != std::string::npos)
-    {
-        ESP_LOGW(TAG, "isPathSafe: traversal component rejected: %s", path.c_str());
-        return false;
-    }
-    if (path.find("//") != std::string::npos)
-    {
-        ESP_LOGW(TAG, "isPathSafe: double-slash rejected: %s", path.c_str());
-        return false;
-    }
-    constexpr size_t MAX_PATH_LEN = 128;
-    if (path.size() > MAX_PATH_LEN)
-    {
-        ESP_LOGW(TAG, "isPathSafe: path too long (%zu > %zu): %.40s...", path.size(), MAX_PATH_LEN, path.c_str());
-        return false;
-    }
-    return true;
-}
+} // namespace
 
 AstrOsStorageManager::AstrOsStorageManager() {}
 AstrOsStorageManager::~AstrOsStorageManager()
@@ -444,7 +428,7 @@ int AstrOsStorageManager::loadEspNowPeerConfigs(espnow_peer_t *config)
 
 bool AstrOsStorageManager::saveFile(std::string filename, std::string data)
 {
-    if (!isPathSafe(filename))
+    if (!isPathSafeAndLog(filename))
     {
         return false;
     }
@@ -457,7 +441,7 @@ bool AstrOsStorageManager::saveFile(std::string filename, std::string data)
 
 bool AstrOsStorageManager::deleteFile(std::string filename)
 {
-    if (!isPathSafe(filename))
+    if (!isPathSafeAndLog(filename))
     {
         return false;
     }
@@ -470,7 +454,7 @@ bool AstrOsStorageManager::deleteFile(std::string filename)
 
 std::string AstrOsStorageManager::readFile(std::string filename)
 {
-    if (!isPathSafe(filename))
+    if (!isPathSafeAndLog(filename))
     {
         return "error";
     }
@@ -483,7 +467,7 @@ std::string AstrOsStorageManager::readFile(std::string filename)
 
 bool AstrOsStorageManager::fileExists(std::string filename)
 {
-    if (!isPathSafe(filename))
+    if (!isPathSafeAndLog(filename))
     {
         return false;
     }
@@ -496,7 +480,7 @@ bool AstrOsStorageManager::fileExists(std::string filename)
 
 std::vector<std::string> AstrOsStorageManager::listFiles(std::string folder)
 {
-    if (!isPathSafe(folder))
+    if (!isPathSafeAndLog(folder))
     {
         return {};
     }

--- a/lib/AstrOsUtility/include/AstrOsPathUtils.hpp
+++ b/lib/AstrOsUtility/include/AstrOsPathUtils.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+namespace AstrOsPathUtils
+{
+    // Maximum characters allowed in a user-supplied relative path. Matches
+    // the previous inline constant inside AstrOsStorageManager::isPathSafe
+    // so the QA-documented reject behaviour does not shift with this
+    // extraction.
+    constexpr std::size_t MAX_PATH_LEN = 128;
+
+    // Returns true when `path` is safe to join against the storage mount
+    // point. Rejects empty paths, absolute paths, any substring `..` or
+    // `//`, and paths longer than MAX_PATH_LEN bytes.
+    //
+    // On rejection, writes a human-readable reason into `reasonOut`
+    // formatted the way `AstrOsStorageManager` used to emit it inline,
+    // e.g. "absolute path rejected: /foo" or "path too long (180 > 128):
+    // <first-40-chars>...". Callers are expected to log it at
+    // ESP_LOGW level at the boundary.
+    //
+    // On success `reasonOut` is cleared.
+    bool isPathSafe(const std::string &path, std::string &reasonOut);
+} // namespace AstrOsPathUtils

--- a/lib/AstrOsUtility/src/AstrOsPathUtils.cpp
+++ b/lib/AstrOsUtility/src/AstrOsPathUtils.cpp
@@ -1,0 +1,43 @@
+#include "AstrOsPathUtils.hpp"
+
+#include <string>
+
+namespace AstrOsPathUtils
+{
+    bool isPathSafe(const std::string &path, std::string &reasonOut)
+    {
+        reasonOut.clear();
+
+        if (path.empty())
+        {
+            reasonOut = "empty path rejected";
+            return false;
+        }
+        if (path[0] == '/')
+        {
+            reasonOut = "absolute path rejected: " + path;
+            return false;
+        }
+        // Conservative: rejects any path containing ".." as a substring, not
+        // just at component boundaries. False positives are benign given
+        // current naming conventions.
+        if (path.find("..") != std::string::npos)
+        {
+            reasonOut = "traversal component rejected: " + path;
+            return false;
+        }
+        if (path.find("//") != std::string::npos)
+        {
+            reasonOut = "double-slash rejected: " + path;
+            return false;
+        }
+        if (path.size() > MAX_PATH_LEN)
+        {
+            std::string truncated = path.substr(0, 40);
+            reasonOut = "path too long (" + std::to_string(path.size()) + " > " + std::to_string(MAX_PATH_LEN) +
+                        "): " + truncated + "...";
+            return false;
+        }
+        return true;
+    }
+} // namespace AstrOsPathUtils

--- a/lib/AstrOsUtility_ESP/include/AstrOsLoggerEsp.h
+++ b/lib/AstrOsUtility_ESP/include/AstrOsLoggerEsp.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#ifdef __cplusplus
+
+#include <AstrOsLogger.hpp>
+
+// Returns an AstrOsLogger whose function pointers forward each level to
+// esp_log_writev(), so PURE libs that accept a logger can emit diagnostics
+// through the normal ESP-IDF logging pipeline when running on-target.
+//
+// On the native host this header is not included; pure libs receive a
+// default-constructed AstrOsLogger whose pointers are null, turning every
+// log call into a no-op.
+AstrOsLogger makeEspLogger();
+
+#endif

--- a/lib/AstrOsUtility_ESP/src/AstrOsLoggerEsp.cpp
+++ b/lib/AstrOsUtility_ESP/src/AstrOsLoggerEsp.cpp
@@ -1,0 +1,42 @@
+#include "AstrOsLoggerEsp.h"
+
+#include <esp_log.h>
+
+namespace
+{
+    void espLogVerbose(const char *tag, const char *fmt, va_list args)
+    {
+        esp_log_writev(ESP_LOG_VERBOSE, tag, fmt, args);
+    }
+
+    void espLogDebug(const char *tag, const char *fmt, va_list args)
+    {
+        esp_log_writev(ESP_LOG_DEBUG, tag, fmt, args);
+    }
+
+    void espLogInfo(const char *tag, const char *fmt, va_list args)
+    {
+        esp_log_writev(ESP_LOG_INFO, tag, fmt, args);
+    }
+
+    void espLogWarn(const char *tag, const char *fmt, va_list args)
+    {
+        esp_log_writev(ESP_LOG_WARN, tag, fmt, args);
+    }
+
+    void espLogError(const char *tag, const char *fmt, va_list args)
+    {
+        esp_log_writev(ESP_LOG_ERROR, tag, fmt, args);
+    }
+} // namespace
+
+AstrOsLogger makeEspLogger()
+{
+    AstrOsLogger logger;
+    logger.trace = &espLogVerbose;
+    logger.debug = &espLogDebug;
+    logger.info = &espLogInfo;
+    logger.warn = &espLogWarn;
+    logger.error = &espLogError;
+    return logger;
+}

--- a/test/test_native/astros_path_utils_tests.cpp
+++ b/test/test_native/astros_path_utils_tests.cpp
@@ -1,0 +1,87 @@
+#include <AstrOsPathUtils.hpp>
+#include <gtest/gtest.h>
+
+#include <string>
+
+using AstrOsPathUtils::isPathSafe;
+using AstrOsPathUtils::MAX_PATH_LEN;
+
+TEST(PathUtils, AcceptsSimpleRelativePath)
+{
+    std::string reason = "preexisting";
+    EXPECT_TRUE(isPathSafe("scripts/foo.scr", reason));
+    EXPECT_TRUE(reason.empty());
+}
+
+TEST(PathUtils, AcceptsNestedRelativePath)
+{
+    std::string reason;
+    EXPECT_TRUE(isPathSafe("scripts/sub/dir/payload.cfg", reason));
+    EXPECT_TRUE(reason.empty());
+}
+
+TEST(PathUtils, RejectsEmptyPath)
+{
+    std::string reason;
+    EXPECT_FALSE(isPathSafe("", reason));
+    EXPECT_EQ(reason, "empty path rejected");
+}
+
+TEST(PathUtils, RejectsAbsolutePath)
+{
+    std::string reason;
+    EXPECT_FALSE(isPathSafe("/etc/passwd", reason));
+    EXPECT_EQ(reason, "absolute path rejected: /etc/passwd");
+}
+
+TEST(PathUtils, RejectsTraversalDotDot)
+{
+    std::string reason;
+    EXPECT_FALSE(isPathSafe("../foo.scr", reason));
+    EXPECT_EQ(reason, "traversal component rejected: ../foo.scr");
+}
+
+TEST(PathUtils, RejectsTraversalDotDotMidPath)
+{
+    std::string reason;
+    EXPECT_FALSE(isPathSafe("scripts/../../etc/passwd", reason));
+    EXPECT_EQ(reason, "traversal component rejected: scripts/../../etc/passwd");
+}
+
+TEST(PathUtils, RejectsDoubleSlash)
+{
+    std::string reason;
+    EXPECT_FALSE(isPathSafe("scripts//foo.scr", reason));
+    EXPECT_EQ(reason, "double-slash rejected: scripts//foo.scr");
+}
+
+TEST(PathUtils, RejectsOverlongPath)
+{
+    std::string longPath(MAX_PATH_LEN + 1, 'a');
+    std::string reason;
+    EXPECT_FALSE(isPathSafe(longPath, reason));
+
+    // Truncation format: "path too long (N > MAX): <first-40-chars>..."
+    std::string expectedPrefix =
+        "path too long (" + std::to_string(longPath.size()) + " > " + std::to_string(MAX_PATH_LEN) + "): ";
+    ASSERT_GE(reason.size(), expectedPrefix.size());
+    EXPECT_EQ(reason.substr(0, expectedPrefix.size()), expectedPrefix);
+    EXPECT_NE(reason.find("..."), std::string::npos);
+}
+
+TEST(PathUtils, AcceptsExactlyMaxPathLen)
+{
+    std::string boundaryPath(MAX_PATH_LEN, 'a');
+    std::string reason = "leftover";
+    EXPECT_TRUE(isPathSafe(boundaryPath, reason));
+    EXPECT_TRUE(reason.empty());
+}
+
+TEST(PathUtils, EmptyTakesPrecedenceOverOtherChecks)
+{
+    // Ensures the guard order is consistent with the original implementation:
+    // empty must be the first reject reason the caller sees.
+    std::string reason = "stale";
+    EXPECT_FALSE(isPathSafe("", reason));
+    EXPECT_EQ(reason, "empty path rejected");
+}

--- a/test/test_native/astros_serial_protocol_server_tests.cpp
+++ b/test/test_native/astros_serial_protocol_server_tests.cpp
@@ -1,14 +1,15 @@
-// Contract tests — feed decodeSerialMessage the exact bytes produced by
-// AstrOs.Server's MessageGenerator (astros_api/src/serial/message_generator.ts)
+// Contract tests — feed decodeSerialMessage the exact payload bytes produced
+// by AstrOs.Server's MessageGenerator (astros_api/src/serial/message_generator.ts)
 // and assert the firmware decodes each message type correctly.
 //
 // The tests below mirror fixtures from the server's own test suite so the two
 // sides stay locked to the same wire format; if either repo changes the
 // encoding, a case here fails.
 //
-// Trailing '\n' is intentionally omitted — the UART RX loop in src/main.cpp
-// strips the newline delimiter before handing the buffer to handleMessage, so
-// decodeSerialMessage never sees it.
+// What the decoder sees: validateSerialMsg has already split the full wire
+// message on GROUP_SEPARATOR and handed us the second half. So these helpers
+// build only the payload group (RECORD_SEPARATOR-joined controller records)
+// — no header, no GS prefix, no trailing newline.
 
 #include <AstrOsMessaging.hpp>
 #include <AstrOsSerialProtocol.hpp>
@@ -35,19 +36,11 @@ namespace
         return ss.str();
     }
 
-    std::string buildHeader(int typeCode, const std::string &validation, const std::string &msgId)
+    // RECORD_SEPARATOR-joins the controller records that the server produces
+    // between GS and EOL.
+    std::string buildServerPayload(const std::vector<std::string> &records)
     {
         std::stringstream ss;
-        ss << typeCode << RECORD_SEPARATOR << validation << RECORD_SEPARATOR << msgId;
-        return ss.str();
-    }
-
-    // TYPE RS VALIDATION RS MSGID GS record[0] RS record[1] ...
-    std::string buildServerMessage(int typeCode, const std::string &validation, const std::string &msgId,
-                                   const std::vector<std::string> &records)
-    {
-        std::stringstream ss;
-        ss << buildHeader(typeCode, validation, msgId) << GROUP_SEPARATOR;
         bool first = true;
         for (const auto &r : records)
         {
@@ -57,12 +50,6 @@ namespace
             first = false;
         }
         return ss.str();
-    }
-
-    // REGISTRATION_SYNC has no payload and no GS — just the header.
-    std::string buildServerMessageNoPayload(int typeCode, const std::string &validation, const std::string &msgId)
-    {
-        return buildHeader(typeCode, validation, msgId);
     }
 
     // Matches the server fixture in message_generator.test.ts:130-169.
@@ -78,10 +65,9 @@ namespace
 
 TEST(SerialProtocolServer, Server_RegistrationSync_Decodes)
 {
-    const std::string wire = buildServerMessageNoPayload(1, "REGISTRATION_SYNC", "123");
+    const std::string payload = "";
 
-    auto result =
-        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::REGISTRATION_SYNC, "123", wire, true);
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::REGISTRATION_SYNC, "123", payload);
 
     ASSERT_EQ(1u, result.commands.size());
     EXPECT_TRUE(result.rejects.empty());
@@ -97,10 +83,9 @@ TEST(SerialProtocolServer, Server_DeployConfig_SingleBroadcast_Decodes)
     // Realistic config payload — internal '@', '|', ':', ';' must round-trip
     // unchanged through the decoder (they are NOT control separators).
     const std::string cfg = deployConfigCfg(4);
-    const std::string wire =
-        buildServerMessage(5, "DEPLOY_CONFIG", "123", {joinUnits({"00:00:00:00:00:00", "body", cfg})});
+    const std::string payload = buildServerPayload({joinUnits({"00:00:00:00:00:00", "body", cfg})});
 
-    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_CONFIG, "123", wire, true);
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_CONFIG, "123", payload);
 
     ASSERT_EQ(1u, result.commands.size());
     EXPECT_TRUE(result.rejects.empty());
@@ -112,10 +97,9 @@ TEST(SerialProtocolServer, Server_DeployConfig_SingleBroadcast_Decodes)
 TEST(SerialProtocolServer, Server_DeployConfig_SpecificMac_Decodes)
 {
     const std::string cfg = deployConfigCfg(9);
-    const std::string wire =
-        buildServerMessage(5, "DEPLOY_CONFIG", "123", {joinUnits({"11:11:11:11:11:11", "core", cfg})});
+    const std::string payload = buildServerPayload({joinUnits({"11:11:11:11:11:11", "core", cfg})});
 
-    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_CONFIG, "123", wire, true);
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_CONFIG, "123", payload);
 
     ASSERT_EQ(1u, result.commands.size());
     EXPECT_EQ(AstrOsInterfaceResponseType::SEND_CONFIG, result.commands[0].responseType);
@@ -130,14 +114,13 @@ TEST(SerialProtocolServer, Server_DeployConfig_ThreeControllers_Decodes)
     const std::string cfg2 = deployConfigCfg(9);
     const std::string cfg3 = deployConfigCfg(14);
 
-    const std::string wire = buildServerMessage(5, "DEPLOY_CONFIG", "123",
-                                                {
-                                                    joinUnits({"00:00:00:00:00:00", "body", cfg1}),
-                                                    joinUnits({"11:11:11:11:11:11", "core", cfg2}),
-                                                    joinUnits({"22:22:22:22:22:22", "dome", cfg3}),
-                                                });
+    const std::string payload = buildServerPayload({
+        joinUnits({"00:00:00:00:00:00", "body", cfg1}),
+        joinUnits({"11:11:11:11:11:11", "core", cfg2}),
+        joinUnits({"22:22:22:22:22:22", "dome", cfg3}),
+    });
 
-    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_CONFIG, "123", wire, true);
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_CONFIG, "123", payload);
 
     ASSERT_EQ(3u, result.commands.size());
     EXPECT_TRUE(result.rejects.empty());
@@ -161,11 +144,9 @@ TEST(SerialProtocolServer, Server_DeployScript_SingleBroadcast_Decodes)
 {
     const std::string scriptId = "script-xyz";
     const std::string body = "function loop() { digitalWrite(pin, 1); }";
-    const std::string wire =
-        buildServerMessage(8, "DEPLOY_SCRIPT", "msg-1", {joinUnits({"00:00:00:00:00:00", "body", scriptId, body})});
+    const std::string payload = buildServerPayload({joinUnits({"00:00:00:00:00:00", "body", scriptId, body})});
 
-    auto result =
-        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_SCRIPT, "msg-1", wire, true);
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_SCRIPT, "msg-1", payload);
 
     ASSERT_EQ(1u, result.commands.size());
     EXPECT_TRUE(result.rejects.empty());
@@ -180,11 +161,9 @@ TEST(SerialProtocolServer, Server_DeployScript_SpecificMac_Decodes)
 {
     const std::string scriptId = "script-xyz";
     const std::string body = "function loop() { digitalWrite(pin, 1); }";
-    const std::string wire =
-        buildServerMessage(8, "DEPLOY_SCRIPT", "msg-1", {joinUnits({"AA:BB:CC:DD:EE:01", "dome", scriptId, body})});
+    const std::string payload = buildServerPayload({joinUnits({"AA:BB:CC:DD:EE:01", "dome", scriptId, body})});
 
-    auto result =
-        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_SCRIPT, "msg-1", wire, true);
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_SCRIPT, "msg-1", payload);
 
     ASSERT_EQ(1u, result.commands.size());
     EXPECT_EQ(AstrOsInterfaceResponseType::SEND_SCRIPT, result.commands[0].responseType);
@@ -196,14 +175,12 @@ TEST(SerialProtocolServer, Server_DeployScript_TwoControllers_Decodes)
 {
     const std::string scriptId = "script-xyz";
     const std::string body = "script-content-here";
-    const std::string wire = buildServerMessage(8, "DEPLOY_SCRIPT", "msg-1",
-                                                {
-                                                    joinUnits({"AA:BB:CC:DD:EE:01", "dome", scriptId, body}),
-                                                    joinUnits({"AA:BB:CC:DD:EE:02", "body", scriptId, body}),
-                                                });
+    const std::string payload = buildServerPayload({
+        joinUnits({"AA:BB:CC:DD:EE:01", "dome", scriptId, body}),
+        joinUnits({"AA:BB:CC:DD:EE:02", "body", scriptId, body}),
+    });
 
-    auto result =
-        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_SCRIPT, "msg-1", wire, true);
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_SCRIPT, "msg-1", payload);
 
     ASSERT_EQ(2u, result.commands.size());
     EXPECT_TRUE(result.rejects.empty());
@@ -218,10 +195,9 @@ TEST(SerialProtocolServer, Server_DeployScript_TwoControllers_Decodes)
 
 TEST(SerialProtocolServer, Server_RunScript_SpecificMac_Decodes)
 {
-    const std::string wire =
-        buildServerMessage(11, "RUN_SCRIPT", "msg-1", {joinUnits({"AA:BB:CC:DD:EE:01", "dome", "script-xyz"})});
+    const std::string payload = buildServerPayload({joinUnits({"AA:BB:CC:DD:EE:01", "dome", "script-xyz"})});
 
-    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::RUN_SCRIPT, "msg-1", wire, true);
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::RUN_SCRIPT, "msg-1", payload);
 
     ASSERT_EQ(1u, result.commands.size());
     EXPECT_EQ(AstrOsInterfaceResponseType::SEND_SCRIPT_RUN, result.commands[0].responseType);
@@ -233,10 +209,9 @@ TEST(SerialProtocolServer, Server_RunScript_SpecificMac_Decodes)
 
 TEST(SerialProtocolServer, Server_PanicStop_LiteralPayload_Decodes)
 {
-    const std::string wire =
-        buildServerMessage(14, "PANIC_STOP", "msg-1", {joinUnits({"AA:BB:CC:DD:EE:01", "dome", "PANIC"})});
+    const std::string payload = buildServerPayload({joinUnits({"AA:BB:CC:DD:EE:01", "dome", "PANIC"})});
 
-    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::PANIC_STOP, "msg-1", wire, true);
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::PANIC_STOP, "msg-1", payload);
 
     ASSERT_EQ(1u, result.commands.size());
     EXPECT_EQ(AstrOsInterfaceResponseType::SEND_PANIC_STOP, result.commands[0].responseType);
@@ -249,10 +224,9 @@ TEST(SerialProtocolServer, Server_PanicStop_LiteralPayload_Decodes)
 TEST(SerialProtocolServer, Server_RunCommand_SingleController_Decodes)
 {
     // Server never emits multi-controller RUN_COMMAND (generator :272-290).
-    const std::string wire =
-        buildServerMessage(15, "RUN_COMMAND", "msg-1", {joinUnits({"AA:BB:CC:DD:EE:01", "dome", "delay(500);"})});
+    const std::string payload = buildServerPayload({joinUnits({"AA:BB:CC:DD:EE:01", "dome", "delay(500);"})});
 
-    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::RUN_COMMAND, "msg-1", wire, true);
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::RUN_COMMAND, "msg-1", payload);
 
     ASSERT_EQ(1u, result.commands.size());
     EXPECT_EQ(AstrOsInterfaceResponseType::SEND_COMMAND, result.commands[0].responseType);
@@ -264,10 +238,9 @@ TEST(SerialProtocolServer, Server_RunCommand_SingleController_Decodes)
 
 TEST(SerialProtocolServer, Server_FormatSd_LiteralPayload_Decodes)
 {
-    const std::string wire =
-        buildServerMessage(18, "FORMAT_SD", "msg-1", {joinUnits({"AA:BB:CC:DD:EE:01", "dome", "FORMAT"})});
+    const std::string payload = buildServerPayload({joinUnits({"AA:BB:CC:DD:EE:01", "dome", "FORMAT"})});
 
-    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::FORMAT_SD, "msg-1", wire, true);
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::FORMAT_SD, "msg-1", payload);
 
     ASSERT_EQ(1u, result.commands.size());
     EXPECT_EQ(AstrOsInterfaceResponseType::SEND_FORMAT_SD, result.commands[0].responseType);
@@ -282,10 +255,9 @@ TEST(SerialProtocolServer, Server_ServoTest_SpecPreservedVerbatim_Decodes)
     // Server never emits multi-controller SERVO_TEST (generator :292-311).
     // The colon-delimited spec 'maestro:3:5:1500' must survive intact —
     // internal ':' is NOT a control separator.
-    const std::string wire =
-        buildServerMessage(21, "SERVO_TEST", "msg-1", {joinUnits({"AA:BB:CC:DD:EE:01", "dome", "maestro:3:5:1500"})});
+    const std::string payload = buildServerPayload({joinUnits({"AA:BB:CC:DD:EE:01", "dome", "maestro:3:5:1500"})});
 
-    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::SERVO_TEST, "msg-1", wire, true);
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::SERVO_TEST, "msg-1", payload);
 
     ASSERT_EQ(1u, result.commands.size());
     EXPECT_EQ(AstrOsInterfaceResponseType::SEND_SERVO_TEST, result.commands[0].responseType);
@@ -298,8 +270,6 @@ TEST(SerialProtocolServer, Server_ServoTest_SpecPreservedVerbatim_Decodes)
 struct ServerBasicExpectation
 {
     AstrOsSerialMessageType type;
-    int wireTypeCode;
-    const char *validation;
     AstrOsInterfaceResponseType masterResponse;
     AstrOsInterfaceResponseType padawanResponse;
     const char *value;
@@ -313,13 +283,12 @@ class ServerBasicRoutingFixture : public ::testing::TestWithParam<ServerBasicExp
 TEST_P(ServerBasicRoutingFixture, TwoControllerRoundTrip)
 {
     const auto &p = GetParam();
-    const std::string wire = buildServerMessage(p.wireTypeCode, p.validation, "msg-1",
-                                                {
-                                                    joinUnits({"00:00:00:00:00:00", "master", p.value}),
-                                                    joinUnits({"AA:BB:CC:DD:EE:01", "dome", p.value}),
-                                                });
+    const std::string payload = buildServerPayload({
+        joinUnits({"00:00:00:00:00:00", "master", p.value}),
+        joinUnits({"AA:BB:CC:DD:EE:01", "dome", p.value}),
+    });
 
-    auto result = AstrOsSerialProtocol::decodeSerialMessage(p.type, "msg-1", wire, true);
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(p.type, "msg-1", payload);
 
     ASSERT_EQ(2u, result.commands.size()) << "type=" << p.label;
     EXPECT_TRUE(result.rejects.empty()) << "type=" << p.label;
@@ -338,12 +307,11 @@ TEST_P(ServerBasicRoutingFixture, TwoControllerRoundTrip)
 // fixture would not reflect real traffic.
 INSTANTIATE_TEST_SUITE_P(
     ServerMultiController, ServerBasicRoutingFixture,
-    ::testing::Values(ServerBasicExpectation{AstrOsSerialMessageType::RUN_SCRIPT, 11, "RUN_SCRIPT",
+    ::testing::Values(ServerBasicExpectation{AstrOsSerialMessageType::RUN_SCRIPT,
                                              AstrOsInterfaceResponseType::SCRIPT_RUN,
                                              AstrOsInterfaceResponseType::SEND_SCRIPT_RUN, "script-xyz", "RUN_SCRIPT"},
-                      ServerBasicExpectation{AstrOsSerialMessageType::PANIC_STOP, 14, "PANIC_STOP",
+                      ServerBasicExpectation{AstrOsSerialMessageType::PANIC_STOP,
                                              AstrOsInterfaceResponseType::PANIC_STOP,
                                              AstrOsInterfaceResponseType::SEND_PANIC_STOP, "PANIC", "PANIC_STOP"},
-                      ServerBasicExpectation{AstrOsSerialMessageType::FORMAT_SD, 18, "FORMAT_SD",
-                                             AstrOsInterfaceResponseType::FORMAT_SD,
+                      ServerBasicExpectation{AstrOsSerialMessageType::FORMAT_SD, AstrOsInterfaceResponseType::FORMAT_SD,
                                              AstrOsInterfaceResponseType::SEND_FORMAT_SD, "FORMAT", "FORMAT_SD"}));

--- a/test/test_native/astros_serial_protocol_server_tests.cpp
+++ b/test/test_native/astros_serial_protocol_server_tests.cpp
@@ -1,0 +1,349 @@
+// Contract tests — feed decodeSerialMessage the exact bytes produced by
+// AstrOs.Server's MessageGenerator (astros_api/src/serial/message_generator.ts)
+// and assert the firmware decodes each message type correctly.
+//
+// The tests below mirror fixtures from the server's own test suite so the two
+// sides stay locked to the same wire format; if either repo changes the
+// encoding, a case here fails.
+//
+// Trailing '\n' is intentionally omitted — the UART RX loop in src/main.cpp
+// strips the newline delimiter before handing the buffer to handleMessage, so
+// decodeSerialMessage never sees it.
+
+#include <AstrOsMessaging.hpp>
+#include <AstrOsSerialProtocol.hpp>
+#include <AstrOsStringUtils.hpp>
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+    std::string joinUnits(std::initializer_list<std::string> fields)
+    {
+        std::stringstream ss;
+        bool first = true;
+        for (const auto &f : fields)
+        {
+            if (!first)
+                ss << UNIT_SEPARATOR;
+            ss << f;
+            first = false;
+        }
+        return ss.str();
+    }
+
+    std::string buildHeader(int typeCode, const std::string &validation, const std::string &msgId)
+    {
+        std::stringstream ss;
+        ss << typeCode << RECORD_SEPARATOR << validation << RECORD_SEPARATOR << msgId;
+        return ss.str();
+    }
+
+    // TYPE RS VALIDATION RS MSGID GS record[0] RS record[1] ...
+    std::string buildServerMessage(int typeCode, const std::string &validation, const std::string &msgId,
+                                   const std::vector<std::string> &records)
+    {
+        std::stringstream ss;
+        ss << buildHeader(typeCode, validation, msgId) << GROUP_SEPARATOR;
+        bool first = true;
+        for (const auto &r : records)
+        {
+            if (!first)
+                ss << RECORD_SEPARATOR;
+            ss << r;
+            first = false;
+        }
+        return ss.str();
+    }
+
+    // REGISTRATION_SYNC has no payload and no GS — just the header.
+    std::string buildServerMessageNoPayload(int typeCode, const std::string &validation, const std::string &msgId)
+    {
+        return buildHeader(typeCode, validation, msgId);
+    }
+
+    // Matches the server fixture in message_generator.test.ts:130-169.
+    std::string deployConfigCfg(int maestroIdx)
+    {
+        std::stringstream ss;
+        ss << "5@1|0|1|0;1@" << maestroIdx << ":1:9600@1:1:1:800:2000:1400:0|2:1:0:500:2500:1500:1";
+        return ss.str();
+    }
+} // namespace
+
+// ---------------- REGISTRATION_SYNC (type 1) ----------------
+
+TEST(SerialProtocolServer, Server_RegistrationSync_Decodes)
+{
+    const std::string wire = buildServerMessageNoPayload(1, "REGISTRATION_SYNC", "123");
+
+    auto result =
+        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::REGISTRATION_SYNC, "123", wire, true);
+
+    ASSERT_EQ(1u, result.commands.size());
+    EXPECT_TRUE(result.rejects.empty());
+    EXPECT_EQ(AstrOsInterfaceResponseType::REGISTRATION_SYNC, result.commands[0].responseType);
+    EXPECT_EQ("123", result.commands[0].msgId);
+    EXPECT_EQ("", result.commands[0].peerMac);
+}
+
+// ---------------- DEPLOY_CONFIG (type 5) ----------------
+
+TEST(SerialProtocolServer, Server_DeployConfig_SingleBroadcast_Decodes)
+{
+    // Realistic config payload — internal '@', '|', ':', ';' must round-trip
+    // unchanged through the decoder (they are NOT control separators).
+    const std::string cfg = deployConfigCfg(4);
+    const std::string wire =
+        buildServerMessage(5, "DEPLOY_CONFIG", "123", {joinUnits({"00:00:00:00:00:00", "body", cfg})});
+
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_CONFIG, "123", wire, true);
+
+    ASSERT_EQ(1u, result.commands.size());
+    EXPECT_TRUE(result.rejects.empty());
+    EXPECT_EQ(AstrOsInterfaceResponseType::SET_CONFIG, result.commands[0].responseType);
+    EXPECT_EQ("", result.commands[0].peerMac);
+    EXPECT_EQ(cfg, result.commands[0].message);
+}
+
+TEST(SerialProtocolServer, Server_DeployConfig_SpecificMac_Decodes)
+{
+    const std::string cfg = deployConfigCfg(9);
+    const std::string wire =
+        buildServerMessage(5, "DEPLOY_CONFIG", "123", {joinUnits({"11:11:11:11:11:11", "core", cfg})});
+
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_CONFIG, "123", wire, true);
+
+    ASSERT_EQ(1u, result.commands.size());
+    EXPECT_EQ(AstrOsInterfaceResponseType::SEND_CONFIG, result.commands[0].responseType);
+    EXPECT_EQ("11:11:11:11:11:11", result.commands[0].peerMac);
+    EXPECT_EQ(cfg, result.commands[0].message);
+}
+
+TEST(SerialProtocolServer, Server_DeployConfig_ThreeControllers_Decodes)
+{
+    // Mirror of message_generator.test.ts:130-169.
+    const std::string cfg1 = deployConfigCfg(4);
+    const std::string cfg2 = deployConfigCfg(9);
+    const std::string cfg3 = deployConfigCfg(14);
+
+    const std::string wire = buildServerMessage(5, "DEPLOY_CONFIG", "123",
+                                                {
+                                                    joinUnits({"00:00:00:00:00:00", "body", cfg1}),
+                                                    joinUnits({"11:11:11:11:11:11", "core", cfg2}),
+                                                    joinUnits({"22:22:22:22:22:22", "dome", cfg3}),
+                                                });
+
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_CONFIG, "123", wire, true);
+
+    ASSERT_EQ(3u, result.commands.size());
+    EXPECT_TRUE(result.rejects.empty());
+
+    EXPECT_EQ(AstrOsInterfaceResponseType::SET_CONFIG, result.commands[0].responseType);
+    EXPECT_EQ("", result.commands[0].peerMac);
+    EXPECT_EQ(cfg1, result.commands[0].message);
+
+    EXPECT_EQ(AstrOsInterfaceResponseType::SEND_CONFIG, result.commands[1].responseType);
+    EXPECT_EQ("11:11:11:11:11:11", result.commands[1].peerMac);
+    EXPECT_EQ(cfg2, result.commands[1].message);
+
+    EXPECT_EQ(AstrOsInterfaceResponseType::SEND_CONFIG, result.commands[2].responseType);
+    EXPECT_EQ("22:22:22:22:22:22", result.commands[2].peerMac);
+    EXPECT_EQ(cfg3, result.commands[2].message);
+}
+
+// ---------------- DEPLOY_SCRIPT (type 8) ----------------
+
+TEST(SerialProtocolServer, Server_DeployScript_SingleBroadcast_Decodes)
+{
+    const std::string scriptId = "script-xyz";
+    const std::string body = "function loop() { digitalWrite(pin, 1); }";
+    const std::string wire =
+        buildServerMessage(8, "DEPLOY_SCRIPT", "msg-1", {joinUnits({"00:00:00:00:00:00", "body", scriptId, body})});
+
+    auto result =
+        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_SCRIPT, "msg-1", wire, true);
+
+    ASSERT_EQ(1u, result.commands.size());
+    EXPECT_TRUE(result.rejects.empty());
+    EXPECT_EQ(AstrOsInterfaceResponseType::SAVE_SCRIPT, result.commands[0].responseType);
+    EXPECT_EQ("", result.commands[0].peerMac);
+
+    const std::string expected = scriptId + UNIT_SEPARATOR + body;
+    EXPECT_EQ(expected, result.commands[0].message);
+}
+
+TEST(SerialProtocolServer, Server_DeployScript_SpecificMac_Decodes)
+{
+    const std::string scriptId = "script-xyz";
+    const std::string body = "function loop() { digitalWrite(pin, 1); }";
+    const std::string wire =
+        buildServerMessage(8, "DEPLOY_SCRIPT", "msg-1", {joinUnits({"AA:BB:CC:DD:EE:01", "dome", scriptId, body})});
+
+    auto result =
+        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_SCRIPT, "msg-1", wire, true);
+
+    ASSERT_EQ(1u, result.commands.size());
+    EXPECT_EQ(AstrOsInterfaceResponseType::SEND_SCRIPT, result.commands[0].responseType);
+    EXPECT_EQ("AA:BB:CC:DD:EE:01", result.commands[0].peerMac);
+    EXPECT_EQ(scriptId + UNIT_SEPARATOR + body, result.commands[0].message);
+}
+
+TEST(SerialProtocolServer, Server_DeployScript_TwoControllers_Decodes)
+{
+    const std::string scriptId = "script-xyz";
+    const std::string body = "script-content-here";
+    const std::string wire = buildServerMessage(8, "DEPLOY_SCRIPT", "msg-1",
+                                                {
+                                                    joinUnits({"AA:BB:CC:DD:EE:01", "dome", scriptId, body}),
+                                                    joinUnits({"AA:BB:CC:DD:EE:02", "body", scriptId, body}),
+                                                });
+
+    auto result =
+        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_SCRIPT, "msg-1", wire, true);
+
+    ASSERT_EQ(2u, result.commands.size());
+    EXPECT_TRUE(result.rejects.empty());
+
+    EXPECT_EQ("AA:BB:CC:DD:EE:01", result.commands[0].peerMac);
+    EXPECT_EQ(AstrOsInterfaceResponseType::SEND_SCRIPT, result.commands[0].responseType);
+    EXPECT_EQ("AA:BB:CC:DD:EE:02", result.commands[1].peerMac);
+    EXPECT_EQ(AstrOsInterfaceResponseType::SEND_SCRIPT, result.commands[1].responseType);
+}
+
+// ---------------- RUN_SCRIPT (type 11) ----------------
+
+TEST(SerialProtocolServer, Server_RunScript_SpecificMac_Decodes)
+{
+    const std::string wire =
+        buildServerMessage(11, "RUN_SCRIPT", "msg-1", {joinUnits({"AA:BB:CC:DD:EE:01", "dome", "script-xyz"})});
+
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::RUN_SCRIPT, "msg-1", wire, true);
+
+    ASSERT_EQ(1u, result.commands.size());
+    EXPECT_EQ(AstrOsInterfaceResponseType::SEND_SCRIPT_RUN, result.commands[0].responseType);
+    EXPECT_EQ("AA:BB:CC:DD:EE:01", result.commands[0].peerMac);
+    EXPECT_EQ("script-xyz", result.commands[0].message);
+}
+
+// ---------------- PANIC_STOP (type 14) ----------------
+
+TEST(SerialProtocolServer, Server_PanicStop_LiteralPayload_Decodes)
+{
+    const std::string wire =
+        buildServerMessage(14, "PANIC_STOP", "msg-1", {joinUnits({"AA:BB:CC:DD:EE:01", "dome", "PANIC"})});
+
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::PANIC_STOP, "msg-1", wire, true);
+
+    ASSERT_EQ(1u, result.commands.size());
+    EXPECT_EQ(AstrOsInterfaceResponseType::SEND_PANIC_STOP, result.commands[0].responseType);
+    EXPECT_EQ("AA:BB:CC:DD:EE:01", result.commands[0].peerMac);
+    EXPECT_EQ("PANIC", result.commands[0].message);
+}
+
+// ---------------- RUN_COMMAND (type 15) ----------------
+
+TEST(SerialProtocolServer, Server_RunCommand_SingleController_Decodes)
+{
+    // Server never emits multi-controller RUN_COMMAND (generator :272-290).
+    const std::string wire =
+        buildServerMessage(15, "RUN_COMMAND", "msg-1", {joinUnits({"AA:BB:CC:DD:EE:01", "dome", "delay(500);"})});
+
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::RUN_COMMAND, "msg-1", wire, true);
+
+    ASSERT_EQ(1u, result.commands.size());
+    EXPECT_EQ(AstrOsInterfaceResponseType::SEND_COMMAND, result.commands[0].responseType);
+    EXPECT_EQ("AA:BB:CC:DD:EE:01", result.commands[0].peerMac);
+    EXPECT_EQ("delay(500);", result.commands[0].message);
+}
+
+// ---------------- FORMAT_SD (type 18) ----------------
+
+TEST(SerialProtocolServer, Server_FormatSd_LiteralPayload_Decodes)
+{
+    const std::string wire =
+        buildServerMessage(18, "FORMAT_SD", "msg-1", {joinUnits({"AA:BB:CC:DD:EE:01", "dome", "FORMAT"})});
+
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::FORMAT_SD, "msg-1", wire, true);
+
+    ASSERT_EQ(1u, result.commands.size());
+    EXPECT_EQ(AstrOsInterfaceResponseType::SEND_FORMAT_SD, result.commands[0].responseType);
+    EXPECT_EQ("AA:BB:CC:DD:EE:01", result.commands[0].peerMac);
+    EXPECT_EQ("FORMAT", result.commands[0].message);
+}
+
+// ---------------- SERVO_TEST (type 21) ----------------
+
+TEST(SerialProtocolServer, Server_ServoTest_SpecPreservedVerbatim_Decodes)
+{
+    // Server never emits multi-controller SERVO_TEST (generator :292-311).
+    // The colon-delimited spec 'maestro:3:5:1500' must survive intact —
+    // internal ':' is NOT a control separator.
+    const std::string wire =
+        buildServerMessage(21, "SERVO_TEST", "msg-1", {joinUnits({"AA:BB:CC:DD:EE:01", "dome", "maestro:3:5:1500"})});
+
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::SERVO_TEST, "msg-1", wire, true);
+
+    ASSERT_EQ(1u, result.commands.size());
+    EXPECT_EQ(AstrOsInterfaceResponseType::SEND_SERVO_TEST, result.commands[0].responseType);
+    EXPECT_EQ("AA:BB:CC:DD:EE:01", result.commands[0].peerMac);
+    EXPECT_EQ("maestro:3:5:1500", result.commands[0].message);
+}
+
+// ---------------- Parameterised multi-controller routing ----------------
+
+struct ServerBasicExpectation
+{
+    AstrOsSerialMessageType type;
+    int wireTypeCode;
+    const char *validation;
+    AstrOsInterfaceResponseType masterResponse;
+    AstrOsInterfaceResponseType padawanResponse;
+    const char *value;
+    const char *label;
+};
+
+class ServerBasicRoutingFixture : public ::testing::TestWithParam<ServerBasicExpectation>
+{
+};
+
+TEST_P(ServerBasicRoutingFixture, TwoControllerRoundTrip)
+{
+    const auto &p = GetParam();
+    const std::string wire = buildServerMessage(p.wireTypeCode, p.validation, "msg-1",
+                                                {
+                                                    joinUnits({"00:00:00:00:00:00", "master", p.value}),
+                                                    joinUnits({"AA:BB:CC:DD:EE:01", "dome", p.value}),
+                                                });
+
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(p.type, "msg-1", wire, true);
+
+    ASSERT_EQ(2u, result.commands.size()) << "type=" << p.label;
+    EXPECT_TRUE(result.rejects.empty()) << "type=" << p.label;
+
+    EXPECT_EQ(p.masterResponse, result.commands[0].responseType) << "type=" << p.label;
+    EXPECT_EQ("", result.commands[0].peerMac);
+    EXPECT_EQ(p.value, result.commands[0].message);
+
+    EXPECT_EQ(p.padawanResponse, result.commands[1].responseType) << "type=" << p.label;
+    EXPECT_EQ("AA:BB:CC:DD:EE:01", result.commands[1].peerMac);
+    EXPECT_EQ(p.value, result.commands[1].message);
+}
+
+// RUN_COMMAND and SERVO_TEST are intentionally omitted — the server never
+// produces multi-controller variants for those types, so a two-controller
+// fixture would not reflect real traffic.
+INSTANTIATE_TEST_SUITE_P(
+    ServerMultiController, ServerBasicRoutingFixture,
+    ::testing::Values(ServerBasicExpectation{AstrOsSerialMessageType::RUN_SCRIPT, 11, "RUN_SCRIPT",
+                                             AstrOsInterfaceResponseType::SCRIPT_RUN,
+                                             AstrOsInterfaceResponseType::SEND_SCRIPT_RUN, "script-xyz", "RUN_SCRIPT"},
+                      ServerBasicExpectation{AstrOsSerialMessageType::PANIC_STOP, 14, "PANIC_STOP",
+                                             AstrOsInterfaceResponseType::PANIC_STOP,
+                                             AstrOsInterfaceResponseType::SEND_PANIC_STOP, "PANIC", "PANIC_STOP"},
+                      ServerBasicExpectation{AstrOsSerialMessageType::FORMAT_SD, 18, "FORMAT_SD",
+                                             AstrOsInterfaceResponseType::FORMAT_SD,
+                                             AstrOsInterfaceResponseType::SEND_FORMAT_SD, "FORMAT", "FORMAT_SD"}));

--- a/test/test_native/astros_serial_protocol_tests.cpp
+++ b/test/test_native/astros_serial_protocol_tests.cpp
@@ -9,17 +9,9 @@
 
 namespace
 {
-    // decodeSerialMessage only looks at the payload group (parts[1] after a
-    // split on GROUP_SEPARATOR), so the header contents are irrelevant for
-    // these tests. Prepend a single GROUP_SEPARATOR to keep the split happy.
-    std::string wrapPayload(const std::string &payload)
-    {
-        std::string out;
-        out += GROUP_SEPARATOR;
-        out += payload;
-        return out;
-    }
-
+    // decodeSerialMessage takes the already-extracted payload group
+    // (RECORD_SEPARATOR-joined controller records). These helpers build
+    // that payload directly — no header, no GROUP_SEPARATOR prefix.
     std::string joinUnits(std::initializer_list<std::string> parts)
     {
         std::stringstream ss;
@@ -94,8 +86,7 @@ TEST(SerialProtocol, MapResponseTypePadawanRegistrationIsUnknown)
 
 TEST(SerialProtocol, RegistrationSyncProducesBroadcastCommand)
 {
-    auto result =
-        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::REGISTRATION_SYNC, "mid", "", true);
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::REGISTRATION_SYNC, "mid", "");
 
     ASSERT_EQ(1u, result.commands.size());
     EXPECT_TRUE(result.rejects.empty());
@@ -112,8 +103,7 @@ TEST(SerialProtocol, RegistrationSyncPadawanStillProducesRegistrationSync)
 {
     // Matches the handleRegistrationSync quirk: the hardcoded SET bypasses
     // the padawan lookup which would otherwise return UNKNOWN.
-    auto result =
-        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::REGISTRATION_SYNC, "mid", "", false);
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::REGISTRATION_SYNC, "mid", "");
 
     ASSERT_EQ(1u, result.commands.size());
     EXPECT_EQ(AstrOsInterfaceResponseType::REGISTRATION_SYNC, result.commands[0].responseType);
@@ -123,9 +113,8 @@ TEST(SerialProtocol, RegistrationSyncPadawanStillProducesRegistrationSync)
 
 TEST(SerialProtocol, DeployConfigBroadcastMacMapsToSetConfig)
 {
-    const std::string payload = wrapPayload(joinUnits({"00:00:00:00:00:00", "master", "CFG_DATA"}));
-    auto result =
-        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_CONFIG, "mid", payload, true);
+    const std::string payload = joinUnits({"00:00:00:00:00:00", "master", "CFG_DATA"});
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_CONFIG, "mid", payload);
 
     ASSERT_EQ(1u, result.commands.size());
     EXPECT_TRUE(result.rejects.empty());
@@ -139,9 +128,8 @@ TEST(SerialProtocol, DeployConfigBroadcastMacMapsToSetConfig)
 
 TEST(SerialProtocol, DeployConfigSpecificMacMapsToSendConfig)
 {
-    const std::string payload = wrapPayload(joinUnits({"AA:BB:CC:DD:EE:FF", "padawan", "CFG_DATA"}));
-    auto result =
-        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_CONFIG, "mid", payload, true);
+    const std::string payload = joinUnits({"AA:BB:CC:DD:EE:FF", "padawan", "CFG_DATA"});
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_CONFIG, "mid", payload);
 
     ASSERT_EQ(1u, result.commands.size());
     EXPECT_TRUE(result.rejects.empty());
@@ -155,9 +143,8 @@ TEST(SerialProtocol, DeployConfigSpecificMacMapsToSendConfig)
 TEST(SerialProtocol, DeployConfigWrongPartCountRejects)
 {
     // Only 2 parts instead of 3.
-    const std::string payload = wrapPayload(joinUnits({"AA:BB:CC:DD:EE:FF", "padawan"}));
-    auto result =
-        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_CONFIG, "mid", payload, true);
+    const std::string payload = joinUnits({"AA:BB:CC:DD:EE:FF", "padawan"});
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_CONFIG, "mid", payload);
 
     EXPECT_TRUE(result.commands.empty());
     ASSERT_EQ(1u, result.rejects.size());
@@ -169,9 +156,8 @@ TEST(SerialProtocol, DeployConfigWrongPartCountRejects)
 TEST(SerialProtocol, DeployScriptReconstructsScriptPayload)
 {
     // Per handler: script = msgParts[2] + UNIT_SEPARATOR + msgParts[3].
-    const std::string payload = wrapPayload(joinUnits({"00:00:00:00:00:00", "master", "scriptId", "scriptBody"}));
-    auto result =
-        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_SCRIPT, "mid", payload, true);
+    const std::string payload = joinUnits({"00:00:00:00:00:00", "master", "scriptId", "scriptBody"});
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_SCRIPT, "mid", payload);
 
     ASSERT_EQ(1u, result.commands.size());
     EXPECT_TRUE(result.rejects.empty());
@@ -185,9 +171,8 @@ TEST(SerialProtocol, DeployScriptReconstructsScriptPayload)
 
 TEST(SerialProtocol, DeployScriptSpecificMacRoutesToSendScript)
 {
-    const std::string payload = wrapPayload(joinUnits({"AA:BB:CC:DD:EE:FF", "padawan", "scriptId", "scriptBody"}));
-    auto result =
-        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_SCRIPT, "mid", payload, true);
+    const std::string payload = joinUnits({"AA:BB:CC:DD:EE:FF", "padawan", "scriptId", "scriptBody"});
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_SCRIPT, "mid", payload);
 
     ASSERT_EQ(1u, result.commands.size());
     EXPECT_EQ(AstrOsInterfaceResponseType::SEND_SCRIPT, result.commands[0].responseType);
@@ -197,9 +182,8 @@ TEST(SerialProtocol, DeployScriptSpecificMacRoutesToSendScript)
 TEST(SerialProtocol, DeployScriptWrongPartCountRejects)
 {
     // 3 parts instead of 4 — malformed script entry.
-    const std::string payload = wrapPayload(joinUnits({"00:00:00:00:00:00", "master", "onlyScript"}));
-    auto result =
-        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_SCRIPT, "mid", payload, true);
+    const std::string payload = joinUnits({"00:00:00:00:00:00", "master", "onlyScript"});
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_SCRIPT, "mid", payload);
 
     EXPECT_TRUE(result.commands.empty());
     ASSERT_EQ(1u, result.rejects.size());
@@ -223,8 +207,8 @@ class BasicCommandRoutingFixture : public ::testing::TestWithParam<BasicCommandE
 TEST_P(BasicCommandRoutingFixture, BroadcastRoutesToMasterResponseType)
 {
     const auto &param = GetParam();
-    const std::string payload = wrapPayload(joinUnits({"00:00:00:00:00:00", "master", "VAL"}));
-    auto result = AstrOsSerialProtocol::decodeSerialMessage(param.type, "mid", payload, true);
+    const std::string payload = joinUnits({"00:00:00:00:00:00", "master", "VAL"});
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(param.type, "mid", payload);
 
     ASSERT_EQ(1u, result.commands.size()) << "type=" << param.label;
     EXPECT_EQ(param.masterResponse, result.commands[0].responseType) << "type=" << param.label;
@@ -235,8 +219,8 @@ TEST_P(BasicCommandRoutingFixture, BroadcastRoutesToMasterResponseType)
 TEST_P(BasicCommandRoutingFixture, SpecificMacRoutesToPadawanResponseType)
 {
     const auto &param = GetParam();
-    const std::string payload = wrapPayload(joinUnits({"AA:BB:CC:DD:EE:FF", "padawan", "VAL"}));
-    auto result = AstrOsSerialProtocol::decodeSerialMessage(param.type, "mid", payload, true);
+    const std::string payload = joinUnits({"AA:BB:CC:DD:EE:FF", "padawan", "VAL"});
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(param.type, "mid", payload);
 
     ASSERT_EQ(1u, result.commands.size()) << "type=" << param.label;
     EXPECT_EQ(param.padawanResponse, result.commands[0].responseType) << "type=" << param.label;
@@ -259,8 +243,8 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST(SerialProtocol, BasicCommandEmptyDestRejects)
 {
-    const std::string payload = wrapPayload(joinUnits({"", "padawan", "VAL"}));
-    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::RUN_COMMAND, "mid", payload, true);
+    const std::string payload = joinUnits({"", "padawan", "VAL"});
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::RUN_COMMAND, "mid", payload);
 
     EXPECT_TRUE(result.commands.empty());
     ASSERT_EQ(1u, result.rejects.size());
@@ -279,9 +263,9 @@ TEST(SerialProtocol, BasicCommandEmptyValueRejects)
     entry += "padawan";
     entry += UNIT_SEPARATOR;
     entry += UNIT_SEPARATOR;
-    const std::string payload = wrapPayload(entry);
+    const std::string payload = entry;
 
-    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::RUN_COMMAND, "mid", payload, true);
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::RUN_COMMAND, "mid", payload);
 
     EXPECT_TRUE(result.commands.empty());
     ASSERT_EQ(1u, result.rejects.size());
@@ -290,8 +274,8 @@ TEST(SerialProtocol, BasicCommandEmptyValueRejects)
 
 TEST(SerialProtocol, BasicCommandWrongPartCountRejects)
 {
-    const std::string payload = wrapPayload(joinUnits({"AA:BB:CC:DD:EE:FF", "padawan"}));
-    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::RUN_COMMAND, "mid", payload, true);
+    const std::string payload = joinUnits({"AA:BB:CC:DD:EE:FF", "padawan"});
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::RUN_COMMAND, "mid", payload);
 
     EXPECT_TRUE(result.commands.empty());
     ASSERT_EQ(1u, result.rejects.size());
@@ -305,9 +289,9 @@ TEST(SerialProtocol, MixedValidAndInvalidEntriesCoexist)
     const std::string good1 = joinUnits({"00:00:00:00:00:00", "master", "v1"});
     const std::string bad = joinUnits({"", "padawan", "v2"}); // empty dest
     const std::string good2 = joinUnits({"AA:BB:CC:DD:EE:FF", "padawan2", "v3"});
-    const std::string payload = wrapPayload(joinRecords({good1, bad, good2}));
+    const std::string payload = joinRecords({good1, bad, good2});
 
-    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::RUN_COMMAND, "mid", payload, true);
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::RUN_COMMAND, "mid", payload);
 
     ASSERT_EQ(2u, result.commands.size());
     EXPECT_EQ(AstrOsInterfaceResponseType::COMMAND, result.commands[0].responseType);
@@ -319,11 +303,31 @@ TEST(SerialProtocol, MixedValidAndInvalidEntriesCoexist)
     EXPECT_EQ(AstrOsSerialProtocol::DecodeRejectReason::EMPTY_DEST, result.rejects[0].reason);
 }
 
+// ---------------- Empty payload ----------------
+
+TEST(SerialProtocol, EmptyPayloadProducesRejectForPayloadTypes)
+{
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_CONFIG, "mid", "");
+
+    EXPECT_TRUE(result.commands.empty());
+    ASSERT_EQ(1u, result.rejects.size());
+    EXPECT_EQ(AstrOsSerialProtocol::DecodeRejectReason::EMPTY_PAYLOAD, result.rejects[0].reason);
+}
+
+TEST(SerialProtocol, EmptyPayloadDoesNotAffectRegistrationSync)
+{
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::REGISTRATION_SYNC, "mid", "");
+
+    ASSERT_EQ(1u, result.commands.size());
+    EXPECT_TRUE(result.rejects.empty());
+    EXPECT_EQ(AstrOsInterfaceResponseType::REGISTRATION_SYNC, result.commands[0].responseType);
+}
+
 // ---------------- Unknown type ----------------
 
 TEST(SerialProtocol, UnknownTypeProducesUnknownTypeReject)
 {
-    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::UNKNOWN, "mid", "", true);
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::UNKNOWN, "mid", "");
 
     EXPECT_TRUE(result.commands.empty());
     ASSERT_EQ(1u, result.rejects.size());
@@ -337,4 +341,5 @@ TEST(SerialProtocol, DescribeRejectReasonReturnsNonNull)
     EXPECT_STRNE("", describeRejectReason(DecodeRejectReason::EMPTY_DEST));
     EXPECT_STRNE("", describeRejectReason(DecodeRejectReason::EMPTY_VALUE));
     EXPECT_STRNE("", describeRejectReason(DecodeRejectReason::UNKNOWN_TYPE));
+    EXPECT_STRNE("", describeRejectReason(DecodeRejectReason::EMPTY_PAYLOAD));
 }

--- a/test/test_native/astros_serial_protocol_tests.cpp
+++ b/test/test_native/astros_serial_protocol_tests.cpp
@@ -1,0 +1,340 @@
+#include <AstrOsMessaging.hpp>
+#include <AstrOsSerialProtocol.hpp>
+#include <AstrOsStringUtils.hpp>
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+    // decodeSerialMessage only looks at the payload group (parts[1] after a
+    // split on GROUP_SEPARATOR), so the header contents are irrelevant for
+    // these tests. Prepend a single GROUP_SEPARATOR to keep the split happy.
+    std::string wrapPayload(const std::string &payload)
+    {
+        std::string out;
+        out += GROUP_SEPARATOR;
+        out += payload;
+        return out;
+    }
+
+    std::string joinUnits(std::initializer_list<std::string> parts)
+    {
+        std::stringstream ss;
+        bool first = true;
+        for (const auto &p : parts)
+        {
+            if (!first)
+                ss << UNIT_SEPARATOR;
+            ss << p;
+            first = false;
+        }
+        return ss.str();
+    }
+
+    std::string joinRecords(std::initializer_list<std::string> entries)
+    {
+        std::stringstream ss;
+        bool first = true;
+        for (const auto &e : entries)
+        {
+            if (!first)
+                ss << RECORD_SEPARATOR;
+            ss << e;
+            first = false;
+        }
+        return ss.str();
+    }
+} // namespace
+
+// ---------------- mapResponseType ----------------
+
+TEST(SerialProtocol, MapResponseTypeMasterTable)
+{
+    using namespace AstrOsSerialProtocol;
+    EXPECT_EQ(AstrOsInterfaceResponseType::REGISTRATION_SYNC,
+              mapResponseType(AstrOsSerialMessageType::REGISTRATION_SYNC, true));
+    EXPECT_EQ(AstrOsInterfaceResponseType::SET_CONFIG, mapResponseType(AstrOsSerialMessageType::DEPLOY_CONFIG, true));
+    EXPECT_EQ(AstrOsInterfaceResponseType::SAVE_SCRIPT, mapResponseType(AstrOsSerialMessageType::DEPLOY_SCRIPT, true));
+    EXPECT_EQ(AstrOsInterfaceResponseType::SCRIPT_RUN, mapResponseType(AstrOsSerialMessageType::RUN_SCRIPT, true));
+    EXPECT_EQ(AstrOsInterfaceResponseType::PANIC_STOP, mapResponseType(AstrOsSerialMessageType::PANIC_STOP, true));
+    EXPECT_EQ(AstrOsInterfaceResponseType::FORMAT_SD, mapResponseType(AstrOsSerialMessageType::FORMAT_SD, true));
+    EXPECT_EQ(AstrOsInterfaceResponseType::COMMAND, mapResponseType(AstrOsSerialMessageType::RUN_COMMAND, true));
+    EXPECT_EQ(AstrOsInterfaceResponseType::SERVO_TEST, mapResponseType(AstrOsSerialMessageType::SERVO_TEST, true));
+}
+
+TEST(SerialProtocol, MapResponseTypePadawanTable)
+{
+    using namespace AstrOsSerialProtocol;
+    EXPECT_EQ(AstrOsInterfaceResponseType::SEND_CONFIG, mapResponseType(AstrOsSerialMessageType::DEPLOY_CONFIG, false));
+    EXPECT_EQ(AstrOsInterfaceResponseType::SEND_SCRIPT, mapResponseType(AstrOsSerialMessageType::DEPLOY_SCRIPT, false));
+    EXPECT_EQ(AstrOsInterfaceResponseType::SEND_SCRIPT_RUN,
+              mapResponseType(AstrOsSerialMessageType::RUN_SCRIPT, false));
+    EXPECT_EQ(AstrOsInterfaceResponseType::SEND_PANIC_STOP,
+              mapResponseType(AstrOsSerialMessageType::PANIC_STOP, false));
+    EXPECT_EQ(AstrOsInterfaceResponseType::SEND_FORMAT_SD, mapResponseType(AstrOsSerialMessageType::FORMAT_SD, false));
+    EXPECT_EQ(AstrOsInterfaceResponseType::SEND_COMMAND, mapResponseType(AstrOsSerialMessageType::RUN_COMMAND, false));
+    EXPECT_EQ(AstrOsInterfaceResponseType::SEND_SERVO_TEST,
+              mapResponseType(AstrOsSerialMessageType::SERVO_TEST, false));
+}
+
+TEST(SerialProtocol, MapResponseTypePadawanRegistrationIsUnknown)
+{
+    // Quirk preserved from the original handler: REGISTRATION_SYNC has no
+    // padawan-side entry in the lookup table, so it falls through to
+    // UNKNOWN. handleRegistrationSync itself bypasses this lookup and
+    // hardcodes REGISTRATION_SYNC — decode preserves that bypass.
+    EXPECT_EQ(AstrOsInterfaceResponseType::UNKNOWN,
+              AstrOsSerialProtocol::mapResponseType(AstrOsSerialMessageType::REGISTRATION_SYNC, false));
+}
+
+// ---------------- REGISTRATION_SYNC ----------------
+
+TEST(SerialProtocol, RegistrationSyncProducesBroadcastCommand)
+{
+    auto result =
+        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::REGISTRATION_SYNC, "mid", "", true);
+
+    ASSERT_EQ(1u, result.commands.size());
+    EXPECT_TRUE(result.rejects.empty());
+
+    const auto &cmd = result.commands[0];
+    EXPECT_EQ(AstrOsInterfaceResponseType::REGISTRATION_SYNC, cmd.responseType);
+    EXPECT_EQ("mid", cmd.msgId);
+    EXPECT_EQ("", cmd.peerMac);
+    EXPECT_EQ("", cmd.peerName);
+    EXPECT_EQ("", cmd.message);
+}
+
+TEST(SerialProtocol, RegistrationSyncPadawanStillProducesRegistrationSync)
+{
+    // Matches the handleRegistrationSync quirk: the hardcoded SET bypasses
+    // the padawan lookup which would otherwise return UNKNOWN.
+    auto result =
+        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::REGISTRATION_SYNC, "mid", "", false);
+
+    ASSERT_EQ(1u, result.commands.size());
+    EXPECT_EQ(AstrOsInterfaceResponseType::REGISTRATION_SYNC, result.commands[0].responseType);
+}
+
+// ---------------- DEPLOY_CONFIG ----------------
+
+TEST(SerialProtocol, DeployConfigBroadcastMacMapsToSetConfig)
+{
+    const std::string payload = wrapPayload(joinUnits({"00:00:00:00:00:00", "master", "CFG_DATA"}));
+    auto result =
+        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_CONFIG, "mid", payload, true);
+
+    ASSERT_EQ(1u, result.commands.size());
+    EXPECT_TRUE(result.rejects.empty());
+
+    const auto &cmd = result.commands[0];
+    EXPECT_EQ(AstrOsInterfaceResponseType::SET_CONFIG, cmd.responseType);
+    EXPECT_EQ("mid", cmd.msgId);
+    EXPECT_EQ("", cmd.peerMac); // broadcast mac is normalised to empty
+    EXPECT_EQ("CFG_DATA", cmd.message);
+}
+
+TEST(SerialProtocol, DeployConfigSpecificMacMapsToSendConfig)
+{
+    const std::string payload = wrapPayload(joinUnits({"AA:BB:CC:DD:EE:FF", "padawan", "CFG_DATA"}));
+    auto result =
+        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_CONFIG, "mid", payload, true);
+
+    ASSERT_EQ(1u, result.commands.size());
+    EXPECT_TRUE(result.rejects.empty());
+
+    const auto &cmd = result.commands[0];
+    EXPECT_EQ(AstrOsInterfaceResponseType::SEND_CONFIG, cmd.responseType);
+    EXPECT_EQ("AA:BB:CC:DD:EE:FF", cmd.peerMac);
+    EXPECT_EQ("CFG_DATA", cmd.message);
+}
+
+TEST(SerialProtocol, DeployConfigWrongPartCountRejects)
+{
+    // Only 2 parts instead of 3.
+    const std::string payload = wrapPayload(joinUnits({"AA:BB:CC:DD:EE:FF", "padawan"}));
+    auto result =
+        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_CONFIG, "mid", payload, true);
+
+    EXPECT_TRUE(result.commands.empty());
+    ASSERT_EQ(1u, result.rejects.size());
+    EXPECT_EQ(AstrOsSerialProtocol::DecodeRejectReason::WRONG_PART_COUNT, result.rejects[0].reason);
+}
+
+// ---------------- DEPLOY_SCRIPT ----------------
+
+TEST(SerialProtocol, DeployScriptReconstructsScriptPayload)
+{
+    // Per handler: script = msgParts[2] + UNIT_SEPARATOR + msgParts[3].
+    const std::string payload = wrapPayload(joinUnits({"00:00:00:00:00:00", "master", "scriptId", "scriptBody"}));
+    auto result =
+        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_SCRIPT, "mid", payload, true);
+
+    ASSERT_EQ(1u, result.commands.size());
+    EXPECT_TRUE(result.rejects.empty());
+
+    const auto &cmd = result.commands[0];
+    EXPECT_EQ(AstrOsInterfaceResponseType::SAVE_SCRIPT, cmd.responseType);
+
+    const std::string expectedScript = std::string("scriptId") + UNIT_SEPARATOR + "scriptBody";
+    EXPECT_EQ(expectedScript, cmd.message);
+}
+
+TEST(SerialProtocol, DeployScriptSpecificMacRoutesToSendScript)
+{
+    const std::string payload = wrapPayload(joinUnits({"AA:BB:CC:DD:EE:FF", "padawan", "scriptId", "scriptBody"}));
+    auto result =
+        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_SCRIPT, "mid", payload, true);
+
+    ASSERT_EQ(1u, result.commands.size());
+    EXPECT_EQ(AstrOsInterfaceResponseType::SEND_SCRIPT, result.commands[0].responseType);
+    EXPECT_EQ("AA:BB:CC:DD:EE:FF", result.commands[0].peerMac);
+}
+
+TEST(SerialProtocol, DeployScriptWrongPartCountRejects)
+{
+    // 3 parts instead of 4 — malformed script entry.
+    const std::string payload = wrapPayload(joinUnits({"00:00:00:00:00:00", "master", "onlyScript"}));
+    auto result =
+        AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::DEPLOY_SCRIPT, "mid", payload, true);
+
+    EXPECT_TRUE(result.commands.empty());
+    ASSERT_EQ(1u, result.rejects.size());
+    EXPECT_EQ(AstrOsSerialProtocol::DecodeRejectReason::WRONG_PART_COUNT, result.rejects[0].reason);
+}
+
+// ---------------- Basic commands ----------------
+
+struct BasicCommandExpectation
+{
+    AstrOsSerialMessageType type;
+    AstrOsInterfaceResponseType masterResponse;
+    AstrOsInterfaceResponseType padawanResponse;
+    const char *label;
+};
+
+class BasicCommandRoutingFixture : public ::testing::TestWithParam<BasicCommandExpectation>
+{
+};
+
+TEST_P(BasicCommandRoutingFixture, BroadcastRoutesToMasterResponseType)
+{
+    const auto &param = GetParam();
+    const std::string payload = wrapPayload(joinUnits({"00:00:00:00:00:00", "master", "VAL"}));
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(param.type, "mid", payload, true);
+
+    ASSERT_EQ(1u, result.commands.size()) << "type=" << param.label;
+    EXPECT_EQ(param.masterResponse, result.commands[0].responseType) << "type=" << param.label;
+    EXPECT_EQ("", result.commands[0].peerMac);
+    EXPECT_EQ("VAL", result.commands[0].message);
+}
+
+TEST_P(BasicCommandRoutingFixture, SpecificMacRoutesToPadawanResponseType)
+{
+    const auto &param = GetParam();
+    const std::string payload = wrapPayload(joinUnits({"AA:BB:CC:DD:EE:FF", "padawan", "VAL"}));
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(param.type, "mid", payload, true);
+
+    ASSERT_EQ(1u, result.commands.size()) << "type=" << param.label;
+    EXPECT_EQ(param.padawanResponse, result.commands[0].responseType) << "type=" << param.label;
+    EXPECT_EQ("AA:BB:CC:DD:EE:FF", result.commands[0].peerMac);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllBasicTypes, BasicCommandRoutingFixture,
+    ::testing::Values(
+        BasicCommandExpectation{AstrOsSerialMessageType::RUN_SCRIPT, AstrOsInterfaceResponseType::SCRIPT_RUN,
+                                AstrOsInterfaceResponseType::SEND_SCRIPT_RUN, "RUN_SCRIPT"},
+        BasicCommandExpectation{AstrOsSerialMessageType::PANIC_STOP, AstrOsInterfaceResponseType::PANIC_STOP,
+                                AstrOsInterfaceResponseType::SEND_PANIC_STOP, "PANIC_STOP"},
+        BasicCommandExpectation{AstrOsSerialMessageType::FORMAT_SD, AstrOsInterfaceResponseType::FORMAT_SD,
+                                AstrOsInterfaceResponseType::SEND_FORMAT_SD, "FORMAT_SD"},
+        BasicCommandExpectation{AstrOsSerialMessageType::RUN_COMMAND, AstrOsInterfaceResponseType::COMMAND,
+                                AstrOsInterfaceResponseType::SEND_COMMAND, "RUN_COMMAND"},
+        BasicCommandExpectation{AstrOsSerialMessageType::SERVO_TEST, AstrOsInterfaceResponseType::SERVO_TEST,
+                                AstrOsInterfaceResponseType::SEND_SERVO_TEST, "SERVO_TEST"}));
+
+TEST(SerialProtocol, BasicCommandEmptyDestRejects)
+{
+    const std::string payload = wrapPayload(joinUnits({"", "padawan", "VAL"}));
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::RUN_COMMAND, "mid", payload, true);
+
+    EXPECT_TRUE(result.commands.empty());
+    ASSERT_EQ(1u, result.rejects.size());
+    EXPECT_EQ(AstrOsSerialProtocol::DecodeRejectReason::EMPTY_DEST, result.rejects[0].reason);
+}
+
+TEST(SerialProtocol, BasicCommandEmptyValueRejects)
+{
+    // AstrOsStringUtils::splitString pops a single trailing empty token, so
+    // a bare "mac US ctrl US" collapses to 2 parts and lands in the
+    // WRONG_PART_COUNT branch. To hit the EMPTY_VALUE branch we need an
+    // explicit extra trailing separator so one empty survives the pop.
+    std::string entry;
+    entry += "AA:BB:CC:DD:EE:FF";
+    entry += UNIT_SEPARATOR;
+    entry += "padawan";
+    entry += UNIT_SEPARATOR;
+    entry += UNIT_SEPARATOR;
+    const std::string payload = wrapPayload(entry);
+
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::RUN_COMMAND, "mid", payload, true);
+
+    EXPECT_TRUE(result.commands.empty());
+    ASSERT_EQ(1u, result.rejects.size());
+    EXPECT_EQ(AstrOsSerialProtocol::DecodeRejectReason::EMPTY_VALUE, result.rejects[0].reason);
+}
+
+TEST(SerialProtocol, BasicCommandWrongPartCountRejects)
+{
+    const std::string payload = wrapPayload(joinUnits({"AA:BB:CC:DD:EE:FF", "padawan"}));
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::RUN_COMMAND, "mid", payload, true);
+
+    EXPECT_TRUE(result.commands.empty());
+    ASSERT_EQ(1u, result.rejects.size());
+    EXPECT_EQ(AstrOsSerialProtocol::DecodeRejectReason::WRONG_PART_COUNT, result.rejects[0].reason);
+}
+
+// ---------------- Mixed valid + invalid in one message ----------------
+
+TEST(SerialProtocol, MixedValidAndInvalidEntriesCoexist)
+{
+    const std::string good1 = joinUnits({"00:00:00:00:00:00", "master", "v1"});
+    const std::string bad = joinUnits({"", "padawan", "v2"}); // empty dest
+    const std::string good2 = joinUnits({"AA:BB:CC:DD:EE:FF", "padawan2", "v3"});
+    const std::string payload = wrapPayload(joinRecords({good1, bad, good2}));
+
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::RUN_COMMAND, "mid", payload, true);
+
+    ASSERT_EQ(2u, result.commands.size());
+    EXPECT_EQ(AstrOsInterfaceResponseType::COMMAND, result.commands[0].responseType);
+    EXPECT_EQ("v1", result.commands[0].message);
+    EXPECT_EQ(AstrOsInterfaceResponseType::SEND_COMMAND, result.commands[1].responseType);
+    EXPECT_EQ("v3", result.commands[1].message);
+
+    ASSERT_EQ(1u, result.rejects.size());
+    EXPECT_EQ(AstrOsSerialProtocol::DecodeRejectReason::EMPTY_DEST, result.rejects[0].reason);
+}
+
+// ---------------- Unknown type ----------------
+
+TEST(SerialProtocol, UnknownTypeProducesUnknownTypeReject)
+{
+    auto result = AstrOsSerialProtocol::decodeSerialMessage(AstrOsSerialMessageType::UNKNOWN, "mid", "", true);
+
+    EXPECT_TRUE(result.commands.empty());
+    ASSERT_EQ(1u, result.rejects.size());
+    EXPECT_EQ(AstrOsSerialProtocol::DecodeRejectReason::UNKNOWN_TYPE, result.rejects[0].reason);
+}
+
+TEST(SerialProtocol, DescribeRejectReasonReturnsNonNull)
+{
+    using namespace AstrOsSerialProtocol;
+    EXPECT_STRNE("", describeRejectReason(DecodeRejectReason::WRONG_PART_COUNT));
+    EXPECT_STRNE("", describeRejectReason(DecodeRejectReason::EMPTY_DEST));
+    EXPECT_STRNE("", describeRejectReason(DecodeRejectReason::EMPTY_VALUE));
+    EXPECT_STRNE("", describeRejectReason(DecodeRejectReason::UNKNOWN_TYPE));
+}


### PR DESCRIPTION
## Summary

  - Establishes the PURE-lib convention: pure logic lives in sibling libs that compile under `[env:test]` and avoid
  all ESP-IDF/FreeRTOS includes. Foundation pieces: `lib/AstrOsLogging` (fn-ptr logger), `lib/AstrOsUtility_ESP` ESP
  adapter, and a CI purity guard parameterised over a `PURE_LIBS` list.
  - Pilots the pattern on the serial message handler: extracts `lib/AstrOsSerialProtocol` (decoder + response-type map
  rejects at the boundary.
  - `isPathSafe` moves out of `AstrOsStorageManager` into `lib/AstrOsUtility/AstrOsPathUtils` with an out-param reject
   reason — proof-point that the foundation round-trips end-to-end.
  - 42 new native tests: 10 for path-utils reject branches + 27 synthetic decoder cases + 15 **contract tests** that
  feed the decoder verbatim bytes from AstrOs.Server's `message_generator.ts` (all 8 server-produced message types
  plus multi-controller variants).
  - CLAUDE.md gains a PURE/MIXED/HARDWARE-ONLY classification column and a short "Adding a new extracted lib"
  subsection.