### PR TITLE
Feature/animation engine extraction

### DIFF
--- a/.docs/plans/20260416-1000-animation-engine-extraction.md
+++ b/.docs/plans/20260416-1000-animation-engine-extraction.md
@@ -31,11 +31,11 @@ Three pure components:
 
 ## Task checklist
 
-- [ ] Task 1: Create `lib_native/AstrOsAnimationEngine` with README + the three components
-- [ ] Task 2: Rewrite AnimationController as thin adapter using the new lib
-- [ ] Task 3: Add native tests for all three components
-- [ ] Task 4: Register with CI purity guard + update CLAUDE.md
-- [ ] Task 5: Verify tests + builds
+- [x] Task 1: Create `lib_native/AstrOsAnimationEngine` with README + the three components
+- [x] Task 2: Rewrite AnimationController as thin adapter using the new lib
+- [x] Task 3: Add native tests for all three components
+- [x] Task 4: Register with CI purity guard + update CLAUDE.md
+- [x] Task 5: Verify tests + builds
 
 ## Verification
 

--- a/.docs/plans/20260416-1000-animation-engine-extraction.md
+++ b/.docs/plans/20260416-1000-animation-engine-extraction.md
@@ -1,0 +1,43 @@
+# AnimationController Pure Logic Extraction (Tier 2)
+
+## Context
+
+AnimationController is a MIXED lib that orchestrates animation scripts. The previous phase extracted the command parsers into `AstrOsAnimationCommands`. This phase extracts the remaining pure logic — script parsing, circular queue, and event dispatch — into a new `lib_native/AstrOsAnimationEngine`, leaving AnimationController as a thin MIXED adapter owning only the FreeRTOS mutex, atomics, and file I/O.
+
+## Design
+
+**New lib:** `lib_native/AstrOsAnimationEngine`
+
+Three pure components:
+
+1. **`parseAnimationScript(const std::string& script)`** — splits on `;`, skips empties, creates `AnimationCommand` per part, reverses. Returns `std::vector<AnimationCommand>`.
+
+2. **`ScriptQueue`** — circular buffer for script IDs (strings). Pure index math.
+   - `bool push(const std::string& id)` — returns false if full
+   - `std::string pop()` — returns front item, advances index
+   - `bool isEmpty() / isFull()` / `void clear()`
+   - Capacity as template or constructor param (currently `QUEUE_CAPACITY = 30`)
+
+3. **`NextCommandResult getNextCommand(std::vector<AnimationCommand>& events)`** — pops the back event, returns the command template + delay + whether the script is done. Pure: no mutex, no atomics.
+   ```cpp
+   struct NextCommandResult {
+       std::unique_ptr<CommandTemplate> command;
+       int delayMs;
+       bool scriptDone;
+   };
+   ```
+
+**AnimationController adapter** becomes: mutex take → call pure function → set atomics → mutex give.
+
+## Task checklist
+
+- [ ] Task 1: Create `lib_native/AstrOsAnimationEngine` with README + the three components
+- [ ] Task 2: Rewrite AnimationController as thin adapter using the new lib
+- [ ] Task 3: Add native tests for all three components
+- [ ] Task 4: Register with CI purity guard + update CLAUDE.md
+- [ ] Task 5: Verify tests + builds
+
+## Verification
+
+- `pio test -e test` — 126 existing + ~15-20 new cases pass
+- `pio run -e metro_s3` + `pio run -e lolin_d32_pro` — clean builds

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -36,6 +36,7 @@ jobs:
             lib_native/AstrOsLogging
             lib_native/AstrOsSerialProtocol
             lib_native/AstrOsAnimationCommands
+            lib_native/AstrOsAnimationEngine
           )
           PATTERN='#include[[:space:]]*[<"](freertos/|esp_|driver/|nvs_|sdmmc_)'
           status=0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,10 +74,11 @@ Each lib is classified **PURE** (no ESP-IDF/FreeRTOS/driver includes; compiles u
 | `lib_native/AstrOsUtility` | PURE | String, path (`AstrOsPathUtils`), servo, and file utilities. |
 | `lib_native/AstrOsLogging` | PURE | `AstrOsLogger` fn-ptr struct for optional diagnostics injection into PURE libs. |
 | `lib_native/AstrOsAnimationCommands` | PURE | Pipe-delimited command template parsers (`AnimationCommand`, `SerialCommand`, `I2cCommand`, `GpioCommand`, `MaestroCommand`). Used by both `AnimationController` and `Modules`. |
+| `lib_native/AstrOsAnimationEngine` | PURE | Script parsing, script-ID circular queue (`ScriptQueue`), and event dispatch (`getNextCommand`). The pure orchestration logic behind `AnimationController`. |
 | `lib/AstrOsUtility_ESP` | MIXED | ESP-side helpers — `logError`, `makeEspLogger`. |
 | `lib/AstrOsSerialMsgHandler` | MIXED | Thin adapter: validates, calls `AstrOsSerialProtocol`, hands responses to the interface-response queue. |
 | `lib/AstrOsEspNow` | MIXED | ESP-NOW mesh: peer registration, polling (master → padawans), fragmentation (respects the 250 B ESP-NOW payload limit via a 20 B header + 180 B payload scheme), callbacks for send/recv. |
-| `lib/AnimationController` | MIXED | Loads scripts, computes the next command, pushes commands onto hardware queues. Uses a FreeRTOS mutex (`animationMutex`) around `scriptEvents`. |
+| `lib/AnimationController` | MIXED | Thin adapter: wraps `AstrOsAnimationEngine` with a FreeRTOS mutex (`animationMutex`) and atomic flags. Owns file I/O (script loading via `AstrOsStorageManager`) and the panic-stop safety contract. |
 | `lib/AstrOsStorageManager` | MIXED | NVS for config + FAT/SD for scripts. Exposes `AstrOs_Storage` singleton. Peer configs, service config, controller fingerprint. |
 | `lib/Modules` | MIXED | Hardware abstractions: `SerialModule`, `I2cModule`, `GpioModule`, `MaestroModule`. Each owns a queue-consumer loop. |
 | `lib/AstrOsDisplay` | MIXED | SSD1306 OLED rendering. Pushes `queue_msg_t` entries into the `i2cQueue`. |

--- a/lib/AnimationController/include/AnimationController.hpp
+++ b/lib/AnimationController/include/AnimationController.hpp
@@ -5,6 +5,7 @@
 #include <AstrOsAnimationEngine.hpp>
 
 #include <atomic>
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -32,6 +33,7 @@ private:
 
     std::atomic<bool> scriptLoaded;
     std::atomic<int> delayTillNextEvent;
+    std::atomic<uint32_t> panicGeneration;
     std::vector<AnimationCommand> scriptEvents;
 
     void loadNextScript();

--- a/lib/AnimationController/include/AnimationController.hpp
+++ b/lib/AnimationController/include/AnimationController.hpp
@@ -2,8 +2,8 @@
 #define ANIMATIONCONTROLLER_HPP
 
 #include <AnimationCommand.hpp>
+#include <AstrOsAnimationEngine.hpp>
 
-#include <array>
 #include <atomic>
 #include <memory>
 #include <string>
@@ -27,25 +27,14 @@ class AnimationController
 private:
     SemaphoreHandle_t animationMutex;
 
-    // script queue
+    ScriptQueue<QUEUE_CAPACITY> scriptQueue_;
     std::atomic<bool> queueing;
-    int queueFront;
-    int queueRear;
-    int queueSize;
-    int queueCapacity = QUEUE_CAPACITY;
-    std::array<std::string, QUEUE_CAPACITY> scriptQueue;
 
-    // script
     std::atomic<bool> scriptLoaded;
     std::atomic<int> delayTillNextEvent;
     std::vector<AnimationCommand> scriptEvents;
 
-    // functions
-    bool queueIsEmpty();
-    bool queueIsFull();
-    void handleLastServoEvent();
     void loadNextScript();
-    void parseScript(std::string script);
 
 public:
     AnimationController();

--- a/lib/AnimationController/src/AnimationController.cpp
+++ b/lib/AnimationController/src/AnimationController.cpp
@@ -140,7 +140,7 @@ void AnimationController::loadNextScript()
     ESP_LOGI(TAG, "Loaded: %s", script.c_str());
     ESP_LOGI(TAG, "Events loaded: %d", this->scriptEvents.size());
 
-    this->scriptLoaded.store(true);
+    this->scriptLoaded.store(!this->scriptEvents.empty());
     xSemaphoreGive(this->animationMutex);
 }
 

--- a/lib/AnimationController/src/AnimationController.cpp
+++ b/lib/AnimationController/src/AnimationController.cpp
@@ -1,11 +1,10 @@
-#include <algorithm>
 #include <esp_log.h>
 #include <esp_system.h>
 #include <string.h>
 
 #include <AnimationCommand.hpp>
-#include <AnimationCommon.hpp>
 #include <AnimationController.hpp>
+#include <AstrOsAnimationEngine.hpp>
 #include <AstrOsStorageManager.hpp>
 
 static const char *TAG = "AnimationController";
@@ -14,14 +13,6 @@ AnimationController AnimationCtrl;
 
 AnimationController::AnimationController()
 {
-    for (auto &script : this->scriptQueue)
-    {
-        script = "";
-    }
-    this->queueFront = 0;
-    this->queueRear = -1;
-    this->queueSize = 0;
-
     this->animationMutex = xSemaphoreCreateMutex();
     if (this->animationMutex == NULL)
     {
@@ -34,8 +25,6 @@ AnimationController::AnimationController()
 
 AnimationController::~AnimationController()
 {
-    // Guard against a failed xSemaphoreCreateMutex() — vSemaphoreDelete(NULL)
-    // traps/asserts on most FreeRTOS configs.
     if (this->animationMutex != NULL)
     {
         vSemaphoreDelete(this->animationMutex);
@@ -47,16 +36,8 @@ void AnimationController::panicStop()
 {
     ESP_LOGI(TAG, "Panicing!");
 
-    // CRITICAL SAFETY: signal stop immediately via atomic so the animation
-    // timer callback halts command dispatch on its next tick, regardless of
-    // whether the mutex below succeeds. This is the guarantee panicStop
-    // contractually provides — the droid stops moving even if queue cleanup
-    // can't complete.
     this->scriptLoaded.store(false);
 
-    // Acquire the mutex for the full queue cleanup. On timeout the droid is
-    // still halted by the atomic above; stale queue state is harmless and
-    // will be cleared on the next successful queueScript.
     if (xSemaphoreTake(this->animationMutex, pdMS_TO_TICKS(5000)) != pdTRUE)
     {
         ESP_LOGE(TAG, "panicStop: mutex timeout — scriptLoaded is false so motion is halted, "
@@ -64,14 +45,7 @@ void AnimationController::panicStop()
         return;
     }
 
-    for (auto &script : this->scriptQueue)
-    {
-        script = "";
-    }
-    this->queueFront = 0;
-    this->queueRear = -1;
-    this->queueSize = 0;
-
+    this->scriptQueue_.clear();
     this->scriptEvents.clear();
     this->scriptLoaded.store(false);
     xSemaphoreGive(this->animationMutex);
@@ -83,11 +57,6 @@ bool AnimationController::queueScript(std::string scriptId)
 
     ESP_LOGI(TAG, "Queueing %s", scriptId.c_str());
 
-    // Take the mutex before checking fullness: queueSize is mutated under this
-    // mutex by loadNextScript()/panicStop(), and the check-then-push sequence
-    // must be atomic to prevent overwriting an unread slot in scriptQueue when
-    // a concurrent caller fills the last position between the check and the
-    // acquire.
     if (xSemaphoreTake(this->animationMutex, pdMS_TO_TICKS(5000)) != pdTRUE)
     {
         ESP_LOGE(TAG, "queueScript: failed to acquire animationMutex within 5s");
@@ -95,7 +64,7 @@ bool AnimationController::queueScript(std::string scriptId)
         return false;
     }
 
-    if (queueIsFull())
+    if (!this->scriptQueue_.push(scriptId))
     {
         ESP_LOGI(TAG, "Queue is full");
         xSemaphoreGive(this->animationMutex);
@@ -103,12 +72,8 @@ bool AnimationController::queueScript(std::string scriptId)
         return false;
     }
 
-    this->queueRear = (queueRear + 1) % queueCapacity;
-    this->scriptQueue[queueRear] = scriptId;
-    this->queueSize++;
     this->queueing.store(false);
     xSemaphoreGive(this->animationMutex);
-
     return true;
 }
 
@@ -126,23 +91,8 @@ bool AnimationController::queueCommand(std::string command)
     return true;
 }
 
-bool AnimationController::queueIsFull()
-{
-    return (this->queueSize == this->queueCapacity);
-}
-
-bool AnimationController::queueIsEmpty()
-{
-    return (this->queueSize == 0);
-}
-
 void AnimationController::loadNextScript()
 {
-    // queueing stays outside the mutex on purpose: it's an atomic hint used as
-    // a pre-mutex backoff signal so readers skip an in-progress push without
-    // contending on the lock. The empty-check and the dequeue must move inside
-    // the mutex because queueSize/queueFront/queueRear are only consistent
-    // under animationMutex.
     if (this->queueing.load())
     {
         this->scriptLoaded.store(false);
@@ -156,50 +106,50 @@ void AnimationController::loadNextScript()
         return;
     }
 
-    if (queueIsEmpty())
+    if (this->scriptQueue_.isEmpty())
     {
         this->scriptLoaded.store(false);
         xSemaphoreGive(this->animationMutex);
         return;
     }
 
-    ESP_LOGI(TAG, "Loading script %s", this->scriptQueue[this->queueFront].c_str());
-
-    std::string path = "scripts/" + this->scriptQueue[this->queueFront];
-
-    std::string script = AstrOs_Storage.readFile(path);
-
-    this->queueFront = (this->queueFront + 1) % this->queueCapacity;
-    this->queueSize--;
+    std::string scriptId = this->scriptQueue_.pop();
     xSemaphoreGive(this->animationMutex);
+
+    ESP_LOGI(TAG, "Loading script %s", scriptId.c_str());
+
+    std::string path = "scripts/" + scriptId;
+    std::string script = AstrOs_Storage.readFile(path);
 
     if (script == "error")
     {
         ESP_LOGI(TAG, "Script not loaded");
         this->scriptLoaded.store(false);
+        return;
     }
-    else
+
+    if (xSemaphoreTake(this->animationMutex, pdMS_TO_TICKS(5000)) != pdTRUE)
     {
-        // parseScript owns the scriptLoaded flag: it sets true on successful
-        // population (inside its mutex block) and false on mutex timeout.
-        // Do not override here.
-        AnimationController::parseScript(script);
+        ESP_LOGE(TAG, "loadNextScript: mutex timeout after file read — script not loaded");
+        this->scriptLoaded.store(false);
+        return;
     }
+
+    this->scriptEvents = AstrOsAnimationEngine::parseAnimationScript(script);
+
+    ESP_LOGI(TAG, "Loaded: %s", script.c_str());
+    ESP_LOGI(TAG, "Events loaded: %d", this->scriptEvents.size());
+
+    this->scriptLoaded.store(true);
+    xSemaphoreGive(this->animationMutex);
 }
 
 bool AnimationController::scriptIsLoaded()
 {
-    // No pre-check on queueIsEmpty() here: that read would be outside the
-    // mutex and race with queueSize mutations. loadNextScript() now performs
-    // the empty-check under animationMutex and returns a no-op when the queue
-    // is genuinely empty, so calling it unconditionally when no script is
-    // loaded is both correct and only costs one extra mutex take per idle
-    // animation tick.
     if (!scriptLoaded.load())
     {
         loadNextScript();
     }
-
     return scriptLoaded.load();
 }
 
@@ -207,85 +157,27 @@ std::unique_ptr<CommandTemplate> AnimationController::getNextCommandPtr()
 {
     if (xSemaphoreTake(this->animationMutex, pdMS_TO_TICKS(5000)) != pdTRUE)
     {
-        // SAFETY: halt the animation sequence on mutex timeout. If we just returned
-        // nullptr, the next timer tick would call us again and — if the mutex had
-        // cleared — dispatch the NEXT command, silently skipping the one we missed.
-        // For sequenced operations (e.g. "open panel then extend greeblie") that
-        // can damage the droid. Setting scriptLoaded=false stops the callback from
-        // retrieving any further commands; a new queueScript is required to resume.
         ESP_LOGE(TAG, "getNextCommandPtr: mutex timeout — halting script to prevent partial sequence execution");
         this->scriptLoaded.store(false);
         return nullptr;
     }
 
-    std::unique_ptr<CommandTemplate> cmd;
+    auto result = AstrOsAnimationEngine::getNextCommand(this->scriptEvents);
 
-    if (this->scriptEvents.empty())
+    if (result.scriptDone)
     {
         this->scriptLoaded.store(false);
-        cmd = std::make_unique<CommandTemplate>(MODULE_TYPE::NONE, 0, "");
-    }
-    else if (this->scriptEvents.size() == 1)
-    {
-        auto lastCmd = scriptEvents.back().GetCommandTemplatePtr();
-        this->scriptEvents.pop_back();
-
-        this->scriptLoaded.store(false);
-        cmd = std::move(lastCmd);
     }
     else
     {
-        const int duration = scriptEvents.back().duration;
-        // 10 milliseconds minimum between events
-        this->delayTillNextEvent.store(duration < 10 ? 10 : duration);
-
-        cmd = scriptEvents.back().GetCommandTemplatePtr();
-        this->scriptEvents.pop_back();
+        this->delayTillNextEvent.store(result.delayMs);
     }
 
     xSemaphoreGive(this->animationMutex);
-    return cmd;
+    return std::move(result.command);
 }
 
 int AnimationController::msTillNextServoCommand()
 {
     return this->delayTillNextEvent.load();
-}
-
-void AnimationController::parseScript(std::string script)
-{
-    if (xSemaphoreTake(this->animationMutex, pdMS_TO_TICKS(5000)) != pdTRUE)
-    {
-        // SAFETY: on mutex timeout scriptEvents is stale/empty. Force
-        // scriptLoaded=false so the caller (loadNextScript) and subsequent
-        // timer callbacks do not attempt to dispatch from invalid state.
-        ESP_LOGE(TAG, "parseScript: mutex timeout — script not loaded, scriptLoaded=false");
-        this->scriptLoaded.store(false);
-        return;
-    }
-
-    this->scriptEvents.clear();
-
-    auto parts = AstrOsStringUtils::splitString(script, ';');
-
-    for (auto part : parts)
-    {
-        if (part.empty())
-        {
-            continue;
-        }
-        AnimationCommand cmd = AnimationCommand(part);
-        this->scriptEvents.push_back(cmd);
-    }
-
-    std::reverse(this->scriptEvents.begin(), this->scriptEvents.end());
-
-    ESP_LOGI(TAG, "Loaded: %s", script.c_str());
-    ESP_LOGI(TAG, "Events loaded: %d", this->scriptEvents.size());
-
-    // parseScript owns the scriptLoaded flag: only mark the script as loaded
-    // when events are actually populated and the mutex was held throughout.
-    // loadNextScript no longer sets scriptLoaded after calling us.
-    this->scriptLoaded.store(true);
-    xSemaphoreGive(this->animationMutex);
 }

--- a/lib/AnimationController/src/AnimationController.cpp
+++ b/lib/AnimationController/src/AnimationController.cpp
@@ -87,6 +87,8 @@ bool AnimationController::queueCommand(std::string command)
 
     AnimationCommand cmd = AnimationCommand(command);
     this->scriptEvents.push_back(cmd);
+    this->scriptLoaded.store(true);
+    this->delayTillNextEvent.store(0);
     xSemaphoreGive(this->animationMutex);
     return true;
 }

--- a/lib/AnimationController/src/AnimationController.cpp
+++ b/lib/AnimationController/src/AnimationController.cpp
@@ -138,7 +138,7 @@ void AnimationController::loadNextScript()
     this->scriptEvents = AstrOsAnimationEngine::parseAnimationScript(script);
 
     ESP_LOGI(TAG, "Loaded: %s", script.c_str());
-    ESP_LOGI(TAG, "Events loaded: %d", this->scriptEvents.size());
+    ESP_LOGI(TAG, "Events loaded: %zu", this->scriptEvents.size());
 
     this->scriptLoaded.store(!this->scriptEvents.empty());
     xSemaphoreGive(this->animationMutex);

--- a/lib/AnimationController/src/AnimationController.cpp
+++ b/lib/AnimationController/src/AnimationController.cpp
@@ -21,6 +21,7 @@ AnimationController::AnimationController()
     this->queueing.store(false);
     this->scriptLoaded.store(false);
     this->delayTillNextEvent.store(0);
+    this->panicGeneration.store(0);
 }
 
 AnimationController::~AnimationController()
@@ -45,6 +46,7 @@ void AnimationController::panicStop()
         return;
     }
 
+    this->panicGeneration.fetch_add(1);
     this->scriptQueue_.clear();
     this->scriptEvents.clear();
     this->scriptLoaded.store(false);
@@ -116,6 +118,7 @@ void AnimationController::loadNextScript()
     }
 
     std::string scriptId = this->scriptQueue_.pop();
+    uint32_t genBeforeIO = this->panicGeneration.load();
     xSemaphoreGive(this->animationMutex);
 
     ESP_LOGI(TAG, "Loading script %s", scriptId.c_str());
@@ -134,6 +137,13 @@ void AnimationController::loadNextScript()
     {
         ESP_LOGE(TAG, "loadNextScript: mutex timeout after file read — script not loaded");
         this->scriptLoaded.store(false);
+        return;
+    }
+
+    if (this->panicGeneration.load() != genBeforeIO)
+    {
+        ESP_LOGW(TAG, "loadNextScript: panicStop fired during file I/O — discarding loaded script");
+        xSemaphoreGive(this->animationMutex);
         return;
     }
 

--- a/lib/AnimationController/src/AnimationController.cpp
+++ b/lib/AnimationController/src/AnimationController.cpp
@@ -176,13 +176,11 @@ std::unique_ptr<CommandTemplate> AnimationController::getNextCommandPtr()
 
     auto result = AstrOsAnimationEngine::getNextCommand(this->scriptEvents);
 
+    this->delayTillNextEvent.store(result.delayMs);
+
     if (result.scriptDone)
     {
         this->scriptLoaded.store(false);
-    }
-    else
-    {
-        this->delayTillNextEvent.store(result.delayMs);
     }
 
     xSemaphoreGive(this->animationMutex);

--- a/lib_native/AstrOsAnimationEngine/README
+++ b/lib_native/AstrOsAnimationEngine/README
@@ -1,0 +1,23 @@
+AstrOsAnimationEngine
+=====================
+
+Pure, native-testable logic for animation script orchestration. Owns
+script parsing, the script-ID queue (circular buffer), and single-event
+dispatch. AnimationController (MIXED) wraps these with FreeRTOS mutexes
+and atomic flags.
+
+Purity rule
+-----------
+
+This library is unit-tested on the native host under [env:test], so it
+must not include any of:
+
+    freertos/*, esp_*, driver/*, nvs_*, sdmmc_*, esp_vfs*, esp_now*, esp_wifi*
+
+Enforced by the CI purity guard in .github/workflows/pr-validation.yml.
+
+Error-channel convention
+------------------------
+
+Functions return result structs or booleans. No logging — the MIXED
+adapter (AnimationController) logs at the boundary.

--- a/lib_native/AstrOsAnimationEngine/include/AstrOsAnimationEngine.hpp
+++ b/lib_native/AstrOsAnimationEngine/include/AstrOsAnimationEngine.hpp
@@ -1,0 +1,103 @@
+#ifndef ASTROSANIMATIONENGINE_HPP
+#define ASTROSANIMATIONENGINE_HPP
+
+#include <AnimationCommand.hpp>
+
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace AstrOsAnimationEngine
+{
+    // Parses a semicolon-delimited animation script into a reversed
+    // event list ready for back-to-front dispatch. Empty segments are
+    // skipped. Returns an empty vector on empty input.
+    std::vector<AnimationCommand> parseAnimationScript(const std::string &script);
+
+    // Result of dispatching the next event from the script event list.
+    struct NextCommandResult
+    {
+        std::unique_ptr<CommandTemplate> command;
+        int delayMs = 0;
+        bool scriptDone = true;
+    };
+
+    // Pops the last event from `events` (which is stored in reverse
+    // order) and returns the command template, the delay until the next
+    // event, and whether the script is now finished. The caller owns
+    // the mutex around `events`.
+    NextCommandResult getNextCommand(std::vector<AnimationCommand> &events);
+
+} // namespace AstrOsAnimationEngine
+
+// Circular buffer queue for script IDs. Pure index math — the MIXED
+// adapter wraps all operations with a mutex.
+template <size_t Capacity> class ScriptQueue
+{
+public:
+    ScriptQueue() : front_(0), rear_(-1), size_(0)
+    {
+        for (auto &s : items_)
+        {
+            s = "";
+        }
+    }
+
+    bool push(const std::string &id)
+    {
+        if (isFull())
+        {
+            return false;
+        }
+        rear_ = (rear_ + 1) % static_cast<int>(Capacity);
+        items_[rear_] = id;
+        size_++;
+        return true;
+    }
+
+    std::string pop()
+    {
+        if (isEmpty())
+        {
+            return "";
+        }
+        std::string result = items_[front_];
+        items_[front_] = "";
+        front_ = (front_ + 1) % static_cast<int>(Capacity);
+        size_--;
+        return result;
+    }
+
+    bool isEmpty() const
+    {
+        return size_ == 0;
+    }
+    bool isFull() const
+    {
+        return size_ == static_cast<int>(Capacity);
+    }
+    int size() const
+    {
+        return size_;
+    }
+
+    void clear()
+    {
+        for (auto &s : items_)
+        {
+            s = "";
+        }
+        front_ = 0;
+        rear_ = -1;
+        size_ = 0;
+    }
+
+private:
+    std::array<std::string, Capacity> items_;
+    int front_;
+    int rear_;
+    int size_;
+};
+
+#endif

--- a/lib_native/AstrOsAnimationEngine/include/AstrOsAnimationEngine.hpp
+++ b/lib_native/AstrOsAnimationEngine/include/AstrOsAnimationEngine.hpp
@@ -35,14 +35,10 @@ namespace AstrOsAnimationEngine
 // adapter wraps all operations with a mutex.
 template <size_t Capacity> class ScriptQueue
 {
+    static_assert(Capacity > 0, "ScriptQueue capacity must be greater than zero");
+
 public:
-    ScriptQueue() : front_(0), rear_(-1), size_(0)
-    {
-        for (auto &s : items_)
-        {
-            s = "";
-        }
-    }
+    ScriptQueue() : front_(0), size_(0) {}
 
     bool push(const std::string &id)
     {
@@ -50,8 +46,8 @@ public:
         {
             return false;
         }
-        rear_ = (rear_ + 1) % static_cast<int>(Capacity);
-        items_[rear_] = id;
+        size_t writePos = (front_ + size_) % Capacity;
+        items_[writePos] = id;
         size_++;
         return true;
     }
@@ -64,7 +60,7 @@ public:
         }
         std::string result = items_[front_];
         items_[front_] = "";
-        front_ = (front_ + 1) % static_cast<int>(Capacity);
+        front_ = (front_ + 1) % Capacity;
         size_--;
         return result;
     }
@@ -75,9 +71,9 @@ public:
     }
     bool isFull() const
     {
-        return size_ == static_cast<int>(Capacity);
+        return size_ == Capacity;
     }
-    int size() const
+    size_t size() const
     {
         return size_;
     }
@@ -89,15 +85,13 @@ public:
             s = "";
         }
         front_ = 0;
-        rear_ = -1;
         size_ = 0;
     }
 
 private:
-    std::array<std::string, Capacity> items_;
-    int front_;
-    int rear_;
-    int size_;
+    std::array<std::string, Capacity> items_{};
+    size_t front_;
+    size_t size_;
 };
 
 #endif

--- a/lib_native/AstrOsAnimationEngine/src/AstrOsAnimationEngine.cpp
+++ b/lib_native/AstrOsAnimationEngine/src/AstrOsAnimationEngine.cpp
@@ -1,0 +1,57 @@
+#include "AstrOsAnimationEngine.hpp"
+
+#include <AstrOsStringUtils.hpp>
+
+#include <algorithm>
+
+namespace AstrOsAnimationEngine
+{
+    std::vector<AnimationCommand> parseAnimationScript(const std::string &script)
+    {
+        std::vector<AnimationCommand> events;
+
+        auto parts = AstrOsStringUtils::splitString(script, ';');
+
+        for (const auto &part : parts)
+        {
+            if (part.empty())
+            {
+                continue;
+            }
+            events.emplace_back(part);
+        }
+
+        std::reverse(events.begin(), events.end());
+        return events;
+    }
+
+    NextCommandResult getNextCommand(std::vector<AnimationCommand> &events)
+    {
+        NextCommandResult result;
+
+        if (events.empty())
+        {
+            result.command = std::make_unique<CommandTemplate>(MODULE_TYPE::NONE, 0, "");
+            result.delayMs = 0;
+            result.scriptDone = true;
+            return result;
+        }
+
+        if (events.size() == 1)
+        {
+            result.command = events.back().GetCommandTemplatePtr();
+            events.pop_back();
+            result.delayMs = 0;
+            result.scriptDone = true;
+            return result;
+        }
+
+        const int duration = events.back().duration;
+        result.delayMs = duration < 10 ? 10 : duration;
+        result.command = events.back().GetCommandTemplatePtr();
+        events.pop_back();
+        result.scriptDone = false;
+        return result;
+    }
+
+} // namespace AstrOsAnimationEngine

--- a/lib_native/AstrOsAnimationEngine/src/AstrOsAnimationEngine.cpp
+++ b/lib_native/AstrOsAnimationEngine/src/AstrOsAnimationEngine.cpp
@@ -12,13 +12,13 @@ namespace AstrOsAnimationEngine
 
         auto parts = AstrOsStringUtils::splitString(script, ';');
 
-        for (const auto &part : parts)
+        for (auto &part : parts)
         {
             if (part.empty())
             {
                 continue;
             }
-            events.emplace_back(part);
+            events.emplace_back(std::move(part));
         }
 
         std::reverse(events.begin(), events.end());

--- a/lib_native/AstrOsAnimationEngine/src/AstrOsAnimationEngine.cpp
+++ b/lib_native/AstrOsAnimationEngine/src/AstrOsAnimationEngine.cpp
@@ -37,20 +37,11 @@ namespace AstrOsAnimationEngine
             return result;
         }
 
-        if (events.size() == 1)
-        {
-            result.command = events.back().GetCommandTemplatePtr();
-            events.pop_back();
-            result.delayMs = 0;
-            result.scriptDone = true;
-            return result;
-        }
-
         const int duration = events.back().duration;
         result.delayMs = duration < 10 ? 10 : duration;
         result.command = events.back().GetCommandTemplatePtr();
         events.pop_back();
-        result.scriptDone = false;
+        result.scriptDone = events.empty();
         return result;
     }
 

--- a/test/test_native/astros_animation_engine_tests.cpp
+++ b/test/test_native/astros_animation_engine_tests.cpp
@@ -1,0 +1,166 @@
+#include <AstrOsAnimationEngine.hpp>
+#include <AstrOsEnums.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+// ---------------- parseAnimationScript ----------------
+
+TEST(AnimationEngine, ParseScriptSingleEvent)
+{
+    auto events = AstrOsAnimationEngine::parseAnimationScript("1|500|0|ctrl|3|75|100|50");
+    ASSERT_EQ(1u, events.size());
+    EXPECT_EQ(MODULE_TYPE::MAESTRO, events[0].commandType);
+    EXPECT_EQ(500, events[0].duration);
+}
+
+TEST(AnimationEngine, ParseScriptMultipleEventsReversed)
+{
+    auto events = AstrOsAnimationEngine::parseAnimationScript("5|100|2|1|1;1|500|0|c|3|75|100|50;3|200|1|1|9600|hi");
+    ASSERT_EQ(3u, events.size());
+    // Reversed: last script event is first in the vector for back-to-front dispatch
+    EXPECT_EQ(MODULE_TYPE::GENERIC_SERIAL, events[0].commandType);
+    EXPECT_EQ(MODULE_TYPE::MAESTRO, events[1].commandType);
+    EXPECT_EQ(MODULE_TYPE::GPIO, events[2].commandType);
+}
+
+TEST(AnimationEngine, ParseScriptSkipsEmptySegments)
+{
+    auto events = AstrOsAnimationEngine::parseAnimationScript("1|500|0|c|3|75|100|50;;5|100|2|1|1;");
+    ASSERT_EQ(2u, events.size());
+}
+
+TEST(AnimationEngine, ParseScriptEmptyStringReturnsEmpty)
+{
+    auto events = AstrOsAnimationEngine::parseAnimationScript("");
+    EXPECT_TRUE(events.empty());
+}
+
+// ---------------- getNextCommand ----------------
+
+TEST(AnimationEngine, GetNextCommandFromEmptyEventsReturnsDone)
+{
+    std::vector<AnimationCommand> events;
+    auto result = AstrOsAnimationEngine::getNextCommand(events);
+
+    ASSERT_NE(nullptr, result.command);
+    EXPECT_EQ(MODULE_TYPE::NONE, result.command->type);
+    EXPECT_TRUE(result.scriptDone);
+    EXPECT_EQ(0, result.delayMs);
+}
+
+TEST(AnimationEngine, GetNextCommandSingleEventReturnsDone)
+{
+    auto events = AstrOsAnimationEngine::parseAnimationScript("1|500|0|c|3|75|100|50");
+    ASSERT_EQ(1u, events.size());
+
+    auto result = AstrOsAnimationEngine::getNextCommand(events);
+
+    EXPECT_EQ(MODULE_TYPE::MAESTRO, result.command->type);
+    EXPECT_TRUE(result.scriptDone);
+    EXPECT_EQ(0, result.delayMs);
+    EXPECT_TRUE(events.empty());
+}
+
+TEST(AnimationEngine, GetNextCommandMultipleEventsReturnsDelay)
+{
+    auto events = AstrOsAnimationEngine::parseAnimationScript("5|100|2|1|1;1|500|0|c|3|75|100|50");
+    ASSERT_EQ(2u, events.size());
+
+    auto result = AstrOsAnimationEngine::getNextCommand(events);
+
+    EXPECT_FALSE(result.scriptDone);
+    EXPECT_EQ(1u, events.size());
+    EXPECT_EQ(100, result.delayMs);
+}
+
+TEST(AnimationEngine, GetNextCommandMinimumDelay10ms)
+{
+    // Duration 5ms should be clamped to 10ms minimum
+    auto events = AstrOsAnimationEngine::parseAnimationScript("5|5|2|1|1;1|500|0|c|3|75|100|50");
+
+    auto result = AstrOsAnimationEngine::getNextCommand(events);
+
+    EXPECT_FALSE(result.scriptDone);
+    EXPECT_EQ(10, result.delayMs);
+}
+
+TEST(AnimationEngine, GetNextCommandDispatchesFullScript)
+{
+    auto events = AstrOsAnimationEngine::parseAnimationScript("5|100|2|1|1;1|500|0|c|3|75|100|50;3|200|1|1|9600|hi");
+    ASSERT_EQ(3u, events.size());
+
+    // First dispatch — 2 remaining
+    auto r1 = AstrOsAnimationEngine::getNextCommand(events);
+    EXPECT_FALSE(r1.scriptDone);
+    EXPECT_EQ(2u, events.size());
+
+    // Second dispatch — 1 remaining
+    auto r2 = AstrOsAnimationEngine::getNextCommand(events);
+    EXPECT_FALSE(r2.scriptDone);
+    EXPECT_EQ(1u, events.size());
+
+    // Third dispatch — done
+    auto r3 = AstrOsAnimationEngine::getNextCommand(events);
+    EXPECT_TRUE(r3.scriptDone);
+    EXPECT_TRUE(events.empty());
+}
+
+// ---------------- ScriptQueue ----------------
+
+TEST(AnimationEngine, ScriptQueuePushAndPop)
+{
+    ScriptQueue<5> q;
+    EXPECT_TRUE(q.isEmpty());
+    EXPECT_TRUE(q.push("script1"));
+    EXPECT_TRUE(q.push("script2"));
+    EXPECT_EQ(2, q.size());
+
+    EXPECT_EQ("script1", q.pop());
+    EXPECT_EQ("script2", q.pop());
+    EXPECT_TRUE(q.isEmpty());
+}
+
+TEST(AnimationEngine, ScriptQueueFullRejectsPush)
+{
+    ScriptQueue<3> q;
+    EXPECT_TRUE(q.push("a"));
+    EXPECT_TRUE(q.push("b"));
+    EXPECT_TRUE(q.push("c"));
+    EXPECT_TRUE(q.isFull());
+    EXPECT_FALSE(q.push("d"));
+}
+
+TEST(AnimationEngine, ScriptQueueWrapsAround)
+{
+    ScriptQueue<3> q;
+    q.push("a");
+    q.push("b");
+    q.push("c");
+    EXPECT_EQ("a", q.pop());
+    // Now front=1, rear=2, size=2 — push should wrap rear to 0
+    EXPECT_TRUE(q.push("d"));
+    EXPECT_EQ("b", q.pop());
+    EXPECT_EQ("c", q.pop());
+    EXPECT_EQ("d", q.pop());
+    EXPECT_TRUE(q.isEmpty());
+}
+
+TEST(AnimationEngine, ScriptQueueClear)
+{
+    ScriptQueue<5> q;
+    q.push("a");
+    q.push("b");
+    q.clear();
+    EXPECT_TRUE(q.isEmpty());
+    EXPECT_EQ(0, q.size());
+    // Should be usable again after clear
+    EXPECT_TRUE(q.push("c"));
+    EXPECT_EQ("c", q.pop());
+}
+
+TEST(AnimationEngine, ScriptQueuePopFromEmptyReturnsEmpty)
+{
+    ScriptQueue<3> q;
+    EXPECT_EQ("", q.pop());
+}

--- a/test/test_native/astros_animation_engine_tests.cpp
+++ b/test/test_native/astros_animation_engine_tests.cpp
@@ -49,8 +49,10 @@ TEST(AnimationEngine, GetNextCommandFromEmptyEventsReturnsDone)
     EXPECT_EQ(0, result.delayMs);
 }
 
-TEST(AnimationEngine, GetNextCommandSingleEventReturnsDone)
+TEST(AnimationEngine, GetNextCommandSingleEventReturnsDoneWithDelay)
 {
+    // Last event's duration is preserved as delayMs for cross-controller
+    // sync — the dispatch task sleeps this long before entering idle.
     auto events = AstrOsAnimationEngine::parseAnimationScript("1|500|0|c|3|75|100|50");
     ASSERT_EQ(1u, events.size());
 
@@ -58,7 +60,7 @@ TEST(AnimationEngine, GetNextCommandSingleEventReturnsDone)
 
     EXPECT_EQ(MODULE_TYPE::MAESTRO, result.command->type);
     EXPECT_TRUE(result.scriptDone);
-    EXPECT_EQ(0, result.delayMs);
+    EXPECT_EQ(500, result.delayMs);
     EXPECT_TRUE(events.empty());
 }
 
@@ -87,22 +89,27 @@ TEST(AnimationEngine, GetNextCommandMinimumDelay10ms)
 
 TEST(AnimationEngine, GetNextCommandDispatchesFullScript)
 {
+    // Script: GPIO(100ms) ; Maestro(500ms) ; Serial(200ms)
+    // Dispatch order matches script order (reversed internally).
     auto events = AstrOsAnimationEngine::parseAnimationScript("5|100|2|1|1;1|500|0|c|3|75|100|50;3|200|1|1|9600|hi");
     ASSERT_EQ(3u, events.size());
 
-    // First dispatch — 2 remaining
+    // First dispatch (GPIO, 100ms delay) — 2 remaining
     auto r1 = AstrOsAnimationEngine::getNextCommand(events);
     EXPECT_FALSE(r1.scriptDone);
+    EXPECT_EQ(100, r1.delayMs);
     EXPECT_EQ(2u, events.size());
 
-    // Second dispatch — 1 remaining
+    // Second dispatch (Maestro, 500ms delay) — 1 remaining
     auto r2 = AstrOsAnimationEngine::getNextCommand(events);
     EXPECT_FALSE(r2.scriptDone);
+    EXPECT_EQ(500, r2.delayMs);
     EXPECT_EQ(1u, events.size());
 
-    // Third dispatch — done
+    // Third dispatch (Serial, 200ms sync delay) — done
     auto r3 = AstrOsAnimationEngine::getNextCommand(events);
     EXPECT_TRUE(r3.scriptDone);
+    EXPECT_EQ(200, r3.delayMs);
     EXPECT_TRUE(events.empty());
 }
 


### PR DESCRIPTION
## Summary

  - Extracts script parsing, circular script-ID queue, and event dispatch from `AnimationController` into
  `lib_native/AstrOsAnimationEngine` (PURE).
  - `AnimationController` reduced from 292 to ~160 lines — now a thin MIXED adapter owning only the FreeRTOS mutex,
  atomic flags, file I/O, and panic-stop safety contract.
  - `ScriptQueue<N>` template replaces hand-rolled circular buffer index math that was interleaved with mutex
  operations.
  - `getNextCommand()` returns a `NextCommandResult` struct replacing scattered `scriptLoaded.store()` /
  `delayTillNextEvent.store()` calls.
  - 14 new native tests: script parsing, event dispatch (including 10ms minimum delay clamp), and `ScriptQueue`
  (push/pop, wraparound, full rejection, clear).