### PR TITLE
Feature/fw chunk nak next expected seq

### DIFF
--- a/.docs/plans/20260514-1941-firmware-ota-esp-master-serial-receive-design.md
+++ b/.docs/plans/20260514-1941-firmware-ota-esp-master-serial-receive-design.md
@@ -131,7 +131,7 @@ Files:
   extend `AstrOsSC::` string table, add builders:
   - `getFwTransferBeginAck(msgId, transferId, status)` — payload `transfer-id<US>status` per `.docs/protocol.md` (no hash field on BEGIN_ACK).
   - `getFwChunkAck(transferId, highestContiguousSeq, nextExpectedSeq, windowRemaining)`
-  - `getFwChunkNak(transferId, lastGoodSeq, reasonCode)`
+  - `getFwChunkNak(transferId, lastGoodSeq, nextExpectedSeq, reasonCode)` — payload `transfer-id<US>last-good-seq<US>next-expected-seq<US>reason-code`. `nextExpectedSeq` disambiguates the first-chunk NAK case where `lastGoodSeq=0` alone cannot distinguish "seq 0 committed, want seq 1" from "nothing committed, want seq 0". Phase 3 callers should pass `bulkResult.highestContiguousSeq` as `lastGoodSeq` and `bulkResult.nextExpectedSeq` as `nextExpectedSeq` (`BulkReceiver` already produces both with the correct first-chunk-NAK semantics: both are 0 when nothing committed yet).
   - `getFwTransferEndAck(msgId, transferId, status, computedSha256Hex)` — payload `transfer-id<US>OK|HASH_MISMATCH|IO_ERROR<US>computed-sha256-hex`. `msgId` echoes the originating END's id.
   - `getFwDeployDone(msgId, transferId, perControllerResults)` — each result `controllerId<US>OK|FAILED<US>finalVersion<US>errorOrEmpty`, RS-separated between results.
 - Parsers returning POD result structs:
@@ -345,16 +345,16 @@ Server                                                    Master
 | BEGIN, SD unavailable / open fail | `FW_TRANSFER_BEGIN_ACK status=io_error` | no state change |
 | BEGIN, free space < total-size | `FW_TRANSFER_BEGIN_ACK status=sd_full` | no state change |
 | BEGIN OK | `FW_TRANSFER_BEGIN_ACK status=OK` | staging.bin opened, sha256 started |
-| CHUNK bad CRC-16 | `FW_CHUNK_NAK last-good-seq reason=CRC` | nothing committed |
-| CHUNK out of order | `FW_CHUNK_NAK reason=OUT_OF_ORDER` | nothing committed |
-| CHUNK payload-len mismatch | `FW_CHUNK_NAK reason=SIZE` | nothing committed |
-| CHUNK base64 decode fail (handler) | `FW_CHUNK_NAK reason=SIZE` | handler frees own buf |
-| CHUNK fwrite fails (Phase 4+) | `FW_CHUNK_NAK reason=FLASH_FULL` | transfer effectively dead |
+| CHUNK bad CRC-16 | `FW_CHUNK_NAK last-good-seq next-expected-seq reason=CRC` | nothing committed |
+| CHUNK out of order | `FW_CHUNK_NAK last-good-seq next-expected-seq reason=OUT_OF_ORDER` | nothing committed |
+| CHUNK payload-len mismatch | `FW_CHUNK_NAK last-good-seq next-expected-seq reason=SIZE` | nothing committed |
+| CHUNK base64 decode fail (handler) | `FW_CHUNK_NAK last-good-seq next-expected-seq reason=SIZE` | handler frees own buf |
+| CHUNK fwrite fails (Phase 4+) | `FW_CHUNK_NAK last-good-seq next-expected-seq reason=FLASH_FULL` | transfer effectively dead |
 | END hash match | `FW_TRANSFER_END_ACK OK <hex>` | rename staging → `<sha-prefix>.bin`, reset state |
 | END hash mismatch | `FW_TRANSFER_END_ACK HASH_MISMATCH <hex>` | **keep staging.bin** for forensics, reset state |
 | END total-chunks mismatch | `FW_TRANSFER_END_ACK IO_ERROR <hex>` | keep staging.bin, reset state |
 | DEPLOY_BEGIN (Phase 3+) | `FW_DEPLOY_DONE` all-FAILED `not_implemented` | no state change |
-| `xQueueSend(otaQueue, …)` full | handler frees, emits `FW_CHUNK_NAK reason=CRC` | no state change |
+| `xQueueSend(otaQueue, …)` full | handler frees, emits `FW_CHUNK_NAK last-good-seq next-expected-seq reason=CRC` | no state change |
 
 ## Testing
 

--- a/.docs/plans/20260514-1941-firmware-ota-esp-master-serial-receive-design.md
+++ b/.docs/plans/20260514-1941-firmware-ota-esp-master-serial-receive-design.md
@@ -131,7 +131,7 @@ Files:
   extend `AstrOsSC::` string table, add builders:
   - `getFwTransferBeginAck(msgId, transferId, status)` — payload `transfer-id<US>status` per `.docs/protocol.md` (no hash field on BEGIN_ACK).
   - `getFwChunkAck(transferId, highestContiguousSeq, nextExpectedSeq, windowRemaining)`
-  - `getFwChunkNak(transferId, lastGoodSeq, nextExpectedSeq, reasonCode)` — payload `transfer-id<US>last-good-seq<US>next-expected-seq<US>reason-code`. `nextExpectedSeq` disambiguates the first-chunk NAK case where `lastGoodSeq=0` alone cannot distinguish "seq 0 committed, want seq 1" from "nothing committed, want seq 0". Phase 3 callers should pass `bulkResult.highestContiguousSeq` as `lastGoodSeq` and `bulkResult.nextExpectedSeq` as `nextExpectedSeq` (`BulkReceiver` already produces both with the correct first-chunk-NAK semantics: both are 0 when nothing committed yet).
+  - `getFwChunkNak(transferId, lastGoodSeq, nextExpectedSeq, reasonCode)` — payload `transfer-id<US>last-good-seq<US>next-expected-seq<US>reason-code`. `nextExpectedSeq` disambiguates the first-chunk NAK case where `lastGoodSeq=0` alone cannot distinguish "seq 0 committed, want seq 1" from "nothing committed, want seq 0". Phase 3 callers should pass `bulkResult.highestContiguousSeq` as `lastGoodSeq` and `bulkResult.nextExpectedSeq` as `nextExpectedSeq`. Phase 2's `BulkReceiver` is *expected* to produce both fields with the correct first-chunk-NAK semantics — both 0 when nothing has been committed yet — and Phase 2 must verify this contract (covered by a `bulk_transport_tests.cpp` case on `feature/ota-phase2-bulk-transport`) before Phase 3 wires them together.
   - `getFwTransferEndAck(msgId, transferId, status, computedSha256Hex)` — payload `transfer-id<US>OK|HASH_MISMATCH|IO_ERROR<US>computed-sha256-hex`. `msgId` echoes the originating END's id.
   - `getFwDeployDone(msgId, transferId, perControllerResults)` — each result `controllerId<US>OK|FAILED<US>finalVersion<US>errorOrEmpty`, RS-separated between results.
 - Parsers returning POD result structs:
@@ -227,6 +227,16 @@ Files:
   `FW_CHUNK_NAK reason=SIZE`.
 - `src/main.cpp` — create `otaQueue` (size 16, item-size sizeof(queue_ota_msg_t)),
   spawn `otaReceiverTask` pinned to core 1.
+
+**Caller contract for FW_* builders (load-bearing).** Every `getFw*` builder
+in `AstrOsSerialMessageService` returns `""` on caller-side programming error
+(invalid `reasonCode` for NAK, invalid `status` for DEPLOY_DONE, etc.). Phase 3
+callers MUST check `.empty()` on the return value before queueing. The
+existing `sendXxxAck` pattern in `AstrOsSerialMsgHandler` does not check this
+and will happily queue a `'\n'`-only payload — which the server discards as
+junk, leaving the transfer hung with no diagnostic trail. Treat empty as a
+fatal local bug: `logError` it with a distinct error id and either abort the
+transfer or emit a fallback `FW_CHUNK_NAK reason=CRC` so progress can resume.
 
 Approx 4-6 files.
 

--- a/.docs/plans/20260514-1948-firmware-ota-phase1-wire-format.md
+++ b/.docs/plans/20260514-1948-firmware-ota-phase1-wire-format.md
@@ -444,6 +444,8 @@ Payload shape: `transfer-id<US>last-good-seq<US>reason-code` where reason-code i
 
 - [x] **Step 1: Write the failing test**
 
+> Superseded — see amendment above.
+
 ```cpp
 TEST(SerialMessages, FwChunkNakCrcMessage)
 {
@@ -486,11 +488,15 @@ Expected: FAIL — `getFwChunkNak` not declared.
 
 Header — append:
 
+> Superseded — see amendment above.
+
 ```cpp
     std::string getFwChunkNak(std::string transferId, uint32_t lastGoodSeq, std::string reasonCode);
 ```
 
 Source — append:
+
+> Superseded — see amendment above.
 
 ```cpp
 /// @brief generates FW_CHUNK_NAK reply. Payload shape:
@@ -515,6 +521,8 @@ Run: `pio test -e test --filter "*serial_messages*"`
 Expected: PASS.
 
 - [x] **Step 5: Commit**
+
+> Superseded — see amendment above.
 
 ```bash
 git add lib_native/AstrOsMessaging/src/AstrOsSerialMessageService.hpp \

--- a/.docs/plans/20260514-1948-firmware-ota-phase1-wire-format.md
+++ b/.docs/plans/20260514-1948-firmware-ota-phase1-wire-format.md
@@ -425,6 +425,16 @@ EOF
 
 ### Task 4: `getFwChunkNak` builder
 
+> **Amendment (commit `a91a7ab`):** Wire format extended to 4 fields by adding
+> `next-expected-seq` between `last-good-seq` and `reason-code`. Code blocks below
+> reflect the original 3-field implementation as it was checked in during Phase 1;
+> the current production signature is
+> `getFwChunkNak(transferId, lastGoodSeq, nextExpectedSeq, reasonCode)`. See the
+> `feature/fw-chunk-nak-next-expected-seq` branch for the amendment rationale
+> (cross-repo bug: AstrOs.Server's chunk_streamer computed
+> `nextToSend = lastGoodSeq + 1` which skipped seq 0 on first-chunk NAK,
+> deadlocking the transfer).
+
 **Files:**
 - Modify: `lib_native/AstrOsMessaging/src/AstrOsSerialMessageService.hpp`
 - Modify: `lib_native/AstrOsMessaging/src/AstrOsSerialMessageService.cpp`

--- a/.docs/protocol.md
+++ b/.docs/protocol.md
@@ -49,7 +49,7 @@ Existing framing is unchanged: `[type(int)][RS][validator-string][RS][msg-id][GS
 | 31 | `FW_TRANSFER_BEGIN_ACK` | master → server | Ready or reject (e.g. SD full). |
 | 32 | `FW_CHUNK` | server → master | One frame of base64-encoded bytes with seq + CRC-16. |
 | 33 | `FW_CHUNK_ACK` | master → server | Cumulative ACK with `next-expected-seq` and `window-remaining`. |
-| 34 | `FW_CHUNK_NAK` | master → server | Bad CRC / out-of-order, with `last-good-seq` and `next-expected-seq`. |
+| 34 | `FW_CHUNK_NAK` | master → server | Reject (CRC \| SIZE \| OUT_OF_ORDER \| FLASH_FULL) with `last-good-seq` and `next-expected-seq`. |
 | 35 | `FW_TRANSFER_END` | server → master | End-of-stream + final SHA-256. |
 | 36 | `FW_TRANSFER_END_ACK` | master → server | `OK` / `HASH_MISMATCH` / `IO_ERROR` + computed hash. |
 | 37 | `FW_DEPLOY_BEGIN` | server → master | Push staged SD copy to listed controllers, in given order. |

--- a/.docs/protocol.md
+++ b/.docs/protocol.md
@@ -49,7 +49,7 @@ Existing framing is unchanged: `[type(int)][RS][validator-string][RS][msg-id][GS
 | 31 | `FW_TRANSFER_BEGIN_ACK` | master → server | Ready or reject (e.g. SD full). |
 | 32 | `FW_CHUNK` | server → master | One frame of base64-encoded bytes with seq + CRC-16. |
 | 33 | `FW_CHUNK_ACK` | master → server | Cumulative ACK with `next-expected-seq` and `window-remaining`. |
-| 34 | `FW_CHUNK_NAK` | master → server | Bad CRC / out-of-order, with `last-good-seq`. |
+| 34 | `FW_CHUNK_NAK` | master → server | Bad CRC / out-of-order, with `last-good-seq` and `next-expected-seq`. |
 | 35 | `FW_TRANSFER_END` | server → master | End-of-stream + final SHA-256. |
 | 36 | `FW_TRANSFER_END_ACK` | master → server | `OK` / `HASH_MISMATCH` / `IO_ERROR` + computed hash. |
 | 37 | `FW_DEPLOY_BEGIN` | server → master | Push staged SD copy to listed controllers, in given order. |
@@ -70,7 +70,13 @@ FW_TRANSFER_BEGIN_ACK: transfer-id<US>status
                       code (e.g., "sd_full", "busy", "unsupported_version")
 FW_CHUNK:             transfer-id<US>seq<US>payload-len<US>base64-bytes<US>crc16-hex
 FW_CHUNK_ACK:         transfer-id<US>highest-contiguous-seq<US>next-expected-seq<US>window-remaining
-FW_CHUNK_NAK:         transfer-id<US>last-good-seq<US>reason-code   // CRC|SIZE|OUT_OF_ORDER|FLASH_FULL
+FW_CHUNK_NAK:         transfer-id<US>last-good-seq<US>next-expected-seq<US>reason-code
+                      reason-code = CRC | SIZE | OUT_OF_ORDER | FLASH_FULL
+                      next-expected-seq disambiguates the first-chunk NAK:
+                      last-good-seq=0 alone cannot distinguish "seq 0
+                      committed, want seq 1" from "nothing committed,
+                      want seq 0". next-expected-seq says which seq the
+                      sender must resend next, unambiguously.
 FW_TRANSFER_END:      transfer-id<US>total-chunks<US>final-sha256-hex
 FW_TRANSFER_END_ACK:  transfer-id<US>OK|HASH_MISMATCH|IO_ERROR<US>computed-sha256-hex
 FW_DEPLOY_BEGIN:      transfer-id<US>order-list   // ordered ids, padawans first, master last
@@ -111,7 +117,7 @@ Server                                Master
 
 ### Failure modes
 
-- CRC fail → `FW_CHUNK_NAK` with `last-good-seq` → server resumes from N+1.
+- CRC fail → `FW_CHUNK_NAK` with `last-good-seq` and `next-expected-seq` → server resumes from `next-expected-seq` (do NOT compute as `last-good-seq + 1`; that breaks on first-chunk NAK).
 - Hash mismatch at end → `FW_TRANSFER_END_ACK HASH_MISMATCH` → server retries the whole transfer once, then fails the job.
 - SD full → `FW_TRANSFER_BEGIN_ACK` rejects → fail job fast.
 - Padawan unreachable / reboot timeout → master moves to next padawan, marks the failed one in `FW_DEPLOY_DONE`. ("Continue past failures" decision.)

--- a/lib_native/AstrOsMessaging/src/AstrOsSerialMessageService.cpp
+++ b/lib_native/AstrOsMessaging/src/AstrOsSerialMessageService.cpp
@@ -213,15 +213,28 @@ std::string AstrOsSerialMessageService::getFwChunkAck(std::string transferId, ui
 ///        last-good-seq=0 alone, the server can't tell whether seq 0 was
 ///        committed (resume from 1) or nothing was committed (resume
 ///        from 0). next-expected-seq is unambiguous — the server resumes
-///        from it directly.
+///        from it directly. Returns "" if `reasonCode` is not one of the
+///        four protocol-defined values (caller programming error).
 /// @param transferId transfer id
-/// @param lastGoodSeq the last seq we committed; 0 when nothing committed yet
+/// @param lastGoodSeq the last seq we committed; 0 when nothing committed
+///        yet (see nextExpectedSeq to distinguish from "seq 0 committed")
 /// @param nextExpectedSeq the seq the server must (re)send next
-/// @param reasonCode "CRC" | "SIZE" | "OUT_OF_ORDER" | "FLASH_FULL"
-/// @return serial message
+/// @param reasonCode must be one of "CRC" | "SIZE" | "OUT_OF_ORDER" |
+///        "FLASH_FULL"; any other value returns "" and the caller is
+///        responsible for noticing and logging
+/// @return serial message, or "" on invalid reasonCode
 std::string AstrOsSerialMessageService::getFwChunkNak(std::string transferId, uint32_t lastGoodSeq,
                                                       uint32_t nextExpectedSeq, std::string reasonCode)
 {
+    // Validate reasonCode against the protocol-defined set. An invalid value
+    // would otherwise pass through to the server, where the parser would
+    // reject the whole frame as UNKNOWN — losing the diagnostic context of
+    // why the frame was sent. Mirrors getFwDeployDone's status validation.
+    if (reasonCode != "CRC" && reasonCode != "SIZE" && reasonCode != "OUT_OF_ORDER" && reasonCode != "FLASH_FULL")
+    {
+        return "";
+    }
+
     std::stringstream ss;
     ss << AstrOsSerialMessageService::generateHeader(AstrOsSerialMessageType::FW_CHUNK_NAK, "na");
     ss << transferId << UNIT_SEPARATOR << std::to_string(lastGoodSeq) << UNIT_SEPARATOR

--- a/lib_native/AstrOsMessaging/src/AstrOsSerialMessageService.cpp
+++ b/lib_native/AstrOsMessaging/src/AstrOsSerialMessageService.cpp
@@ -208,17 +208,24 @@ std::string AstrOsSerialMessageService::getFwChunkAck(std::string transferId, ui
 }
 
 /// @brief generates FW_CHUNK_NAK reply. Payload shape:
-///        transfer-id<US>last-good-seq<US>reason-code.
+///        transfer-id<US>last-good-seq<US>next-expected-seq<US>reason-code.
+///        `next-expected-seq` disambiguates the first-chunk NAK: when
+///        last-good-seq=0 alone, the server can't tell whether seq 0 was
+///        committed (resume from 1) or nothing was committed (resume
+///        from 0). next-expected-seq is unambiguous — the server resumes
+///        from it directly.
 /// @param transferId transfer id
-/// @param lastGoodSeq the last seq we committed (server resumes from N+1)
+/// @param lastGoodSeq the last seq we committed; 0 when nothing committed yet
+/// @param nextExpectedSeq the seq the server must (re)send next
 /// @param reasonCode "CRC" | "SIZE" | "OUT_OF_ORDER" | "FLASH_FULL"
 /// @return serial message
 std::string AstrOsSerialMessageService::getFwChunkNak(std::string transferId, uint32_t lastGoodSeq,
-                                                      std::string reasonCode)
+                                                      uint32_t nextExpectedSeq, std::string reasonCode)
 {
     std::stringstream ss;
     ss << AstrOsSerialMessageService::generateHeader(AstrOsSerialMessageType::FW_CHUNK_NAK, "na");
-    ss << transferId << UNIT_SEPARATOR << std::to_string(lastGoodSeq) << UNIT_SEPARATOR << reasonCode;
+    ss << transferId << UNIT_SEPARATOR << std::to_string(lastGoodSeq) << UNIT_SEPARATOR
+       << std::to_string(nextExpectedSeq) << UNIT_SEPARATOR << reasonCode;
     return ss.str();
 }
 

--- a/lib_native/AstrOsMessaging/src/AstrOsSerialMessageService.cpp
+++ b/lib_native/AstrOsMessaging/src/AstrOsSerialMessageService.cpp
@@ -216,9 +216,12 @@ std::string AstrOsSerialMessageService::getFwChunkAck(std::string transferId, ui
 ///        from it directly. Returns "" if `reasonCode` is not one of the
 ///        four protocol-defined values (caller programming error).
 /// @param transferId transfer id
-/// @param lastGoodSeq the last seq we committed; 0 when nothing committed
-///        yet (see nextExpectedSeq to distinguish from "seq 0 committed")
-/// @param nextExpectedSeq the seq the server must (re)send next
+/// @param lastGoodSeq the last seq we committed; 0 by convention when nothing
+///        has been committed yet. Receivers must look at nextExpectedSeq to
+///        disambiguate, since lastGoodSeq=0 is also the legitimate value when
+///        seq 0 has actually been committed.
+/// @param nextExpectedSeq the seq the server should resend next (the resume
+///        point — authoritative; do not derive from lastGoodSeq + 1)
 /// @param reasonCode must be one of "CRC" | "SIZE" | "OUT_OF_ORDER" |
 ///        "FLASH_FULL"; any other value returns "" and the caller is
 ///        responsible for noticing and logging

--- a/lib_native/AstrOsMessaging/src/AstrOsSerialMessageService.hpp
+++ b/lib_native/AstrOsMessaging/src/AstrOsSerialMessageService.hpp
@@ -172,7 +172,8 @@ public:
     std::string getFwTransferBeginAck(std::string msgId, std::string transferId, std::string status);
     std::string getFwChunkAck(std::string transferId, uint32_t highestContiguousSeq, uint32_t nextExpectedSeq,
                               uint8_t windowRemaining);
-    std::string getFwChunkNak(std::string transferId, uint32_t lastGoodSeq, std::string reasonCode);
+    std::string getFwChunkNak(std::string transferId, uint32_t lastGoodSeq, uint32_t nextExpectedSeq,
+                              std::string reasonCode);
     std::string getFwTransferEndAck(std::string msgId, std::string transferId, std::string status,
                                     std::string computedSha256Hex);
     std::string getFwDeployDone(std::string msgId, std::string transferId,

--- a/test/test_native/astros_serial_messages_tests.cpp
+++ b/test/test_native/astros_serial_messages_tests.cpp
@@ -396,7 +396,8 @@ TEST(SerialMessages, FwChunkAckMessage)
 TEST(SerialMessages, FwChunkNakCrcMessage)
 {
     auto msgSvc = AstrOsSerialMessageService();
-    auto value = msgSvc.getFwChunkNak("7", 40, "CRC");
+    // lastGoodSeq=40, nextExpectedSeq=41 — sender resumes from 41.
+    auto value = msgSvc.getFwChunkNak("7", 40, 41, "CRC");
 
     auto validation = msgSvc.validateSerialMsg(value);
     ASSERT_TRUE(validation.valid);
@@ -405,23 +406,43 @@ TEST(SerialMessages, FwChunkNakCrcMessage)
 
     auto records = AstrOsStringUtils::splitString(value, GROUP_SEPARATOR);
     auto payloadParts = AstrOsStringUtils::splitString(records[1], UNIT_SEPARATOR);
-    ASSERT_EQ(3u, payloadParts.size());
+    ASSERT_EQ(4u, payloadParts.size());
     EXPECT_EQ("7", payloadParts[0]);
     EXPECT_EQ("40", payloadParts[1]);
-    EXPECT_EQ("CRC", payloadParts[2]);
+    EXPECT_EQ("41", payloadParts[2]);
+    EXPECT_EQ("CRC", payloadParts[3]);
+}
+
+TEST(SerialMessages, FwChunkNakFirstChunkDisambiguatesViaNextExpectedSeq)
+{
+    auto msgSvc = AstrOsSerialMessageService();
+    // First-chunk NAK: lastGoodSeq=0 is the protocol-ambiguous value, but
+    // nextExpectedSeq=0 unambiguously says "send seq 0 again". A naive
+    // server that computed lastGoodSeq+1 would have skipped to seq 1.
+    auto value = msgSvc.getFwChunkNak("7", 0, 0, "CRC");
+
+    auto validation = msgSvc.validateSerialMsg(value);
+    ASSERT_TRUE(validation.valid);
+
+    auto records = AstrOsStringUtils::splitString(value, GROUP_SEPARATOR);
+    auto payloadParts = AstrOsStringUtils::splitString(records[1], UNIT_SEPARATOR);
+    ASSERT_EQ(4u, payloadParts.size());
+    EXPECT_EQ("0", payloadParts[1]); // lastGoodSeq
+    EXPECT_EQ("0", payloadParts[2]); // nextExpectedSeq — the disambiguating field
+    EXPECT_EQ("CRC", payloadParts[3]);
 }
 
 TEST(SerialMessages, FwChunkNakOutOfOrderMessage)
 {
     auto msgSvc = AstrOsSerialMessageService();
-    auto value = msgSvc.getFwChunkNak("7", 40, "OUT_OF_ORDER");
+    auto value = msgSvc.getFwChunkNak("7", 40, 41, "OUT_OF_ORDER");
 
     auto validation = msgSvc.validateSerialMsg(value);
     ASSERT_TRUE(validation.valid);
     auto records = AstrOsStringUtils::splitString(value, GROUP_SEPARATOR);
     auto payloadParts = AstrOsStringUtils::splitString(records[1], UNIT_SEPARATOR);
-    ASSERT_EQ(3u, payloadParts.size());
-    EXPECT_EQ("OUT_OF_ORDER", payloadParts[2]);
+    ASSERT_EQ(4u, payloadParts.size());
+    EXPECT_EQ("OUT_OF_ORDER", payloadParts[3]); // reason-code moved to slot 3 with the new field
 }
 
 TEST(SerialMessages, FwTransferEndAckOkMessage)

--- a/test/test_native/astros_serial_messages_tests.cpp
+++ b/test/test_native/astros_serial_messages_tests.cpp
@@ -481,9 +481,18 @@ TEST(SerialMessages, FwChunkNakRejectsInvalidReasonCode)
     // at the source rather than emitting an unidentifiable frame.
     auto msgSvc = AstrOsSerialMessageService();
 
+    // Sanity foil: an otherwise-identical call with a valid reasonCode must
+    // NOT return empty. Pins that emptiness is reasonCode-driven, not a
+    // regression that short-circuits the whole builder.
+    EXPECT_FALSE(msgSvc.getFwChunkNak("7", 0, 0, "CRC").empty());
+
     EXPECT_TRUE(msgSvc.getFwChunkNak("7", 0, 0, "WAT").empty());
     EXPECT_TRUE(msgSvc.getFwChunkNak("7", 0, 0, "").empty());
-    EXPECT_TRUE(msgSvc.getFwChunkNak("7", 0, 0, "crc").empty()); // case-sensitive
+    EXPECT_TRUE(msgSvc.getFwChunkNak("7", 0, 0, "crc").empty());          // case-sensitive
+    EXPECT_TRUE(msgSvc.getFwChunkNak("7", 0, 0, "out_of_order").empty()); // case-sensitive
+    EXPECT_TRUE(msgSvc.getFwChunkNak("7", 0, 0, " CRC").empty());         // leading space
+    EXPECT_TRUE(msgSvc.getFwChunkNak("7", 0, 0, "CRC ").empty());         // trailing space
+    EXPECT_TRUE(msgSvc.getFwChunkNak("7", 0, 0, "OUT-OF-ORDER").empty()); // wrong separator
 }
 
 TEST(SerialMessages, FwTransferEndAckOkMessage)

--- a/test/test_native/astros_serial_messages_tests.cpp
+++ b/test/test_native/astros_serial_messages_tests.cpp
@@ -442,7 +442,48 @@ TEST(SerialMessages, FwChunkNakOutOfOrderMessage)
     auto records = AstrOsStringUtils::splitString(value, GROUP_SEPARATOR);
     auto payloadParts = AstrOsStringUtils::splitString(records[1], UNIT_SEPARATOR);
     ASSERT_EQ(4u, payloadParts.size());
-    EXPECT_EQ("OUT_OF_ORDER", payloadParts[3]); // reason-code moved to slot 3 with the new field
+    EXPECT_EQ("7", payloadParts[0]);            // transferId
+    EXPECT_EQ("40", payloadParts[1]);           // lastGoodSeq
+    EXPECT_EQ("41", payloadParts[2]);           // nextExpectedSeq
+    EXPECT_EQ("OUT_OF_ORDER", payloadParts[3]); // reasonCode
+}
+
+TEST(SerialMessages, FwChunkNakSizeMessage)
+{
+    auto msgSvc = AstrOsSerialMessageService();
+    auto value = msgSvc.getFwChunkNak("7", 5, 6, "SIZE");
+
+    auto validation = msgSvc.validateSerialMsg(value);
+    ASSERT_TRUE(validation.valid);
+    auto records = AstrOsStringUtils::splitString(value, GROUP_SEPARATOR);
+    auto payloadParts = AstrOsStringUtils::splitString(records[1], UNIT_SEPARATOR);
+    ASSERT_EQ(4u, payloadParts.size());
+    EXPECT_EQ("SIZE", payloadParts[3]);
+}
+
+TEST(SerialMessages, FwChunkNakFlashFullMessage)
+{
+    auto msgSvc = AstrOsSerialMessageService();
+    auto value = msgSvc.getFwChunkNak("7", 100, 101, "FLASH_FULL");
+
+    auto validation = msgSvc.validateSerialMsg(value);
+    ASSERT_TRUE(validation.valid);
+    auto records = AstrOsStringUtils::splitString(value, GROUP_SEPARATOR);
+    auto payloadParts = AstrOsStringUtils::splitString(records[1], UNIT_SEPARATOR);
+    ASSERT_EQ(4u, payloadParts.size());
+    EXPECT_EQ("FLASH_FULL", payloadParts[3]);
+}
+
+TEST(SerialMessages, FwChunkNakRejectsInvalidReasonCode)
+{
+    // Caller programming error: an unrecognized reason string is silently
+    // unparseable on the server side. The builder returns "" to flag this
+    // at the source rather than emitting an unidentifiable frame.
+    auto msgSvc = AstrOsSerialMessageService();
+
+    EXPECT_TRUE(msgSvc.getFwChunkNak("7", 0, 0, "WAT").empty());
+    EXPECT_TRUE(msgSvc.getFwChunkNak("7", 0, 0, "").empty());
+    EXPECT_TRUE(msgSvc.getFwChunkNak("7", 0, 0, "crc").empty()); // case-sensitive
 }
 
 TEST(SerialMessages, FwTransferEndAckOkMessage)


### PR DESCRIPTION
## Summary

Cross-repo protocol amendment that fixes a first-chunk deadlock in the
firmware OTA wire format. The original `FW_CHUNK_NAK` payload
(`transfer-id<US>last-good-seq<US>reason-code`) was ambiguous: when the
NAK fired on the very first chunk, `last-good-seq=0` could mean either
"seq 0 committed, want seq 1" or "nothing committed, want seq 0". The
server's `chunk_streamer` resolved that ambiguity by computing
`nextToSend = last-good-seq + 1`, which skipped seq 0 on first-chunk NAK
and hung the transfer.

**Fix:** add an explicit `next-expected-seq` field between `last-good-seq`
and `reason-code`. The receiver is now authoritative about the resume
point. **This PR must merge alongside its paired AstrOs.Server PR** on
the matching `feature/fw-chunk-nak-next-expected-seq` branch — the two
ends of the wire change in lockstep, and `.docs/protocol.md` is
byte-identical across both repos.

**Wire format change:**
```
before:  FW_CHUNK_NAK  transfer-id <US> last-good-seq <US> reason-code
after:   FW_CHUNK_NAK  transfer-id <US> last-good-seq <US> next-expected-seq <US> reason-code
```

Where `reason-code ∈ { CRC | SIZE | OUT_OF_ORDER | FLASH_FULL }`. First-chunk
NAK semantics: `last-good-seq=0` AND `next-expected-seq=0` when nothing has
been committed yet.

**Changes in this PR:**

- `lib_native/AstrOsMessaging/src/AstrOsSerialMessageService.{hpp,cpp}` — `getFwChunkNak` signature extended to `(transferId, lastGoodSeq, nextExpectedSeq, reasonCode)`. Added defensive `reasonCode` validation: builder returns `""` on values outside the four-value protocol set (mirrors the existing `getFwDeployDone` precedent for `status` validation).
- `.docs/protocol.md` — 4-field wire format spec including a `do NOT compute as last-good-seq + 1; that breaks on first-chunk NAK` foot-gun warning at the spec level. Byte-identical to `AstrOs.Server/.docs/protocol.md`.
- `.docs/plans/20260514-1948-firmware-ota-phase1-wire-format.md` — Task 4 carries an amendment banner pointing at this branch; the original 3-field code blocks are preserved as history and tagged `> Superseded — see amendment above.` so grep-jumpers landing on them don't mistake them for current truth.
- `.docs/plans/20260514-1941-firmware-ota-esp-master-serial-receive-design.md` — design doc line 134 updated to the 4-arg signature with explicit Phase 3 caller-side field mapping (`BulkReceiver.highestContiguousSeq → wire last-good-seq`, `BulkReceiver.nextExpectedSeq → wire next-expected-seq`). Added a load-bearing caller-contract note: every `getFw*` builder returns `""` on caller-side programming error, and Phase 3 MUST check `.empty()` before queueing (the existing `sendXxxAck` pattern in `AstrOsSerialMsgHandler.cpp:108-158` doesn't, and a copy-paste of that pattern for FW frames would silently queue a `'\n'`-only payload, hanging the transfer with no diagnostic trail).
- `test/test_native/astros_serial_messages_tests.cpp` — six tests touching the builder:
  - `FwChunkNakCrcMessage` (was 3-field, updated)
  - `FwChunkNakFirstChunkDisambiguatesViaNextExpectedSeq` (new — pins the actual bug fix)
  - `FwChunkNakOutOfOrderMessage` (strengthened to assert all 4 payload slots)
  - `FwChunkNakSizeMessage` (new — coverage for SIZE reason)
  - `FwChunkNakFlashFullMessage` (new — coverage for FLASH_FULL reason)
  - `FwChunkNakRejectsInvalidReasonCode` (new — sanity foil + 7 negative cases: arbitrary string, empty, case-mismatch, alternate snake_case, leading/trailing whitespace, wrong separator)

**Hardening informed by two passes of multi-agent PR review** (code-reviewer, comment-analyzer, pr-test-analyzer, silent-failure-hunter):
- Pass 1: stale plan-doc signatures (3 reviewers convergent), missing reasonCode validation in builder, weak OutOfOrder assertions, missing SIZE/FLASH_FULL coverage — all addressed.
- Pass 2: `BulkReceiver` doc claim was unverifiable on this branch (2 reviewers convergent) — reworded to forward-looking; Phase 3 caller-contract documentation gap closed; negative-test sanity-foil added so the empty-string assertion can't pass for the wrong reason; whitespace/casing edge cases added.

## Test plan

- [x] `pio test -e test` passes (261/261)
- [x] `pio run -e metro_s3` builds clean
- [x] `pio run -e lolin_d32_pro` builds clean
- [x] clang-format clean on changed files (pre-commit hook enforced)
- [x] Two PR-toolkit review passes — zero critical issues
- [x] Cross-repo `protocol.md` verified byte-identical to AstrOs.Server's copy
- [ ] End-to-end first-chunk-NAK manual test — gated on Phase 3 wire-up landing on the ESP side. Until then, the cross-repo `flash_chunk_nak.integration.test.ts` on the AstrOs.Server PR exercises the deadlock-recovery path against a stub master.

## Cross-repo pairing

Must merge in lockstep with the paired AstrOs.Server PR.

| Repo | Branch | Commits |
|---|---|---|
| AstrOs.ESP | `feature/fw-chunk-nak-next-expected-seq` | `a91a7ab`, `52337fc`, `0ef71b3` |
| AstrOs.Server | `feature/fw-chunk-nak-next-expected-seq` | `db624af`, `e1a2688`, `aabd267`, `98bd992`, `bc2997e` (+ chore `fda3b90`) |

Merging only one side would create a wire format split: an ESP master built from this branch would emit 4-field NAKs that a `main`-built server would parse as malformed-reason (server-side parser rejects on `parts.length !== 4`); conversely, a `main`-built ESP would emit 3-field NAKs that the new server parser would reject for the same reason.

## Commit-by-commit

- **`a91a7ab`** `fix(protocol): add next-expected-seq to FW_CHUNK_NAK wire format` — core wire format change. 4-field payload, builder signature, parallel updates to `protocol.md` and both plan docs.
- **`52337fc`** `fix(messaging): validate FW_CHUNK_NAK reasonCode + update plan docs` — PR-toolkit pass 1 cleanup. Defensive `reasonCode` validation in the builder (returns `""` on invalid values, mirrors `getFwDeployDone`); plan-doc signatures and failure-mode tables refreshed; OutOfOrder test strengthened; SIZE/FLASH_FULL/RejectsInvalidReasonCode tests added.
- **`0ef71b3`** `docs(messaging): clean up FW_CHUNK_NAK plan docs + harden negative test` — PR-toolkit pass 2 cleanup. Forward-looking BulkReceiver doc claim, Phase 3 caller-contract block in design doc, superseded markers on Phase 1 plan obsolete blocks, doxygen wording tightenings, negative-test sanity foil + whitespace/casing edge cases, `protocol.md` reason-code hint expansion (paired with AstrOs.Server `bc2997e`).

## Known backlog (out of scope for this PR)

- **Empty-`transferId` hardening across all four FW_* builders.** `getFwChunkNak`, `getFwChunkAck`, `getFwTransferBeginAck`, `getFwTransferEndAck` all accept an empty `transferId` and silently produce structurally-malformed frames (leading `<US>` before the empty field) that the server's parser rejects as junk — same hang-on-transfer failure mode as the original first-chunk bug. Worth a paired follow-up PR; expanding scope here would dilute the focused `next-expected-seq` amendment.
- **`generateHeader` return-not-checked is codebase-wide and pre-dates this branch.** Addressing it consistently across all builders is a separate concern.
- **Adjacent `uint32_t` swap hazard** in the builder signature is the same pattern as `getFwChunkAck`. Type-hardening (e.g., distinct strong types or a struct argument) should apply codebase-wide, not piecemeal here.

