### PR TITLE
Feature/ota phase2 bulk transport

### DIFF
--- a/.docs/plans/20260514-2300-firmware-ota-phase2-bulk-transport.md
+++ b/.docs/plans/20260514-2300-firmware-ota-phase2-bulk-transport.md
@@ -2,22 +2,55 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-> **Post-implementation amendments (commits `6123a6a`, `fe87535`, and the
-> PR-toolkit cleanup pass on `feature/ota-phase2-bulk-transport`):** the
-> original plan claimed `crc16_ccitt_false` was byte-identical to ESP-IDF's
-> `esp_crc16_le`. That is wrong — `esp_crc16_le` is CRC-16/CCITT
-> *reflected* with init=0 and produces different output. The correct
-> ESP-IDF equivalent is `~esp_rom_crc16_be((uint16_t)~0xFFFF, buf, len)`.
-> The plan also said the single-zero-byte CRC value is `0x1EF0`; the
-> correct value is `0xE1F0` (nibbles transposed). The shipped README,
-> `.hpp`, and tests have the corrected forms; the historical text in this
-> plan is preserved with inline corrections (`~~strikethrough~~ →
-> correction`) so the original intent is auditable. Test totals also moved
-> (22 → 26 cases, 279 → 287 total) after `fe87535` added 4 strengthening
-> tests. Final PR-toolkit pass on the same branch added `BeginResult`,
-> `EndResult::Reason`, `ChunkResult` factory methods, totalSize/windowSize
-> validation, and a `seq >= totalChunks` overflow guard — see the cleanup
-> commits for the API redesign rationale.
+> **Post-implementation amendments** (commits `6123a6a`, `fe87535`, and the
+> PR-toolkit cleanup pass on `feature/ota-phase2-bulk-transport`).
+>
+> **CRC interop:** the original plan claimed `crc16_ccitt_false` was
+> byte-identical to ESP-IDF's `esp_crc16_le`. That is wrong — `esp_crc16_le`
+> is CRC-16/CCITT *reflected* with init=0 and produces different output.
+> The correct ESP-IDF equivalent is
+> `~esp_rom_crc16_be((uint16_t)~0xFFFF, buf, len)`. The plan also said the
+> single-zero-byte CRC value is `0x1EF0`; the correct value is `0xE1F0`
+> (nibbles transposed). The shipped README, `.hpp`, and tests have the
+> corrected forms.
+>
+> **Test totals:** the plan originally said "22 new tests / 279 total."
+> Actual shipped numbers are **32 new BulkTransport tests / 293 total**
+> (261 develop baseline + 32). Growth came in three waves: original 22
+> tests at the task-by-task TDD stage, +4 strengthening tests in
+> `fe87535`, then +6 more during the PR-toolkit cleanup pass (4
+> `begin()`-validation tests in `cc8b749` covering ZERO_WINDOW_SIZE and
+> the three SIZE_INCONSISTENT shapes, plus 2 in `cbd000a` —
+> `Crc16MultiByteNonStringVector` and `OnEndOkLeavesReceiverInPostOkState`).
+>
+> **API redesign from the PR-toolkit pass:** added `BeginResult`,
+> `EndResult::Reason`, `ChunkResult` factory methods (`ack`,
+> `nakActive`, `nakInactive`) with a private default constructor,
+> `[[nodiscard]]` on `BeginResult`/`EndResult`, totalSize/windowSize
+> validation in `begin()`, a `seq >= totalChunks_` overflow guard in
+> `onChunk`, and a private `lastGoodSeq()` helper folding the
+> duplicated first-chunk-NAK contract into one place.
+>
+> **HASH_MISMATCH ownership** moved: originally attributed to "the
+> Phase 3 OtaReceiver that owns the streaming SHA-256 context," but
+> the corrected layering is — Phase 3's MIXED `OtaReceiver` sinks
+> payload to `/dev/null` and never returns `HASH_MISMATCH`; only the
+> Phase 4 enhancement that adds the streaming SHA-256 context will
+> produce it. The shipped `.hpp` reflects this; the Task-3 plan-body
+> skeleton (lines ~413-424) still carries the original (incorrect)
+> claim and was not surgically corrected.
+>
+> **Plan-body skeletons are historical, NOT current code.** The
+> task-by-task skeletons in the body of this plan (especially Task 3's
+> `EndResult` shape, Task 4's `void begin(...)` signature, and the
+> ~19 test-call sites) reflect the original API as it was first
+> implemented, not the post-cleanup shipped API. The CRC interop
+> claims were surgically corrected (the highest-stakes drift); the
+> API-redesign drift was not. **Re-executors of this plan must
+> consult the shipped `.hpp`/`.cpp` and the cleanup commits as the
+> source of truth for the final API.** Trying to build solely from
+> the body skeletons will produce a working but obsolete API surface
+> the PR-toolkit pass has since superseded.
 
 **Goal:** Build `lib_native/AstrOsBulkTransport` — a PURE, native-testable state machine that consumes parsed `FW_CHUNK` records and produces ACK/NAK decisions with sliding-window backpressure. No firmware behavior change; this is the algorithmic core that Phase 3 will wire into the `AstrOsSerialMsgHandler` dispatch path.
 
@@ -408,6 +441,17 @@ namespace AstrOsBulkTransport
         uint16_t payloadLen = 0;
     };
 
+    // NOTE — superseded by cleanup commit `cbd000a` (PR-toolkit pass):
+    //
+    // (1) HASH_MISMATCH ownership moved to Phase 4 — Phase 3's MIXED
+    //     OtaReceiver sinks payload to /dev/null and never produces it.
+    //     Only the Phase 4 enhancement with the streaming SHA-256 context
+    //     ever returns HASH_MISMATCH. The comment below predates that
+    //     layering decision.
+    // (2) EndResult gained a `Reason` enum (NONE | NOT_ACTIVE |
+    //     WRONG_XFER_ID | SENDER_TOTAL_MISMATCH | RECEIVER_SHORT_COUNT)
+    //     and a `[[nodiscard]]` attribute. See the shipped `.hpp` for
+    //     the final shape.
     struct EndResult
     {
         // HASH_MISMATCH is reserved for the MIXED-layer caller (Phase 3
@@ -1266,7 +1310,7 @@ EOF
 - [ ] **Step 1: Run the full native test suite**
 
 Run: `/home/jeff/.platformio/penv/bin/pio test -e test`
-Expected: 261 → 287 (26 new BulkTransport tests, including the 4 strengthening cases added late by commit `fe87535`). All pass.
+Expected: 261 → 293 (32 new BulkTransport tests — 22 from the original task-by-task TDD, 4 from `fe87535`'s strengthening pass, 6 more from the PR-toolkit cleanup pass — 4 begin-validation in `cc8b749` + `Crc16MultiByteNonStringVector` and `OnEndOkLeavesReceiverInPostOkState` in `cbd000a`). All pass.
 
 - [ ] **Step 2: Build both board firmware variants**
 
@@ -1324,7 +1368,7 @@ Adds:
 
 ## Test plan
 
-- [x] \`pio test -e test\` passes (287/287 — Phase 2 added 26 tests on top of develop's 261)
+- [x] \`pio test -e test\` passes (293/293 — Phase 2 added 32 tests on top of develop's 261)
 - [x] \`pio run -e metro_s3\` builds clean
 - [x] \`pio run -e lolin_d32_pro\` builds clean
 - [x] CI native-purity grep finds no forbidden includes in the new lib
@@ -1351,7 +1395,7 @@ EOF
   - `onEnd` OK + IO_ERROR (Tasks 7 + 8) ✓
   - End-to-end integration test (Task 9) ✓
   - Final verification + PR (Task 10) ✓
-  - **Post-implementation hardening from PR-toolkit pass (not a numbered task)**: `begin()` input-validation guards (zero `chunkSize`/`totalChunks`/`windowSize`, `totalSize` ≈ `totalChunks * chunkSize` consistency); `seq >= totalChunks_` overflow guard on the SIZE math; `BeginResult` return value; `EndResult::Reason` enum (distinct IO_ERROR causes); `ChunkResult` factory methods preventing invalid field combinations; `writeResumePoint` helper folding the duplicated first-chunk-NAK contract into one place. ✓
+  - **Post-implementation hardening from PR-toolkit pass (not a numbered task)**: `begin()` input-validation guards (zero `chunkSize`/`totalChunks`/`windowSize`, `totalSize` ≈ `totalChunks * chunkSize` consistency); `seq >= totalChunks_` overflow guard on the SIZE math; `BeginResult` return value; `EndResult::Reason` enum (distinct IO_ERROR causes); `ChunkResult` factory methods preventing invalid field combinations; `lastGoodSeq()` private helper folding the duplicated first-chunk-NAK contract into one place. ✓
 - **Placeholder scan:** the original plan was free of TBDs at task-execution time. The amendment header above flags the specific claims (CRC interop, single-zero-byte value, 22/279 test counts) that were superseded by the PR-toolkit cleanup; surgical corrections in-body keep the plan re-executable.
 - **Type consistency:** `BulkReceiver`, `ChunkResult`, `EndResult`, `Decision`, `NakReason` are used consistently across all tasks. `crc16_ccitt_false` lowercase-underscore naming is used everywhere.
 - **Scope check:** 10 tasks. Above the CLAUDE.md ~8-task warning, but each task is small (≤2 files, ≤30 min) and Phase 2 is genuinely one coherent unit — splitting into "scaffold" and "state machine" sub-phases would just add cross-PR coordination cost without value. If the scope grows past 10, escalate.

--- a/.docs/plans/20260514-2300-firmware-ota-phase2-bulk-transport.md
+++ b/.docs/plans/20260514-2300-firmware-ota-phase2-bulk-transport.md
@@ -1,0 +1,1333 @@
+# Firmware OTA Phase 2 — Bulk Transport State Machine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `lib_native/AstrOsBulkTransport` — a PURE, native-testable state machine that consumes parsed `FW_CHUNK` records and produces ACK/NAK decisions with sliding-window backpressure. No firmware behavior change; this is the algorithmic core that Phase 3 will wire into the `AstrOsSerialMsgHandler` dispatch path.
+
+**Architecture:** A small `BulkReceiver` class plus a standalone CRC-16/CCITT-FALSE helper. Sequential receive (no reorder buffer): every chunk must arrive with `seq == nextSeq_`; out-of-order chunks are NAK'd. `windowRemaining` returned on every ACK is always the configured `windowSize` — backpressure is a sender concern. CRC validation uses our own `crc16_ccitt_false` (PURE libs can't link `esp_crc16_le`). The lib does *not* touch payload bytes — `onChunk` receives a `const uint8_t*`/`uint16_t` pair and passes them straight back through `ChunkResult` on ACK so the caller can write them to wherever it wants (SD card in Phase 4, /dev/null in Phase 3).
+
+**Tech Stack:** C++17, googletest, PlatformIO `[env:test]` native build. Mirrors the existing PURE-lib pattern established by `lib_native/AstrOsSerialProtocol` and `lib_native/AstrOsAnimationEngine`.
+
+**Design doc:** `.docs/plans/20260514-1941-firmware-ota-esp-master-serial-receive-design.md` (Phase 2 section)
+**Phase 1 (already merged):** the `FW_*` wire format and the `parseFwChunk` parser that produces the records this state machine consumes.
+**Phase context:** This is Phase 2 of 5. Phase 3 wires the `BulkReceiver` into the serial-handler task; Phase 4 adds SD writer + streaming SHA; Phase 5 hardens failure modes.
+
+---
+
+## File Structure
+
+| Path | Purpose | Action |
+|---|---|---|
+| `lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp` | Public API: enums, result structs, `BulkReceiver` class, `crc16_ccitt_false` decl | Create |
+| `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp` | `BulkReceiver` method bodies + CRC impl | Create |
+| `lib_native/AstrOsBulkTransport/README` | Purity rule + forbidden include prefixes (mirrors `AstrOsSerialProtocol/README`) | Create |
+| `.github/workflows/pr-validation.yml` | Append `lib_native/AstrOsBulkTransport` to the `PURE_LIBS` array | Modify |
+| `test/test_native/bulk_transport_tests.cpp` | Native tests for the state machine + CRC helper | Create |
+
+No changes to `lib_native/AstrOsMessaging`, `lib_native/AstrOsSerialProtocol`, or any MIXED-side lib. PlatformIO auto-discovers libs under `lib_native/` via the `lib_extra_dirs = lib_native` setting in `platformio.ini:12` — no `library.json` is required (the existing PURE libs don't have one).
+
+## Background notes for the implementer
+
+- **`pio` is at `/home/jeff/.platformio/penv/bin/pio`** (not on default PATH). All test/build commands in this plan use the full path.
+- **Run native tests with**: `/home/jeff/.platformio/penv/bin/pio test -e test`. The `--filter "test_native"` matches the test folder, not test names; matching by test name uses `--filter "*BulkTransport*"` against the GoogleTest binary.
+- **The pre-commit hook runs clang-format** on staged C/C++ files. Expect it to reformat whitespace; the commit still succeeds.
+- **The CI native-purity guard** (`.github/workflows/pr-validation.yml`) greps for `#include <(freertos/|esp_|driver/|nvs_|sdmmc_)…>` across every path in `PURE_LIBS`. Don't include any of those, ever. The lib has no need to — we're not touching FreeRTOS, ESP-IDF, or hardware. Standard C++17 only.
+- **No exceptions.** CLAUDE.md and existing patterns: don't `throw`; don't `try/catch`. Return result structs.
+- **CRC-16/CCITT-FALSE:** poly `0x1021`, init `0xFFFF`, no input reflection, no output reflection, no XOR-out. Same as `esp_crc16_le` would compute on-device. Many online CRC calculators get this wrong (CCITT vs CCITT-FALSE vs XMODEM are all different) — the test in Task 2 uses the canonical "123456789" → `0x29B1` check vector.
+- **`windowRemaining` semantics:** always returned as the configured `windowSize`. The receiver has zero state in-flight after a chunk is ACK'd (it's already validated and "consumed" by the caller). Backpressure is a sender-side optimization. Document this in the header.
+- **`xferId` mismatch / not-active:** NAK with `reason=OUT_OF_ORDER`. The wire-level reason codes are `CRC | SIZE | OUT_OF_ORDER | FLASH_FULL`; we map all structural rejection to `OUT_OF_ORDER`. The internal `NakReason` enum stays 1:1 with the wire-level set.
+- **`HASH_MISMATCH` in `EndResult::Status`:** reserved for the Phase 3+ MIXED layer that computes the hash. This Phase 2 implementation never returns `HASH_MISMATCH` — only `OK` or `IO_ERROR` (chunk-count mismatch).
+- **The lib does not own payload memory.** `onChunk` takes `const uint8_t* payload, uint16_t payloadLen`; `ChunkResult` passes them straight back on ACK. Caller (Phase 3 OtaReceiver) is responsible for the buffer's lifetime — typically `payload` lives in a queue-message struct that the caller frees after processing.
+
+---
+
+### Task 1: Scaffold the PURE lib + register with CI
+
+**Files:**
+- Create: `lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp`
+- Create: `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp`
+- Create: `lib_native/AstrOsBulkTransport/README`
+- Modify: `.github/workflows/pr-validation.yml`
+
+This task lays down the directory, an empty-but-valid header + source, the README, and the CI purity-guard registration. No functional code yet. The goal is "this compiles, CI accepts it, no tests fail" — a clean foundation for the subsequent TDD tasks.
+
+- [ ] **Step 1: Create the README**
+
+`lib_native/AstrOsBulkTransport/README`:
+
+```
+AstrOsBulkTransport
+===================
+
+Pure, native-testable state machine for the chunk-based bulk transport
+used by the firmware OTA path. Consumes FW_CHUNK records (parsed by
+lib_native/AstrOsMessaging) and produces ACK/NAK decisions, with
+sliding-window backpressure metadata for the sender. Companion to the
+FW_* wire format that Phase 1 added to AstrOsMessaging; consumed by
+the MIXED OtaReceiver that Phase 3 will introduce.
+
+Purity rule
+-----------
+
+This library is unit-tested on the native host under [env:test], so it
+must not include any of:
+
+    freertos/*, esp_*, driver/*, nvs_*, sdmmc_*, esp_vfs*, esp_now*, esp_wifi*
+
+Enforced by the CI purity guard in .github/workflows/pr-validation.yml.
+
+Error-channel convention
+------------------------
+
+The state machine returns ChunkResult / EndResult structs with explicit
+Decision and Status fields. No exceptions, no logger injection. The
+MIXED caller (Phase 3 OtaReceiver) is responsible for translating
+results into wire-level FW_CHUNK_ACK / FW_CHUNK_NAK / FW_TRANSFER_END_ACK
+messages and for any ESP_LOGW logging at the boundary.
+
+CRC
+---
+
+This lib owns its own crc16_ccitt_false implementation. The CRC matches
+ESP-IDF's esp_crc16_le (poly 0x1021, init 0xFFFF, no reflection, no
+XOR-out) — they are byte-identical. The Phase 3 MIXED layer should call
+the PURE crc16_ccitt_false directly rather than esp_crc16_le; a single
+bench test confirming the two produce identical output for the same
+inputs is the only justification needed to keep both around.
+```
+
+- [ ] **Step 2: Create the header skeleton**
+
+`lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp`:
+
+```cpp
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace AstrOsBulkTransport
+{
+    // Single-frame CRC-16/CCITT-FALSE. Poly 0x1021, init 0xFFFF, no input
+    // reflection, no output reflection, no XOR-out. Byte-identical to
+    // ESP-IDF's esp_crc16_le. Standalone (not a class method) so tests
+    // can pin behavior independently of the receiver state machine.
+    uint16_t crc16_ccitt_false(const uint8_t *data, size_t len);
+} // namespace AstrOsBulkTransport
+```
+
+- [ ] **Step 3: Create the source skeleton**
+
+`lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp`:
+
+```cpp
+#include "AstrOsBulkTransport.hpp"
+
+namespace AstrOsBulkTransport
+{
+    uint16_t crc16_ccitt_false(const uint8_t *data, size_t len)
+    {
+        (void)data;
+        (void)len;
+        return 0; // implemented in Task 2
+    }
+} // namespace AstrOsBulkTransport
+```
+
+- [ ] **Step 4: Register with the CI purity guard**
+
+In `.github/workflows/pr-validation.yml`, find the `PURE_LIBS=(` array (around line 33). Append `lib_native/AstrOsBulkTransport` as a new entry. The block should read:
+
+```yaml
+          PURE_LIBS=(
+            lib_native/AstrOsMessaging
+            lib_native/AstrOsUtility
+            lib_native/AstrOsLogging
+            lib_native/AstrOsSerialProtocol
+            lib_native/AstrOsAnimationCommands
+            lib_native/AstrOsAnimationEngine
+            lib_native/AstrOsEspNowProtocol
+            lib_native/AstrOsEspNowPeers
+            lib_native/AstrOsBulkTransport
+          )
+```
+
+- [ ] **Step 5: Verify the existing test suite still passes**
+
+Run: `/home/jeff/.platformio/penv/bin/pio test -e test`
+Expected: 257/257 pass (Phase 1 baseline). The new lib has no tests yet but its presence under `lib_native/` should not break anything.
+
+- [ ] **Step 6: Verify both boards still build**
+
+```bash
+/home/jeff/.platformio/penv/bin/pio run -e metro_s3
+/home/jeff/.platformio/penv/bin/pio run -e lolin_d32_pro
+```
+Expected: both succeed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/jeff/Source/astros/AstrOs.ESP
+git add lib_native/AstrOsBulkTransport/ .github/workflows/pr-validation.yml
+git commit -m "$(cat <<'EOF'
+feat(bulk-transport): scaffold lib_native/AstrOsBulkTransport
+
+Phase 2 of the OTA firmware work. Adds the PURE-lib skeleton plus the
+CI purity-guard registration. Header declares only the standalone
+crc16_ccitt_false helper as a placeholder return; class definition
+and method bodies land in subsequent tasks. No tests yet — the next
+task adds the CRC implementation under TDD.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: `crc16_ccitt_false` implementation + tests
+
+**Files:**
+- Modify: `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp`
+- Create: `test/test_native/bulk_transport_tests.cpp`
+
+CRC-16/CCITT-FALSE: poly `0x1021`, init `0xFFFF`, no input/output reflection, no XOR-out. The canonical check vector is `"123456789"` (9 ASCII bytes) → `0x29B1`. Other useful pin-tests: empty input → `0xFFFF` (the init value); single zero byte → `0x1EF0`; `0xFF` byte → `0xFF00`.
+
+- [ ] **Step 1: Create the test file with failing tests**
+
+`test/test_native/bulk_transport_tests.cpp`:
+
+```cpp
+#include <AstrOsBulkTransport.hpp>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace
+{
+    // Helper: compute CRC over a string literal (excluding null terminator).
+    uint16_t crc(const char *s)
+    {
+        return AstrOsBulkTransport::crc16_ccitt_false(reinterpret_cast<const uint8_t *>(s), std::strlen(s));
+    }
+} // namespace
+
+//=================================================================================================
+// CRC-16/CCITT-FALSE (poly 0x1021, init 0xFFFF, no reflection, no XOR-out)
+//=================================================================================================
+
+TEST(BulkTransport, Crc16EmptyInputReturnsInitValue)
+{
+    // Empty input: CRC equals the init value 0xFFFF.
+    EXPECT_EQ(0xFFFFu, AstrOsBulkTransport::crc16_ccitt_false(nullptr, 0));
+}
+
+TEST(BulkTransport, Crc16CanonicalCheckVector)
+{
+    // "123456789" -> 0x29B1 per the canonical CCITT-FALSE test vector.
+    EXPECT_EQ(0x29B1u, crc("123456789"));
+}
+
+TEST(BulkTransport, Crc16SingleZeroByte)
+{
+    // A single 0x00 byte: well-known CCITT-FALSE result 0x1EF0.
+    const uint8_t data[] = {0x00};
+    EXPECT_EQ(0x1EF0u, AstrOsBulkTransport::crc16_ccitt_false(data, 1));
+}
+
+TEST(BulkTransport, Crc16SingleFfByte)
+{
+    // A single 0xFF byte: well-known CCITT-FALSE result 0xFF00.
+    const uint8_t data[] = {0xFF};
+    EXPECT_EQ(0xFF00u, AstrOsBulkTransport::crc16_ccitt_false(data, 1));
+}
+
+TEST(BulkTransport, Crc16DeterministicAcrossCalls)
+{
+    // Same input on two separate invocations must produce the same output —
+    // a regression guard for any future caching/state mistake.
+    const uint8_t data[] = {0xDE, 0xAD, 0xBE, 0xEF};
+    uint16_t first = AstrOsBulkTransport::crc16_ccitt_false(data, 4);
+    uint16_t second = AstrOsBulkTransport::crc16_ccitt_false(data, 4);
+    EXPECT_EQ(first, second);
+}
+```
+
+Add `#include <cstring>` at the top of the file too, since the helper uses `std::strlen`.
+
+- [ ] **Step 2: Run tests to verify they FAIL**
+
+Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Expected: most CRC tests fail (the placeholder returns `0`). The empty-input test happens to pass coincidentally (placeholder `return 0` ≠ `0xFFFF`, so it actually fails too).
+
+- [ ] **Step 3: Implement `crc16_ccitt_false`**
+
+In `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp`, replace the placeholder implementation:
+
+```cpp
+#include "AstrOsBulkTransport.hpp"
+
+namespace AstrOsBulkTransport
+{
+    // CRC-16/CCITT-FALSE. Bit-by-bit reference implementation:
+    //   poly = 0x1021, init = 0xFFFF, refIn = false, refOut = false, xorOut = 0.
+    // Table-based variants would be faster but the volume here (one chunk =
+    // ~4 KB per frame, ~5 MB/s peak throughput) doesn't justify the static
+    // table cost in a PURE lib that has no on-device performance pressure.
+    uint16_t crc16_ccitt_false(const uint8_t *data, size_t len)
+    {
+        uint16_t crc = 0xFFFFu;
+        for (size_t i = 0; i < len; i++)
+        {
+            crc ^= static_cast<uint16_t>(data[i]) << 8;
+            for (int bit = 0; bit < 8; bit++)
+            {
+                if (crc & 0x8000u)
+                {
+                    crc = static_cast<uint16_t>((crc << 1) ^ 0x1021u);
+                }
+                else
+                {
+                    crc = static_cast<uint16_t>(crc << 1);
+                }
+            }
+        }
+        return crc;
+    }
+} // namespace AstrOsBulkTransport
+```
+
+- [ ] **Step 4: Run tests to verify they PASS**
+
+Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Expected: 257 → 262 (5 new CRC tests). All pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/jeff/Source/astros/AstrOs.ESP
+git add lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp \
+        test/test_native/bulk_transport_tests.cpp
+git commit -m "$(cat <<'EOF'
+feat(bulk-transport): crc16_ccitt_false standalone helper
+
+Bit-by-bit reference implementation of CRC-16/CCITT-FALSE (poly 0x1021,
+init 0xFFFF, no reflection, no XOR-out). Byte-identical to
+esp_crc16_le. Five native tests cover the canonical "123456789" check
+vector, empty-input init-value, single-zero/FF bytes, and call
+determinism.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Public type definitions (enums, result structs, `BulkReceiver` shape)
+
+**Files:**
+- Modify: `lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp`
+
+This task adds the type definitions — `Decision`, `NakReason`, `ChunkResult`, `EndResult`, the `BulkReceiver` class declaration — but no method bodies yet. The lib will still build because the class is just a declaration. The point is to get the public API surface in place so subsequent tasks fill in one method at a time.
+
+No tests yet — types are checked at compile time. The first behavioral test lands in Task 4.
+
+- [ ] **Step 1: Add the type definitions**
+
+In `lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp`, replace the existing namespace contents (currently just `crc16_ccitt_false`) with the full set:
+
+```cpp
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace AstrOsBulkTransport
+{
+    // Single-frame CRC-16/CCITT-FALSE. Poly 0x1021, init 0xFFFF, no input
+    // reflection, no output reflection, no XOR-out. Byte-identical to
+    // ESP-IDF's esp_crc16_le.
+    uint16_t crc16_ccitt_false(const uint8_t *data, size_t len);
+
+    enum class Decision
+    {
+        ACK,
+        NAK
+    };
+
+    // Internal NAK reasons map 1:1 to the wire-level FW_CHUNK_NAK reason
+    // codes (CRC | SIZE | OUT_OF_ORDER | FLASH_FULL). `WRONG_TRANSFER_ID`
+    // and `NOT_ACTIVE` are NOT distinct enum entries — those structural
+    // rejections all map to OUT_OF_ORDER, matching the wire protocol.
+    enum class NakReason : uint8_t
+    {
+        NONE = 0,
+        CRC = 1,
+        SIZE = 2,
+        OUT_OF_ORDER = 3,
+        FLASH_FULL = 4
+    };
+
+    struct ChunkResult
+    {
+        Decision decision = Decision::NAK;
+        uint32_t highestContiguousSeq = 0;
+        uint32_t nextExpectedSeq = 0;
+        uint8_t windowRemaining = 0;
+        NakReason reason = NakReason::NONE;
+        // On ACK only: the caller's input pointer + length pass straight
+        // through, unmodified. BulkReceiver does not own this memory and
+        // does not touch the bytes. nullptr/0 on NAK.
+        const uint8_t *payload = nullptr;
+        uint16_t payloadLen = 0;
+    };
+
+    struct EndResult
+    {
+        // HASH_MISMATCH is reserved for the MIXED-layer caller (Phase 3
+        // OtaReceiver) that owns the streaming SHA-256 context. This
+        // PURE state machine only knows about chunk counts; it returns
+        // OK on matching totals and IO_ERROR on mismatch.
+        enum class Status
+        {
+            OK,
+            HASH_MISMATCH,
+            IO_ERROR
+        };
+        Status status = Status::IO_ERROR;
+    };
+
+    // Sequential chunk-receive state machine for the firmware OTA path.
+    // The receiver commits chunks strictly in seq order — sliding window
+    // is a sender optimization, not a reorder buffer. After every ACK
+    // the receiver reports `windowRemaining = windowSize_` because it
+    // tracks no in-flight state (each ACK'd chunk is already consumed
+    // by the caller).
+    //
+    // Usage:
+    //   BulkReceiver r;
+    //   r.begin(xferId, totalSize, totalChunks, chunkSize, windowSize);
+    //   for each FW_CHUNK arrival:
+    //       auto cr = r.onChunk(xferId, seq, len, crc16, payload);
+    //       // caller acts on cr.decision (write bytes / send ACK / send NAK)
+    //   auto er = r.onEnd(xferId, totalChunksSent);
+    //   r.reset();  // ready for next transfer; safe to call anytime.
+    class BulkReceiver
+    {
+      public:
+        void begin(uint8_t xferId, uint32_t totalSize, uint32_t totalChunks, uint16_t chunkSize, uint8_t windowSize);
+        ChunkResult onChunk(uint8_t xferId, uint32_t seq, uint16_t payloadLen, uint16_t crc16, const uint8_t *payload);
+        EndResult onEnd(uint8_t xferId, uint32_t totalChunksSent);
+        void reset();
+
+      private:
+        uint8_t xferId_ = 0;
+        uint32_t nextSeq_ = 0;
+        uint32_t totalSize_ = 0;
+        uint32_t totalChunks_ = 0;
+        uint16_t chunkSize_ = 0;
+        uint8_t windowSize_ = 0;
+        bool active_ = false;
+    };
+} // namespace AstrOsBulkTransport
+```
+
+- [ ] **Step 2: Verify the lib still compiles**
+
+Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Expected: 262/262 pass — CRC tests still green, no new tests added yet. The `BulkReceiver` class is declared but its methods aren't called from anywhere, so the linker won't complain about missing definitions yet.
+
+(If you get a linker error like "undefined reference to `AstrOsBulkTransport::BulkReceiver::begin`", that means a test file is already trying to use the class — check whether any later-task test was accidentally included.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/jeff/Source/astros/AstrOs.ESP
+git add lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
+git commit -m "$(cat <<'EOF'
+feat(bulk-transport): public type definitions + BulkReceiver shape
+
+Adds Decision / NakReason / ChunkResult / EndResult / BulkReceiver to
+the header. Method bodies land in subsequent tasks under TDD. NakReason
+mirrors the wire-level FW_CHUNK_NAK reason codes 1:1 — structural
+rejections (wrong xferId, not active) collapse to OUT_OF_ORDER on the
+wire. EndResult::Status::HASH_MISMATCH is reserved for the MIXED-layer
+caller; this PURE state machine only validates chunk counts.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: `BulkReceiver::begin` + `reset` + state inspection through `onChunk`
+
+**Files:**
+- Modify: `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp`
+- Modify: `test/test_native/bulk_transport_tests.cpp`
+
+`begin` is a simple field initializer; `reset` is the inverse. Since neither method returns anything observable directly, we test them by observing `onChunk` behavior afterward — but `onChunk` isn't fully implemented yet. So we implement `begin`/`reset` together with the **minimum** `onChunk` needed for happy-path observation (the full reject paths come in Tasks 5–6). The minimal `onChunk` for Task 4 is: "if active and seq matches and payload is fine, accept it; otherwise NAK with `OUT_OF_ORDER`."
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `test/test_native/bulk_transport_tests.cpp`:
+
+```cpp
+//=================================================================================================
+// BulkReceiver::begin + reset + minimal onChunk happy path
+//=================================================================================================
+
+TEST(BulkTransport, BeginThenSingleChunkInOrderAcks)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/12, /*totalChunks=*/1, /*chunkSize=*/12, /*windowSize=*/16);
+
+    const uint8_t payload[] = {'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd', '!'};
+    uint16_t expectedCrc = AstrOsBulkTransport::crc16_ccitt_false(payload, sizeof(payload));
+
+    auto result = r.onChunk(/*xferId=*/7, /*seq=*/0, sizeof(payload), expectedCrc, payload);
+
+    EXPECT_EQ(AstrOsBulkTransport::Decision::ACK, result.decision);
+    EXPECT_EQ(AstrOsBulkTransport::NakReason::NONE, result.reason);
+    EXPECT_EQ(0u, result.highestContiguousSeq);
+    EXPECT_EQ(1u, result.nextExpectedSeq);
+    EXPECT_EQ(16u, result.windowRemaining); // matches the windowSize passed to begin()
+    EXPECT_EQ(payload, result.payload);     // pointer passes through unmodified
+    EXPECT_EQ(sizeof(payload), result.payloadLen);
+}
+
+TEST(BulkTransport, OnChunkBeforeBeginNaksOutOfOrder)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    // No begin() called.
+    const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
+
+    auto result = r.onChunk(/*xferId=*/7, /*seq=*/0, 4, crc, payload);
+
+    EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
+    EXPECT_EQ(AstrOsBulkTransport::NakReason::OUT_OF_ORDER, result.reason);
+}
+
+TEST(BulkTransport, ResetReturnsToInactive)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/100, /*totalChunks=*/1, /*chunkSize=*/100, /*windowSize=*/8);
+    r.reset();
+
+    // After reset, onChunk should behave the same as if begin() had never been called.
+    const uint8_t payload[] = {0x01, 0x02};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 2);
+    auto result = r.onChunk(/*xferId=*/7, /*seq=*/0, 2, crc, payload);
+
+    EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
+    EXPECT_EQ(AstrOsBulkTransport::NakReason::OUT_OF_ORDER, result.reason);
+}
+
+TEST(BulkTransport, BeginAfterEndReusesReceiver)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t firstPayload[] = {'a', 'b', 'c', 'd'};
+    uint16_t firstCrc = AstrOsBulkTransport::crc16_ccitt_false(firstPayload, 4);
+    auto first = r.onChunk(7, 0, 4, firstCrc, firstPayload);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, first.decision);
+
+    // Reset, begin a new transfer with a different xferId, and accept its first chunk.
+    r.reset();
+    r.begin(/*xferId=*/9, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t secondPayload[] = {'e', 'f', 'g', 'h'};
+    uint16_t secondCrc = AstrOsBulkTransport::crc16_ccitt_false(secondPayload, 4);
+    auto second = r.onChunk(9, 0, 4, secondCrc, secondPayload);
+
+    EXPECT_EQ(AstrOsBulkTransport::Decision::ACK, second.decision);
+    EXPECT_EQ(0u, second.highestContiguousSeq);
+    EXPECT_EQ(1u, second.nextExpectedSeq);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they FAIL**
+
+Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Expected: link errors (`undefined reference to BulkReceiver::begin`, etc.) — the methods are declared but have no definitions yet.
+
+- [ ] **Step 3: Implement `begin`, `reset`, and a minimal `onChunk`**
+
+In `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp`, append after the CRC implementation:
+
+```cpp
+    void BulkReceiver::begin(uint8_t xferId, uint32_t totalSize, uint32_t totalChunks, uint16_t chunkSize,
+                              uint8_t windowSize)
+    {
+        xferId_ = xferId;
+        nextSeq_ = 0;
+        totalSize_ = totalSize;
+        totalChunks_ = totalChunks;
+        chunkSize_ = chunkSize;
+        windowSize_ = windowSize;
+        active_ = true;
+    }
+
+    void BulkReceiver::reset()
+    {
+        xferId_ = 0;
+        nextSeq_ = 0;
+        totalSize_ = 0;
+        totalChunks_ = 0;
+        chunkSize_ = 0;
+        windowSize_ = 0;
+        active_ = false;
+    }
+
+    ChunkResult BulkReceiver::onChunk(uint8_t xferId, uint32_t seq, uint16_t payloadLen, uint16_t crc16,
+                                       const uint8_t *payload)
+    {
+        ChunkResult result{};
+        result.decision = Decision::NAK;
+        result.reason = NakReason::OUT_OF_ORDER;
+        // highestContiguousSeq / nextExpectedSeq / windowRemaining default to 0 for the not-active path.
+
+        if (!active_ || xferId != xferId_ || seq != nextSeq_)
+        {
+            // Subsequent tasks: explicit handling for CRC / SIZE / etc. For
+            // now, anything other than a matching in-order chunk on an
+            // active transfer NAKs as OUT_OF_ORDER.
+            return result;
+        }
+
+        // Happy path: ACK and advance.
+        // CRC + SIZE validation come in Task 5/6; for now we trust the inputs
+        // to keep this task's diff focused on begin/reset/state.
+        (void)crc16;
+        (void)payloadLen;
+        result.decision = Decision::ACK;
+        result.reason = NakReason::NONE;
+        result.highestContiguousSeq = seq;
+        result.nextExpectedSeq = seq + 1;
+        result.windowRemaining = windowSize_;
+        result.payload = payload;
+        result.payloadLen = payloadLen;
+        nextSeq_++;
+        return result;
+    }
+```
+
+Note: the public `EndResult BulkReceiver::onEnd(...)` is declared in the header but not defined yet. As long as nothing calls it, the linker doesn't care. (If your toolchain does complain, add a stub: `EndResult BulkReceiver::onEnd(uint8_t, uint32_t) { return {}; }` and remove it in Task 7.)
+
+- [ ] **Step 4: Run tests to verify they PASS**
+
+Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Expected: 262 → 266 (4 new tests). All pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/jeff/Source/astros/AstrOs.ESP
+git add lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp \
+        test/test_native/bulk_transport_tests.cpp
+git commit -m "$(cat <<'EOF'
+feat(bulk-transport): begin + reset + minimal onChunk happy path
+
+BulkReceiver state-machine skeleton: begin() initializes the active
+transfer; reset() returns to inactive; onChunk() ACKs an in-order
+matching chunk on an active transfer and NAKs with OUT_OF_ORDER for
+the not-active / wrong-xferId / wrong-seq cases. CRC and SIZE
+validation come in subsequent tasks. Four tests cover the happy path,
+not-active rejection, post-reset rejection, and begin-after-end reuse.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: `BulkReceiver::onChunk` — CRC + SIZE rejection
+
+**Files:**
+- Modify: `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp`
+- Modify: `test/test_native/bulk_transport_tests.cpp`
+
+CRC validation: receiver recomputes `crc16_ccitt_false(payload, payloadLen)` and rejects with `NakReason::CRC` if the recomputed value doesn't match the `crc16` argument.
+
+SIZE validation: `payloadLen` must equal `chunkSize_` for all chunks except possibly the last one. The last chunk may be shorter if `totalSize_` isn't a clean multiple of `chunkSize_`. The current chunk's expected length is:
+
+```
+remainingSize = totalSize_ - (seq * chunkSize_);
+expectedLen = min(chunkSize_, remainingSize)
+```
+
+`SIZE` NAK fires if `payloadLen != expectedLen`.
+
+Both new NAK paths report `highestContiguousSeq = nextSeq_ - 1` (last committed seq), `nextExpectedSeq = nextSeq_` (where the sender should resume), `windowRemaining = windowSize_`. The first chunk's `highestContiguousSeq` is reported as `0` when `nextSeq_ == 0` — that's a known one-off: the wire-level meaning is "I've committed nothing yet"; downstream clients treat `highest=0, next=0` as the initial-state marker.
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `test/test_native/bulk_transport_tests.cpp`:
+
+```cpp
+//=================================================================================================
+// BulkReceiver::onChunk — CRC + SIZE rejection
+//=================================================================================================
+
+TEST(BulkTransport, OnChunkBadCrcNaks)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
+    uint16_t realCrc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
+    auto result = r.onChunk(7, 0, 4, /*crc16=*/static_cast<uint16_t>(realCrc ^ 0xFFFFu), payload);
+
+    EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
+    EXPECT_EQ(AstrOsBulkTransport::NakReason::CRC, result.reason);
+    // No chunk committed yet -> reported as 0/0.
+    EXPECT_EQ(0u, result.highestContiguousSeq);
+    EXPECT_EQ(0u, result.nextExpectedSeq);
+    EXPECT_EQ(16u, result.windowRemaining);
+}
+
+TEST(BulkTransport, OnChunkPayloadLenMismatchNaksSize)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    // totalSize = 4096, chunkSize = 1024 -> 4 chunks of 1024 bytes each.
+    r.begin(/*xferId=*/7, /*totalSize=*/4096, /*totalChunks=*/4, /*chunkSize=*/1024, /*windowSize=*/16);
+
+    // Sender claims this is chunk 0 with len=500 — wrong; should be 1024.
+    std::vector<uint8_t> payload(500, 0xAA);
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload.data(), payload.size());
+    auto result = r.onChunk(7, 0, static_cast<uint16_t>(payload.size()), crc, payload.data());
+
+    EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
+    EXPECT_EQ(AstrOsBulkTransport::NakReason::SIZE, result.reason);
+}
+
+TEST(BulkTransport, OnChunkLastShortChunkAcks)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    // totalSize = 2500, chunkSize = 1024 -> chunks of 1024, 1024, 452.
+    r.begin(/*xferId=*/7, /*totalSize=*/2500, /*totalChunks=*/3, /*chunkSize=*/1024, /*windowSize=*/16);
+
+    // Commit chunks 0 and 1.
+    std::vector<uint8_t> fullChunk(1024, 0xCC);
+    uint16_t fullCrc = AstrOsBulkTransport::crc16_ccitt_false(fullChunk.data(), fullChunk.size());
+    auto r0 = r.onChunk(7, 0, 1024, fullCrc, fullChunk.data());
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r0.decision);
+    auto r1 = r.onChunk(7, 1, 1024, fullCrc, fullChunk.data());
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r1.decision);
+
+    // Last chunk: 452 bytes — the short tail.
+    std::vector<uint8_t> tail(452, 0xDD);
+    uint16_t tailCrc = AstrOsBulkTransport::crc16_ccitt_false(tail.data(), tail.size());
+    auto r2 = r.onChunk(7, 2, 452, tailCrc, tail.data());
+    EXPECT_EQ(AstrOsBulkTransport::Decision::ACK, r2.decision);
+    EXPECT_EQ(2u, r2.highestContiguousSeq);
+    EXPECT_EQ(3u, r2.nextExpectedSeq);
+}
+
+TEST(BulkTransport, OnChunkWrongPayloadLenOnLastChunkNaksSize)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    // totalSize = 2500, chunkSize = 1024 -> last chunk expected = 452 bytes.
+    r.begin(/*xferId=*/7, /*totalSize=*/2500, /*totalChunks=*/3, /*chunkSize=*/1024, /*windowSize=*/16);
+
+    std::vector<uint8_t> fullChunk(1024, 0xCC);
+    uint16_t fullCrc = AstrOsBulkTransport::crc16_ccitt_false(fullChunk.data(), fullChunk.size());
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(7, 0, 1024, fullCrc, fullChunk.data()).decision);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(7, 1, 1024, fullCrc, fullChunk.data()).decision);
+
+    // Last chunk: sender sends 1024 bytes but only 452 are expected.
+    std::vector<uint8_t> wrongTail(1024, 0xDD);
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(wrongTail.data(), wrongTail.size());
+    auto result = r.onChunk(7, 2, 1024, crc, wrongTail.data());
+
+    EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
+    EXPECT_EQ(AstrOsBulkTransport::NakReason::SIZE, result.reason);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they FAIL**
+
+Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Expected: the new tests fail (the current `onChunk` ignores CRC/SIZE — bad CRC + wrong length both pass through as ACK).
+
+- [ ] **Step 3: Add SIZE + CRC checks to `onChunk`**
+
+In `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp`, replace the body of `onChunk` with:
+
+```cpp
+    ChunkResult BulkReceiver::onChunk(uint8_t xferId, uint32_t seq, uint16_t payloadLen, uint16_t crc16,
+                                       const uint8_t *payload)
+    {
+        ChunkResult result{};
+        result.decision = Decision::NAK;
+        // Reported window: always windowSize_ on every reply. The receiver
+        // tracks no in-flight state.
+        result.windowRemaining = active_ ? windowSize_ : 0;
+
+        // Structural rejections first: not-active, wrong xferId, out-of-seq.
+        // All collapse to OUT_OF_ORDER per the wire-level reason-code set.
+        if (!active_ || xferId != xferId_ || seq != nextSeq_)
+        {
+            result.reason = NakReason::OUT_OF_ORDER;
+            // highestContiguousSeq / nextExpectedSeq default to 0 on the
+            // not-active path; on an active mismatch they should reflect
+            // the receiver's actual state so the sender can resync.
+            if (active_)
+            {
+                result.highestContiguousSeq = (nextSeq_ == 0) ? 0 : (nextSeq_ - 1);
+                result.nextExpectedSeq = nextSeq_;
+            }
+            return result;
+        }
+
+        // SIZE: compute the expected length for THIS seq. All chunks are
+        // chunkSize_ bytes except possibly the last one (totalSize_ may not
+        // be a clean multiple of chunkSize_).
+        uint32_t expectedLen = chunkSize_;
+        uint32_t committedBytes = static_cast<uint32_t>(seq) * chunkSize_;
+        if (committedBytes + chunkSize_ > totalSize_)
+        {
+            expectedLen = totalSize_ - committedBytes;
+        }
+        if (payloadLen != expectedLen)
+        {
+            result.reason = NakReason::SIZE;
+            result.highestContiguousSeq = (nextSeq_ == 0) ? 0 : (nextSeq_ - 1);
+            result.nextExpectedSeq = nextSeq_;
+            return result;
+        }
+
+        // CRC: recompute over the payload and compare.
+        uint16_t computed = crc16_ccitt_false(payload, payloadLen);
+        if (computed != crc16)
+        {
+            result.reason = NakReason::CRC;
+            result.highestContiguousSeq = (nextSeq_ == 0) ? 0 : (nextSeq_ - 1);
+            result.nextExpectedSeq = nextSeq_;
+            return result;
+        }
+
+        // ACK and advance.
+        result.decision = Decision::ACK;
+        result.reason = NakReason::NONE;
+        result.highestContiguousSeq = seq;
+        result.nextExpectedSeq = seq + 1;
+        result.payload = payload;
+        result.payloadLen = payloadLen;
+        nextSeq_++;
+        return result;
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they PASS**
+
+Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Expected: 266 → 270 (4 new tests). All pass including the existing happy-path test from Task 4.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/jeff/Source/astros/AstrOs.ESP
+git add lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp \
+        test/test_native/bulk_transport_tests.cpp
+git commit -m "$(cat <<'EOF'
+feat(bulk-transport): onChunk CRC + SIZE validation
+
+onChunk recomputes crc16_ccitt_false over the payload and rejects
+with NakReason::CRC on mismatch. Payload-len is checked against the
+expected size for the current seq, including the short-last-chunk
+case (totalSize % chunkSize != 0). Both rejection paths report
+highestContiguousSeq / nextExpectedSeq so the sender can resync.
+4 new tests cover bad CRC, wrong payload length, correct short last
+chunk, and wrong-sized last chunk.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: `BulkReceiver::onChunk` — duplicate + wrong-xferId state reporting
+
+**Files:**
+- Modify: `test/test_native/bulk_transport_tests.cpp`
+
+The behaviour for wrong-xferId already collapses to `OUT_OF_ORDER` in Task 4's code. Duplicate-seq (the sender retransmits seq=0 after we've already ACK'd it and moved to nextSeq_=1) also collapses to `OUT_OF_ORDER` since `seq != nextSeq_` triggers the structural-reject branch. This task adds explicit test coverage for both behaviours — no source changes needed if Task 5 is correct, just additional regression guards.
+
+If the assertion in Step 3 fails, the production logic from Task 5 needs to be re-examined; only add source code if a test reveals a bug.
+
+- [ ] **Step 1: Add the duplicate + wrong-xferId tests**
+
+Append to `test/test_native/bulk_transport_tests.cpp`:
+
+```cpp
+//=================================================================================================
+// BulkReceiver::onChunk — duplicate + wrong-xferId rejection
+//=================================================================================================
+
+TEST(BulkTransport, OnChunkDuplicateSeqNaksOutOfOrder)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
+
+    // ACK seq=0 cleanly.
+    auto first = r.onChunk(7, 0, 4, crc, payload);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, first.decision);
+    EXPECT_EQ(1u, first.nextExpectedSeq);
+
+    // Sender retransmits seq=0 — receiver has already moved on.
+    auto duplicate = r.onChunk(7, 0, 4, crc, payload);
+    EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, duplicate.decision);
+    EXPECT_EQ(AstrOsBulkTransport::NakReason::OUT_OF_ORDER, duplicate.reason);
+    // Reports we last committed seq=0, expect seq=1 next.
+    EXPECT_EQ(0u, duplicate.highestContiguousSeq);
+    EXPECT_EQ(1u, duplicate.nextExpectedSeq);
+}
+
+TEST(BulkTransport, OnChunkSkipForwardNaksOutOfOrder)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
+
+    // Sender jumps to seq=1 without sending seq=0.
+    auto skipped = r.onChunk(7, 1, 4, crc, payload);
+    EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, skipped.decision);
+    EXPECT_EQ(AstrOsBulkTransport::NakReason::OUT_OF_ORDER, skipped.reason);
+    EXPECT_EQ(0u, skipped.nextExpectedSeq);
+}
+
+TEST(BulkTransport, OnChunkWrongXferIdNaksOutOfOrder)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
+
+    // Send a chunk claiming xferId=9 on a receiver bound to xferId=7.
+    auto result = r.onChunk(/*xferId=*/9, 0, 4, crc, payload);
+    EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
+    EXPECT_EQ(AstrOsBulkTransport::NakReason::OUT_OF_ORDER, result.reason);
+    EXPECT_EQ(0u, result.nextExpectedSeq);
+
+    // The receiver state must not have been corrupted: a correct chunk for
+    // xferId=7 still gets ACK'd cleanly afterward.
+    auto recovery = r.onChunk(7, 0, 4, crc, payload);
+    EXPECT_EQ(AstrOsBulkTransport::Decision::ACK, recovery.decision);
+    EXPECT_EQ(1u, recovery.nextExpectedSeq);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they PASS immediately**
+
+Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Expected: 270 → 273. All new tests pass on first attempt because the structural-reject branch in Task 5's `onChunk` already collapses these cases to `OUT_OF_ORDER`. If any fail, *do not* "fix" them by editing the production code without first re-reading it carefully — the test is more likely to be wrong than the implementation, given Task 5 already covered the logic.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/jeff/Source/astros/AstrOs.ESP
+git add test/test_native/bulk_transport_tests.cpp
+git commit -m "$(cat <<'EOF'
+test(bulk-transport): duplicate + skip-forward + wrong-xferId coverage
+
+Adds three regression tests for the structural-reject path in onChunk:
+duplicate seq, skip-forward seq, and wrong xferId all NAK as
+OUT_OF_ORDER. Also verifies that a wrong-xferId attempt does not
+corrupt receiver state — a subsequent correct chunk still ACKs
+cleanly. No source changes; behavior was already correct from Task 5.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: `BulkReceiver::onEnd` — happy path
+
+**Files:**
+- Modify: `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp`
+- Modify: `test/test_native/bulk_transport_tests.cpp`
+
+`onEnd` validates that the transfer is complete: `active_ == true`, `xferId == xferId_`, and `totalChunksSent == totalChunks_` (the value the sender reports must match what was declared in `begin()`), AND `nextSeq_ == totalChunks_` (the receiver actually saw and ACK'd every chunk). All matching → `Status::OK`. The caller is responsible for `reset()`ing the receiver afterward.
+
+This task covers the OK path only; the IO_ERROR path lands in Task 8.
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `test/test_native/bulk_transport_tests.cpp`:
+
+```cpp
+//=================================================================================================
+// BulkReceiver::onEnd — happy path
+//=================================================================================================
+
+TEST(BulkTransport, OnEndAfterAllChunksReturnsOk)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(7, 0, 4, crc, payload).decision);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(7, 1, 4, crc, payload).decision);
+
+    auto end = r.onEnd(/*xferId=*/7, /*totalChunksSent=*/2);
+    EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::OK, end.status);
+}
+```
+
+- [ ] **Step 2: Run test to verify it FAILS**
+
+Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Expected: link error if Task 4 didn't include a stub for `onEnd`. Or, if Task 4's stub returned `{}` (default `Status::IO_ERROR`), the test fails with `Expected: equality of these values: AstrOsBulkTransport::EndResult::Status::OK ... Actual: 2 (IO_ERROR)`.
+
+- [ ] **Step 3: Implement `onEnd` happy path**
+
+Append to `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp` (or replace the stub from Task 4):
+
+```cpp
+    EndResult BulkReceiver::onEnd(uint8_t xferId, uint32_t totalChunksSent)
+    {
+        EndResult result{};
+        result.status = EndResult::Status::IO_ERROR;
+
+        if (!active_ || xferId != xferId_)
+        {
+            return result;
+        }
+        if (totalChunksSent != totalChunks_)
+        {
+            return result;
+        }
+        if (nextSeq_ != totalChunks_)
+        {
+            return result;
+        }
+
+        result.status = EndResult::Status::OK;
+        return result;
+    }
+```
+
+- [ ] **Step 4: Run test to verify it PASSES**
+
+Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Expected: 273 → 274. The OK case passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/jeff/Source/astros/AstrOs.ESP
+git add lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp \
+        test/test_native/bulk_transport_tests.cpp
+git commit -m "$(cat <<'EOF'
+feat(bulk-transport): onEnd happy path returns OK
+
+After begin + all chunks ACK'd in order, onEnd(matchingXferId,
+totalChunks) returns Status::OK. Reject paths (not active / wrong
+xferId / chunk-count mismatch) collapse to IO_ERROR; explicit tests
+for those follow in the next task.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: `BulkReceiver::onEnd` — IO_ERROR reject paths
+
+**Files:**
+- Modify: `test/test_native/bulk_transport_tests.cpp`
+
+Test the four IO_ERROR paths Task 7's implementation introduced: not-active, wrong xferId, sender-reported total mismatch, receiver-actual chunk count mismatch. No source changes if Task 7's implementation is correct; the assertions verify each guard fires.
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `test/test_native/bulk_transport_tests.cpp`:
+
+```cpp
+//=================================================================================================
+// BulkReceiver::onEnd — IO_ERROR reject paths
+//=================================================================================================
+
+TEST(BulkTransport, OnEndBeforeBeginReturnsIoError)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    // No begin() called.
+    auto end = r.onEnd(/*xferId=*/7, /*totalChunksSent=*/1);
+    EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::IO_ERROR, end.status);
+}
+
+TEST(BulkTransport, OnEndWrongXferIdReturnsIoError)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(7, 0, 4, crc, payload).decision);
+
+    // Caller claims this END is for a different xferId.
+    auto end = r.onEnd(/*xferId=*/9, /*totalChunksSent=*/1);
+    EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::IO_ERROR, end.status);
+}
+
+TEST(BulkTransport, OnEndSenderTotalMismatchReturnsIoError)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(7, 0, 4, crc, payload).decision);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(7, 1, 4, crc, payload).decision);
+
+    // Sender claims 3 chunks were sent, but begin() said 2.
+    auto end = r.onEnd(/*xferId=*/7, /*totalChunksSent=*/3);
+    EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::IO_ERROR, end.status);
+}
+
+TEST(BulkTransport, OnEndReceiverShortChunkCountReturnsIoError)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(7, 0, 4, crc, payload).decision);
+    // Only one chunk was sent; sender claims 2 to match the declared total.
+
+    auto end = r.onEnd(/*xferId=*/7, /*totalChunksSent=*/2);
+    EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::IO_ERROR, end.status);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they PASS immediately**
+
+Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Expected: 274 → 278. All new tests pass on first attempt — the guards in Task 7's `onEnd` already handle each path.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/jeff/Source/astros/AstrOs.ESP
+git add test/test_native/bulk_transport_tests.cpp
+git commit -m "$(cat <<'EOF'
+test(bulk-transport): onEnd IO_ERROR reject paths
+
+Four regression tests cover the IO_ERROR paths through onEnd:
+not-active, wrong xferId, sender-reported total mismatch, and
+receiver-actual chunk-count short. No source changes; behavior
+was already correct from Task 7.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 9: End-to-end multi-chunk integration test
+
+**Files:**
+- Modify: `test/test_native/bulk_transport_tests.cpp`
+
+A single end-to-end test that drives a realistic transfer: 10 chunks of varying sizes, all in order, with one CRC failure mid-stream followed by a successful retransmit, then `onEnd`. This is the "if you only run one BulkReceiver test on the bench rig, run this one" smoke test — it exercises every code path through `begin → many onChunks → onEnd → OK`.
+
+- [ ] **Step 1: Add the integration test**
+
+Append to `test/test_native/bulk_transport_tests.cpp`:
+
+```cpp
+//=================================================================================================
+// BulkReceiver — end-to-end happy path with one mid-stream CRC retransmit
+//=================================================================================================
+
+TEST(BulkTransport, EndToEndTenChunkTransferWithMidStreamRetransmit)
+{
+    constexpr uint32_t kTotalSize = 9500;
+    constexpr uint16_t kChunkSize = 1024;
+    constexpr uint32_t kTotalChunks = 10; // 9 full chunks + 1 short (9500 - 9216 = 284 bytes)
+    constexpr uint8_t kXferId = 42;
+    constexpr uint8_t kWindowSize = 16;
+
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(kXferId, kTotalSize, kTotalChunks, kChunkSize, kWindowSize);
+
+    // 9 full chunks + 1 short tail.
+    std::vector<uint8_t> fullPayload(kChunkSize, 0xA5);
+    uint16_t fullCrc = AstrOsBulkTransport::crc16_ccitt_false(fullPayload.data(), fullPayload.size());
+
+    for (uint32_t seq = 0; seq < kTotalChunks - 1; seq++)
+    {
+        if (seq == 5)
+        {
+            // Mid-stream CRC error: sender sends correct payload with a corrupted CRC field.
+            auto nakResult =
+                r.onChunk(kXferId, seq, kChunkSize, static_cast<uint16_t>(fullCrc ^ 0x00FFu), fullPayload.data());
+            ASSERT_EQ(AstrOsBulkTransport::Decision::NAK, nakResult.decision);
+            ASSERT_EQ(AstrOsBulkTransport::NakReason::CRC, nakResult.reason);
+            EXPECT_EQ(4u, nakResult.highestContiguousSeq);
+            EXPECT_EQ(5u, nakResult.nextExpectedSeq);
+            // Sender retransmits seq=5 with the correct CRC.
+        }
+        auto okResult = r.onChunk(kXferId, seq, kChunkSize, fullCrc, fullPayload.data());
+        ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, okResult.decision) << "ACK failed at seq=" << seq;
+        ASSERT_EQ(seq + 1, okResult.nextExpectedSeq);
+    }
+
+    // Final short chunk: 9500 - 9 * 1024 = 9500 - 9216 = 284 bytes.
+    constexpr uint16_t kTailLen = 284;
+    std::vector<uint8_t> tail(kTailLen, 0xC3);
+    uint16_t tailCrc = AstrOsBulkTransport::crc16_ccitt_false(tail.data(), tail.size());
+    auto tailResult = r.onChunk(kXferId, kTotalChunks - 1, kTailLen, tailCrc, tail.data());
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, tailResult.decision);
+    EXPECT_EQ(kTotalChunks - 1, tailResult.highestContiguousSeq);
+    EXPECT_EQ(kTotalChunks, tailResult.nextExpectedSeq);
+
+    // End of transfer.
+    auto endResult = r.onEnd(kXferId, kTotalChunks);
+    EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::OK, endResult.status);
+
+    r.reset();
+}
+```
+
+- [ ] **Step 2: Run tests to verify the new test PASSES**
+
+Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Expected: 278 → 279. The integration test passes — and if any of the prior tasks left a subtle bug, this is likely where it surfaces.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/jeff/Source/astros/AstrOs.ESP
+git add test/test_native/bulk_transport_tests.cpp
+git commit -m "$(cat <<'EOF'
+test(bulk-transport): end-to-end 10-chunk transfer with CRC retransmit
+
+Drives a full realistic transfer: 10 chunks (9 full + 1 short tail),
+one mid-stream CRC failure followed by a successful retransmit, then
+onEnd → OK. Exercises the complete begin → many onChunks → onEnd path
+in one test — the canonical smoke test if only one BulkReceiver test
+were run.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 10: Final verification + open PR
+
+**Files:** None modified — verification only.
+
+- [ ] **Step 1: Run the full native test suite**
+
+Run: `/home/jeff/.platformio/penv/bin/pio test -e test`
+Expected: 257 → 279 (22 new BulkTransport tests). All pass.
+
+- [ ] **Step 2: Build both board firmware variants**
+
+```bash
+/home/jeff/.platformio/penv/bin/pio run -e metro_s3
+/home/jeff/.platformio/penv/bin/pio run -e lolin_d32_pro
+```
+Expected: both succeed. Phase 2 doesn't change firmware behavior; this just confirms the new lib doesn't accidentally break the on-device build (e.g., via header transitive includes that confuse the IDF build).
+
+- [ ] **Step 3: Confirm CI purity guard is happy**
+
+The CI guard greps the source tree for forbidden include patterns. Simulate it locally:
+
+```bash
+grep -rEn '#include[[:space:]]*[<"](freertos/|esp_|driver/|nvs_|sdmmc_)' lib_native/AstrOsBulkTransport
+```
+Expected: no output. If anything matches, the offending include must move out of the PURE lib.
+
+- [ ] **Step 4: clang-format check on changed files**
+
+```bash
+find lib_native/AstrOsBulkTransport test/test_native/bulk_transport_tests.cpp \
+    -name '*.hpp' -o -name '*.cpp' -o -name '*.h' | \
+    xargs clang-format --dry-run --Werror
+```
+Expected: no output. (The pre-commit hook should have already kept this clean.)
+
+- [ ] **Step 5: Push branch + open PR**
+
+The branch `feature/ota-phase2-bulk-transport` was cut from `develop` before this plan started. To push and open the PR:
+
+```bash
+git push -u origin feature/ota-phase2-bulk-transport
+
+gh pr create --base develop --title "Firmware OTA Phase 2 — bulk-transport state machine" --body "$(cat <<'EOF'
+## Summary
+
+Phase 2 of the ESP-side OTA firmware work. Adds the
+\`lib_native/AstrOsBulkTransport\` PURE state machine that consumes
+parsed \`FW_CHUNK\` records (from Phase 1's \`parseFwChunk\`) and
+produces ACK/NAK decisions with sliding-window backpressure metadata.
+**No firmware behavior change yet** — this phase is purely a new PURE
+lib with native tests. Phase 3 wires the BulkReceiver into the
+serial-handler dispatch path.
+
+Design: \`.docs/plans/20260514-1941-firmware-ota-esp-master-serial-receive-design.md\`
+Plan: \`.docs/plans/20260514-2300-firmware-ota-phase2-bulk-transport.md\`
+
+Adds:
+- New PURE lib \`lib_native/AstrOsBulkTransport\` with \`BulkReceiver\` class + \`crc16_ccitt_false\` standalone helper
+- \`Decision\`, \`NakReason\`, \`ChunkResult\`, \`EndResult\` public types
+- Sequential chunk-receive state machine: in-order commit, structural rejections collapse to OUT_OF_ORDER, CRC + SIZE validation, short-last-chunk support
+- 22 new native tests covering CRC check vectors, in-order happy path, every rejection (CRC / SIZE / OUT_OF_ORDER / wrong-xferId / not-active / duplicate / skip-forward), onEnd OK and IO_ERROR paths, plus a 10-chunk end-to-end integration test with mid-stream CRC retransmit
+- CI purity-guard registration for the new lib in \`.github/workflows/pr-validation.yml\`
+
+## Test plan
+
+- [x] \`pio test -e test\` passes (279/279)
+- [x] \`pio run -e metro_s3\` builds clean
+- [x] \`pio run -e lolin_d32_pro\` builds clean
+- [x] CI native-purity grep finds no forbidden includes in the new lib
+- [x] clang-format clean on changed files
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+(`git push` and `gh pr create` need to run from your VS Code terminal where auth is established.)
+
+---
+
+## Self-review notes (already applied to this plan)
+
+- **Spec coverage:** every Phase 2 deliverable in the design doc is covered:
+  - PURE lib scaffolding + README + CI registration (Task 1) ✓
+  - `crc16_ccitt_false` (Task 2) ✓
+  - Type definitions + `BulkReceiver` shape (Task 3) ✓
+  - `begin` / `reset` / minimal `onChunk` (Task 4) ✓
+  - `onChunk` CRC + SIZE validation (Task 5) ✓
+  - `onChunk` duplicate / skip / wrong-xferId test coverage (Task 6) ✓
+  - `onEnd` OK + IO_ERROR (Tasks 7 + 8) ✓
+  - End-to-end integration test (Task 9) ✓
+  - Final verification + PR (Task 10) ✓
+- **Placeholder scan:** no TBDs, no "add appropriate handling", every code step shows the actual code.
+- **Type consistency:** `BulkReceiver`, `ChunkResult`, `EndResult`, `Decision`, `NakReason` are used consistently across all tasks. `crc16_ccitt_false` lowercase-underscore naming is used everywhere.
+- **Scope check:** 10 tasks. Above the CLAUDE.md ~8-task warning, but each task is small (≤2 files, ≤30 min) and Phase 2 is genuinely one coherent unit — splitting into "scaffold" and "state machine" sub-phases would just add cross-PR coordination cost without value. If the scope grows past 10, escalate.

--- a/.docs/plans/20260514-2300-firmware-ota-phase2-bulk-transport.md
+++ b/.docs/plans/20260514-2300-firmware-ota-phase2-bulk-transport.md
@@ -78,8 +78,8 @@ No changes to `lib_native/AstrOsMessaging`, `lib_native/AstrOsSerialProtocol`, o
 
 ## Background notes for the implementer
 
-- **`pio` is at `/home/jeff/.platformio/penv/bin/pio`** (not on default PATH). All test/build commands in this plan use the full path.
-- **Run native tests with**: `/home/jeff/.platformio/penv/bin/pio test -e test`. The `--filter "test_native"` matches the test folder, not test names; matching by test name uses `--filter "*BulkTransport*"` against the GoogleTest binary.
+- **`pio` should be on your PATH.** If the PlatformIO virtualenv isn't activated, invoke it via its full install path (commonly `~/.platformio/penv/bin/pio` for the per-user installer, or via your VS Code PlatformIO extension's bundled binary). The commands below all use bare `pio` — substitute the path that works for your setup.
+- **Run native tests with**: `pio test -e test`. The `--filter "test_native"` matches the test folder, not test names; matching by test name uses `--filter "*BulkTransport*"` against the GoogleTest binary.
 - **The pre-commit hook runs clang-format** on staged C/C++ files. Expect it to reformat whitespace; the commit still succeeds.
 - **The CI native-purity guard** (`.github/workflows/pr-validation.yml`) greps for `#include <(freertos/|esp_|driver/|nvs_|sdmmc_)…>` across every path in `PURE_LIBS`. Don't include any of those, ever. The lib has no need to — we're not touching FreeRTOS, ESP-IDF, or hardware. Standard C++17 only.
 - **No exceptions.** CLAUDE.md and existing patterns: don't `throw`; don't `try/catch`. Return result structs.
@@ -209,21 +209,21 @@ In `.github/workflows/pr-validation.yml`, find the `PURE_LIBS=(` array (around l
 
 - [ ] **Step 5: Verify the existing test suite still passes**
 
-Run: `/home/jeff/.platformio/penv/bin/pio test -e test`
+Run: `pio test -e test`
 Expected: 257/257 pass (Phase 1 baseline). The new lib has no tests yet but its presence under `lib_native/` should not break anything.
 
 - [ ] **Step 6: Verify both boards still build**
 
 ```bash
-/home/jeff/.platformio/penv/bin/pio run -e metro_s3
-/home/jeff/.platformio/penv/bin/pio run -e lolin_d32_pro
+pio run -e metro_s3
+pio run -e lolin_d32_pro
 ```
 Expected: both succeed.
 
 - [ ] **Step 7: Commit**
 
 ```bash
-cd /home/jeff/Source/astros/AstrOs.ESP
+cd <repo-root>
 git add lib_native/AstrOsBulkTransport/ .github/workflows/pr-validation.yml
 git commit -m "$(cat <<'EOF'
 feat(bulk-transport): scaffold lib_native/AstrOsBulkTransport
@@ -314,7 +314,7 @@ Add `#include <cstring>` at the top of the file too, since the helper uses `std:
 
 - [ ] **Step 2: Run tests to verify they FAIL**
 
-Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Run: `pio test -e test --filter "test_native"`
 Expected: most CRC tests fail (the placeholder returns `0`). The empty-input test happens to pass coincidentally (placeholder `return 0` ≠ `0xFFFF`, so it actually fails too).
 
 - [ ] **Step 3: Implement `crc16_ccitt_false`**
@@ -356,13 +356,13 @@ namespace AstrOsBulkTransport
 
 - [ ] **Step 4: Run tests to verify they PASS**
 
-Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Run: `pio test -e test --filter "test_native"`
 Expected: 257 → 262 (5 new CRC tests). All pass.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-cd /home/jeff/Source/astros/AstrOs.ESP
+cd <repo-root>
 git add lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp \
         test/test_native/bulk_transport_tests.cpp
 git commit -m "$(cat <<'EOF'
@@ -504,7 +504,7 @@ namespace AstrOsBulkTransport
 
 - [ ] **Step 2: Verify the lib still compiles**
 
-Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Run: `pio test -e test --filter "test_native"`
 Expected: 262/262 pass — CRC tests still green, no new tests added yet. The `BulkReceiver` class is declared but its methods aren't called from anywhere, so the linker won't complain about missing definitions yet.
 
 (If you get a linker error like "undefined reference to `AstrOsBulkTransport::BulkReceiver::begin`", that means a test file is already trying to use the class — check whether any later-task test was accidentally included.)
@@ -512,7 +512,7 @@ Expected: 262/262 pass — CRC tests still green, no new tests added yet. The `B
 - [ ] **Step 3: Commit**
 
 ```bash
-cd /home/jeff/Source/astros/AstrOs.ESP
+cd <repo-root>
 git add lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
 git commit -m "$(cat <<'EOF'
 feat(bulk-transport): public type definitions + BulkReceiver shape
@@ -621,7 +621,7 @@ TEST(BulkTransport, BeginAfterEndReusesReceiver)
 
 - [ ] **Step 2: Run tests to verify they FAIL**
 
-Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Run: `pio test -e test --filter "test_native"`
 Expected: link errors (`undefined reference to BulkReceiver::begin`, etc.) — the methods are declared but have no definitions yet.
 
 - [ ] **Step 3: Implement `begin`, `reset`, and a minimal `onChunk`**
@@ -689,13 +689,13 @@ Note: the public `EndResult BulkReceiver::onEnd(...)` is declared in the header 
 
 - [ ] **Step 4: Run tests to verify they PASS**
 
-Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Run: `pio test -e test --filter "test_native"`
 Expected: 262 → 266 (4 new tests). All pass.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-cd /home/jeff/Source/astros/AstrOs.ESP
+cd <repo-root>
 git add lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp \
         test/test_native/bulk_transport_tests.cpp
 git commit -m "$(cat <<'EOF'
@@ -821,7 +821,7 @@ TEST(BulkTransport, OnChunkWrongPayloadLenOnLastChunkNaksSize)
 
 - [ ] **Step 2: Run tests to verify they FAIL**
 
-Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Run: `pio test -e test --filter "test_native"`
 Expected: the new tests fail (the current `onChunk` ignores CRC/SIZE — bad CRC + wrong length both pass through as ACK).
 
 - [ ] **Step 3: Add SIZE + CRC checks to `onChunk`**
@@ -895,13 +895,13 @@ In `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp`, replace the bod
 
 - [ ] **Step 4: Run tests to verify they PASS**
 
-Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Run: `pio test -e test --filter "test_native"`
 Expected: 266 → 270 (4 new tests). All pass including the existing happy-path test from Task 4.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-cd /home/jeff/Source/astros/AstrOs.ESP
+cd <repo-root>
 git add lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp \
         test/test_native/bulk_transport_tests.cpp
 git commit -m "$(cat <<'EOF'
@@ -1001,13 +1001,13 @@ TEST(BulkTransport, OnChunkWrongXferIdNaksOutOfOrder)
 
 - [ ] **Step 2: Run tests to verify they PASS immediately**
 
-Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Run: `pio test -e test --filter "test_native"`
 Expected: 270 → 273. All new tests pass on first attempt because the structural-reject branch in Task 5's `onChunk` already collapses these cases to `OUT_OF_ORDER`. If any fail, *do not* "fix" them by editing the production code without first re-reading it carefully — the test is more likely to be wrong than the implementation, given Task 5 already covered the logic.
 
 - [ ] **Step 3: Commit**
 
 ```bash
-cd /home/jeff/Source/astros/AstrOs.ESP
+cd <repo-root>
 git add test/test_native/bulk_transport_tests.cpp
 git commit -m "$(cat <<'EOF'
 test(bulk-transport): duplicate + skip-forward + wrong-xferId coverage
@@ -1061,7 +1061,7 @@ TEST(BulkTransport, OnEndAfterAllChunksReturnsOk)
 
 - [ ] **Step 2: Run test to verify it FAILS**
 
-Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Run: `pio test -e test --filter "test_native"`
 Expected: link error if Task 4 didn't include a stub for `onEnd`. Or, if Task 4's stub returned `{}` (default `Status::IO_ERROR`), the test fails with `Expected: equality of these values: AstrOsBulkTransport::EndResult::Status::OK ... Actual: 2 (IO_ERROR)`.
 
 - [ ] **Step 3: Implement `onEnd` happy path**
@@ -1094,13 +1094,13 @@ Append to `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp` (or repla
 
 - [ ] **Step 4: Run test to verify it PASSES**
 
-Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Run: `pio test -e test --filter "test_native"`
 Expected: 273 → 274. The OK case passes.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-cd /home/jeff/Source/astros/AstrOs.ESP
+cd <repo-root>
 git add lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp \
         test/test_native/bulk_transport_tests.cpp
 git commit -m "$(cat <<'EOF'
@@ -1188,13 +1188,13 @@ TEST(BulkTransport, OnEndReceiverShortChunkCountReturnsIoError)
 
 - [ ] **Step 2: Run tests to verify they PASS immediately**
 
-Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Run: `pio test -e test --filter "test_native"`
 Expected: 274 → 278. All new tests pass on first attempt — the guards in Task 7's `onEnd` already handle each path.
 
 - [ ] **Step 3: Commit**
 
 ```bash
-cd /home/jeff/Source/astros/AstrOs.ESP
+cd <repo-root>
 git add test/test_native/bulk_transport_tests.cpp
 git commit -m "$(cat <<'EOF'
 test(bulk-transport): onEnd IO_ERROR reject paths
@@ -1279,13 +1279,13 @@ TEST(BulkTransport, EndToEndTenChunkTransferWithMidStreamRetransmit)
 
 - [ ] **Step 2: Run tests to verify the new test PASSES**
 
-Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
+Run: `pio test -e test --filter "test_native"`
 Expected: prior-test-count + 1. The integration test passes — and if any of the prior tasks left a subtle bug, this is likely where it surfaces.
 
 - [ ] **Step 3: Commit**
 
 ```bash
-cd /home/jeff/Source/astros/AstrOs.ESP
+cd <repo-root>
 git add test/test_native/bulk_transport_tests.cpp
 git commit -m "$(cat <<'EOF'
 test(bulk-transport): end-to-end 10-chunk transfer with CRC retransmit
@@ -1309,14 +1309,14 @@ EOF
 
 - [ ] **Step 1: Run the full native test suite**
 
-Run: `/home/jeff/.platformio/penv/bin/pio test -e test`
+Run: `pio test -e test`
 Expected: 261 → 293 (32 new BulkTransport tests — 22 from the original task-by-task TDD, 4 from `fe87535`'s strengthening pass, 6 more from the PR-toolkit cleanup pass — 4 begin-validation in `cc8b749` + `Crc16MultiByteNonStringVector` and `OnEndOkLeavesReceiverInPostOkState` in `cbd000a`). All pass.
 
 - [ ] **Step 2: Build both board firmware variants**
 
 ```bash
-/home/jeff/.platformio/penv/bin/pio run -e metro_s3
-/home/jeff/.platformio/penv/bin/pio run -e lolin_d32_pro
+pio run -e metro_s3
+pio run -e lolin_d32_pro
 ```
 Expected: both succeed. Phase 2 doesn't change firmware behavior; this just confirms the new lib doesn't accidentally break the on-device build (e.g., via header transitive includes that confuse the IDF build).
 

--- a/.docs/plans/20260514-2300-firmware-ota-phase2-bulk-transport.md
+++ b/.docs/plans/20260514-2300-firmware-ota-phase2-bulk-transport.md
@@ -2,6 +2,23 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+> **Post-implementation amendments (commits `6123a6a`, `fe87535`, and the
+> PR-toolkit cleanup pass on `feature/ota-phase2-bulk-transport`):** the
+> original plan claimed `crc16_ccitt_false` was byte-identical to ESP-IDF's
+> `esp_crc16_le`. That is wrong — `esp_crc16_le` is CRC-16/CCITT
+> *reflected* with init=0 and produces different output. The correct
+> ESP-IDF equivalent is `~esp_rom_crc16_be((uint16_t)~0xFFFF, buf, len)`.
+> The plan also said the single-zero-byte CRC value is `0x1EF0`; the
+> correct value is `0xE1F0` (nibbles transposed). The shipped README,
+> `.hpp`, and tests have the corrected forms; the historical text in this
+> plan is preserved with inline corrections (`~~strikethrough~~ →
+> correction`) so the original intent is auditable. Test totals also moved
+> (22 → 26 cases, 279 → 287 total) after `fe87535` added 4 strengthening
+> tests. Final PR-toolkit pass on the same branch added `BeginResult`,
+> `EndResult::Reason`, `ChunkResult` factory methods, totalSize/windowSize
+> validation, and a `seq >= totalChunks` overflow guard — see the cleanup
+> commits for the API redesign rationale.
+
 **Goal:** Build `lib_native/AstrOsBulkTransport` — a PURE, native-testable state machine that consumes parsed `FW_CHUNK` records and produces ACK/NAK decisions with sliding-window backpressure. No firmware behavior change; this is the algorithmic core that Phase 3 will wire into the `AstrOsSerialMsgHandler` dispatch path.
 
 **Architecture:** A small `BulkReceiver` class plus a standalone CRC-16/CCITT-FALSE helper. Sequential receive (no reorder buffer): every chunk must arrive with `seq == nextSeq_`; out-of-order chunks are NAK'd. `windowRemaining` returned on every ACK is always the configured `windowSize` — backpressure is a sender concern. CRC validation uses our own `crc16_ccitt_false` (PURE libs can't link `esp_crc16_le`). The lib does *not* touch payload bytes — `onChunk` receives a `const uint8_t*`/`uint16_t` pair and passes them straight back through `ChunkResult` on ACK so the caller can write them to wherever it wants (SD card in Phase 4, /dev/null in Phase 3).
@@ -33,7 +50,7 @@ No changes to `lib_native/AstrOsMessaging`, `lib_native/AstrOsSerialProtocol`, o
 - **The pre-commit hook runs clang-format** on staged C/C++ files. Expect it to reformat whitespace; the commit still succeeds.
 - **The CI native-purity guard** (`.github/workflows/pr-validation.yml`) greps for `#include <(freertos/|esp_|driver/|nvs_|sdmmc_)…>` across every path in `PURE_LIBS`. Don't include any of those, ever. The lib has no need to — we're not touching FreeRTOS, ESP-IDF, or hardware. Standard C++17 only.
 - **No exceptions.** CLAUDE.md and existing patterns: don't `throw`; don't `try/catch`. Return result structs.
-- **CRC-16/CCITT-FALSE:** poly `0x1021`, init `0xFFFF`, no input reflection, no output reflection, no XOR-out. Same as `esp_crc16_le` would compute on-device. Many online CRC calculators get this wrong (CCITT vs CCITT-FALSE vs XMODEM are all different) — the test in Task 2 uses the canonical "123456789" → `0x29B1` check vector.
+- **CRC-16/CCITT-FALSE:** poly `0x1021`, init `0xFFFF`, no input reflection, no output reflection, no XOR-out. **NOT `esp_crc16_le`** — that ESP-IDF helper is CRC-16/CCITT (*reflected*, init=0) and produces different output. The matching ESP-IDF form is `~esp_rom_crc16_be((uint16_t)~0xFFFF, buf, len)`. Many online CRC calculators get this wrong (CCITT vs CCITT-FALSE vs XMODEM are all different) — the test in Task 2 uses the canonical "123456789" → `0x29B1` check vector.
 - **`windowRemaining` semantics:** always returned as the configured `windowSize`. The receiver has zero state in-flight after a chunk is ACK'd (it's already validated and "consumed" by the caller). Backpressure is a sender-side optimization. Document this in the header.
 - **`xferId` mismatch / not-active:** NAK with `reason=OUT_OF_ORDER`. The wire-level reason codes are `CRC | SIZE | OUT_OF_ORDER | FLASH_FULL`; we map all structural rejection to `OUT_OF_ORDER`. The internal `NakReason` enum stays 1:1 with the wire-level set.
 - **`HASH_MISMATCH` in `EndResult::Status`:** reserved for the Phase 3+ MIXED layer that computes the hash. This Phase 2 implementation never returns `HASH_MISMATCH` — only `OK` or `IO_ERROR` (chunk-count mismatch).
@@ -88,12 +105,15 @@ messages and for any ESP_LOGW logging at the boundary.
 CRC
 ---
 
-This lib owns its own crc16_ccitt_false implementation. The CRC matches
-ESP-IDF's esp_crc16_le (poly 0x1021, init 0xFFFF, no reflection, no
-XOR-out) — they are byte-identical. The Phase 3 MIXED layer should call
-the PURE crc16_ccitt_false directly rather than esp_crc16_le; a single
-bench test confirming the two produce identical output for the same
-inputs is the only justification needed to keep both around.
+This lib owns its own crc16_ccitt_false implementation: CRC-16/CCITT-FALSE
+(poly 0x1021, init 0xFFFF, no input/output reflection, no XOR-out). This
+is NOT byte-identical to esp_crc16_le — that ESP-IDF helper is the
+*reflected* CCITT variant (init=0) and produces different output. The
+matching ESP-IDF form is ~esp_rom_crc16_be((uint16_t)~0xFFFF, buf, len).
+Canonical check vector: "123456789" → 0x29B1. The Phase 3 MIXED layer
+should call the PURE crc16_ccitt_false directly rather than reaching for
+the ESP-IDF helpers (none of which are byte-identical without the wrapper
+above).
 ```
 
 - [ ] **Step 2: Create the header skeleton**
@@ -109,9 +129,11 @@ inputs is the only justification needed to keep both around.
 namespace AstrOsBulkTransport
 {
     // Single-frame CRC-16/CCITT-FALSE. Poly 0x1021, init 0xFFFF, no input
-    // reflection, no output reflection, no XOR-out. Byte-identical to
-    // ESP-IDF's esp_crc16_le. Standalone (not a class method) so tests
-    // can pin behavior independently of the receiver state machine.
+    // reflection, no output reflection, no XOR-out. NOT esp_crc16_le (that
+    // helper is the reflected variant, init=0). The matching ESP-IDF form
+    // is ~esp_rom_crc16_be((uint16_t)~0xFFFF, buf, len). Standalone (not a
+    // class method) so tests can pin behavior independently of the
+    // receiver state machine.
     uint16_t crc16_ccitt_false(const uint8_t *data, size_t len);
 } // namespace AstrOsBulkTransport
 ```
@@ -192,7 +214,7 @@ EOF
 - Modify: `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp`
 - Create: `test/test_native/bulk_transport_tests.cpp`
 
-CRC-16/CCITT-FALSE: poly `0x1021`, init `0xFFFF`, no input/output reflection, no XOR-out. The canonical check vector is `"123456789"` (9 ASCII bytes) → `0x29B1`. Other useful pin-tests: empty input → `0xFFFF` (the init value); single zero byte → `0x1EF0`; `0xFF` byte → `0xFF00`.
+CRC-16/CCITT-FALSE: poly `0x1021`, init `0xFFFF`, no input/output reflection, no XOR-out. The canonical check vector is `"123456789"` (9 ASCII bytes) → `0x29B1`. Other useful pin-tests: empty input → `0xFFFF` (the init value); single zero byte → `0xE1F0`; `0xFF` byte → `0xFF00`.
 
 - [ ] **Step 1: Create the test file with failing tests**
 
@@ -232,9 +254,9 @@ TEST(BulkTransport, Crc16CanonicalCheckVector)
 
 TEST(BulkTransport, Crc16SingleZeroByte)
 {
-    // A single 0x00 byte: well-known CCITT-FALSE result 0x1EF0.
+    // A single 0x00 byte: well-known CCITT-FALSE result 0xE1F0.
     const uint8_t data[] = {0x00};
-    EXPECT_EQ(0x1EF0u, AstrOsBulkTransport::crc16_ccitt_false(data, 1));
+    EXPECT_EQ(0xE1F0u, AstrOsBulkTransport::crc16_ccitt_false(data, 1));
 }
 
 TEST(BulkTransport, Crc16SingleFfByte)
@@ -314,10 +336,10 @@ git commit -m "$(cat <<'EOF'
 feat(bulk-transport): crc16_ccitt_false standalone helper
 
 Bit-by-bit reference implementation of CRC-16/CCITT-FALSE (poly 0x1021,
-init 0xFFFF, no reflection, no XOR-out). Byte-identical to
-esp_crc16_le. Five native tests cover the canonical "123456789" check
-vector, empty-input init-value, single-zero/FF bytes, and call
-determinism.
+init 0xFFFF, no reflection, no XOR-out). NOT esp_crc16_le — that helper
+is the reflected variant and produces different output. Five native
+tests cover the canonical "123456789" check vector, empty-input
+init-value, single-zero/FF bytes, and call determinism.
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 EOF
@@ -348,8 +370,9 @@ In `lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp`, replace the
 namespace AstrOsBulkTransport
 {
     // Single-frame CRC-16/CCITT-FALSE. Poly 0x1021, init 0xFFFF, no input
-    // reflection, no output reflection, no XOR-out. Byte-identical to
-    // ESP-IDF's esp_crc16_le.
+    // reflection, no output reflection, no XOR-out. NOT esp_crc16_le (that
+    // helper is the reflected variant, init=0). The matching ESP-IDF form
+    // is ~esp_rom_crc16_be((uint16_t)~0xFFFF, buf, len).
     uint16_t crc16_ccitt_false(const uint8_t *data, size_t len);
 
     enum class Decision
@@ -1213,7 +1236,7 @@ TEST(BulkTransport, EndToEndTenChunkTransferWithMidStreamRetransmit)
 - [ ] **Step 2: Run tests to verify the new test PASSES**
 
 Run: `/home/jeff/.platformio/penv/bin/pio test -e test --filter "test_native"`
-Expected: 278 → 279. The integration test passes — and if any of the prior tasks left a subtle bug, this is likely where it surfaces.
+Expected: prior-test-count + 1. The integration test passes — and if any of the prior tasks left a subtle bug, this is likely where it surfaces.
 
 - [ ] **Step 3: Commit**
 
@@ -1243,7 +1266,7 @@ EOF
 - [ ] **Step 1: Run the full native test suite**
 
 Run: `/home/jeff/.platformio/penv/bin/pio test -e test`
-Expected: 257 → 279 (22 new BulkTransport tests). All pass.
+Expected: 261 → 287 (26 new BulkTransport tests, including the 4 strengthening cases added late by commit `fe87535`). All pass.
 
 - [ ] **Step 2: Build both board firmware variants**
 
@@ -1296,12 +1319,12 @@ Adds:
 - New PURE lib \`lib_native/AstrOsBulkTransport\` with \`BulkReceiver\` class + \`crc16_ccitt_false\` standalone helper
 - \`Decision\`, \`NakReason\`, \`ChunkResult\`, \`EndResult\` public types
 - Sequential chunk-receive state machine: in-order commit, structural rejections collapse to OUT_OF_ORDER, CRC + SIZE validation, short-last-chunk support
-- 22 new native tests covering CRC check vectors, in-order happy path, every rejection (CRC / SIZE / OUT_OF_ORDER / wrong-xferId / not-active / duplicate / skip-forward), onEnd OK and IO_ERROR paths, plus a 10-chunk end-to-end integration test with mid-stream CRC retransmit
+- 26 new native tests covering CRC check vectors, in-order happy path, every rejection (CRC / SIZE / OUT_OF_ORDER / wrong-xferId / not-active / duplicate / skip-forward), `begin()` input-validation guards (zero-`chunkSize`, zero-`totalChunks`, `totalSize` consistency, zero-`windowSize`), onEnd OK and per-reason IO_ERROR paths, plus a 10-chunk end-to-end integration test with mid-stream CRC retransmit
 - CI purity-guard registration for the new lib in \`.github/workflows/pr-validation.yml\`
 
 ## Test plan
 
-- [x] \`pio test -e test\` passes (279/279)
+- [x] \`pio test -e test\` passes (287/287 — Phase 2 added 26 tests on top of develop's 261)
 - [x] \`pio run -e metro_s3\` builds clean
 - [x] \`pio run -e lolin_d32_pro\` builds clean
 - [x] CI native-purity grep finds no forbidden includes in the new lib
@@ -1328,6 +1351,7 @@ EOF
   - `onEnd` OK + IO_ERROR (Tasks 7 + 8) ✓
   - End-to-end integration test (Task 9) ✓
   - Final verification + PR (Task 10) ✓
-- **Placeholder scan:** no TBDs, no "add appropriate handling", every code step shows the actual code.
+  - **Post-implementation hardening from PR-toolkit pass (not a numbered task)**: `begin()` input-validation guards (zero `chunkSize`/`totalChunks`/`windowSize`, `totalSize` ≈ `totalChunks * chunkSize` consistency); `seq >= totalChunks_` overflow guard on the SIZE math; `BeginResult` return value; `EndResult::Reason` enum (distinct IO_ERROR causes); `ChunkResult` factory methods preventing invalid field combinations; `writeResumePoint` helper folding the duplicated first-chunk-NAK contract into one place. ✓
+- **Placeholder scan:** the original plan was free of TBDs at task-execution time. The amendment header above flags the specific claims (CRC interop, single-zero-byte value, 22/279 test counts) that were superseded by the PR-toolkit cleanup; surgical corrections in-body keep the plan re-executable.
 - **Type consistency:** `BulkReceiver`, `ChunkResult`, `EndResult`, `Decision`, `NakReason` are used consistently across all tasks. `crc16_ccitt_false` lowercase-underscore naming is used everywhere.
 - **Scope check:** 10 tasks. Above the CLAUDE.md ~8-task warning, but each task is small (≤2 files, ≤30 min) and Phase 2 is genuinely one coherent unit — splitting into "scaffold" and "state machine" sub-phases would just add cross-PR coordination cost without value. If the scope grows past 10, escalate.

--- a/.docs/protocol.md
+++ b/.docs/protocol.md
@@ -23,7 +23,7 @@ When extending either enum, **append** — never reorder existing entries. Both 
 | Item | Value | Notes |
 |---|---|---|
 | Image hash | SHA-256, hex-encoded as 64 lowercase chars | Computed by server over the full `.bin`; verified at master (after SD landing) and at each padawan (after `esp_ota_end`). |
-| Frame CRC | CRC-16/CCITT-FALSE (poly `0x1021`, init `0xFFFF`) | Per ESP-NOW data frame, over `[transfer-id .. payload bytes]`. ESP-IDF: `esp_crc16_le`. |
+| Frame CRC | CRC-16/CCITT-FALSE (poly `0x1021`, init `0xFFFF`, no input/output reflection, no XOR-out) | Per ESP-NOW data frame, over `[transfer-id .. payload bytes]`. NOT `esp_crc16_le` — that helper is CRC-16/CCITT (reflected, init=0) and produces different output. The canonical PURE implementation is `AstrOsBulkTransport::crc16_ccitt_false`; equivalent ESP-IDF form is `~esp_rom_crc16_be((uint16_t)~0xFFFF, buf, len)`. Canonical check vector: `"123456789"` → `0x29B1`. |
 | Serial chunk size | 4096 bytes (decoded) | Base64-encoded in the wire form, ≈ 5.5 KB per `FW_CHUNK` line at 115200 baud (~0.5 s transit). |
 | ESP-NOW chunk size | 128 bytes | Per `OTA_DATA` frame; 1.2 MB image ≈ 9400 frames per padawan. |
 | Serial sliding window | 16 frames | Inflight bytes ≈ 64 KB. |

--- a/.docs/protocol.md
+++ b/.docs/protocol.md
@@ -23,7 +23,7 @@ When extending either enum, **append** — never reorder existing entries. Both 
 | Item | Value | Notes |
 |---|---|---|
 | Image hash | SHA-256, hex-encoded as 64 lowercase chars | Computed by server over the full `.bin`; verified at master (after SD landing) and at each padawan (after `esp_ota_end`). |
-| Frame CRC | CRC-16/CCITT-FALSE (poly `0x1021`, init `0xFFFF`, no input/output reflection, no XOR-out) | Per ESP-NOW data frame, over `[transfer-id .. payload bytes]`. NOT `esp_crc16_le` — that helper is CRC-16/CCITT (reflected, init=0) and produces different output. The canonical PURE implementation is `AstrOsBulkTransport::crc16_ccitt_false`; equivalent ESP-IDF form is `~esp_rom_crc16_be((uint16_t)~0xFFFF, buf, len)`. Canonical check vector: `"123456789"` → `0x29B1`. |
+| Frame CRC | CRC-16/CCITT-FALSE (poly `0x1021`, init `0xFFFF`, no input/output reflection, no XOR-out) | Per data frame. **Serial scope** (`FW_CHUNK`): over the decoded payload bytes. **ESP-NOW scope** (`OTA_DATA`): over `[transfer-id .. payload bytes]`. NOT `esp_crc16_le` — that helper is CRC-16/CCITT (reflected, init=0) and produces different output. The canonical PURE implementation is `AstrOsBulkTransport::crc16_ccitt_false`; equivalent ESP-IDF form is `~esp_rom_crc16_be((uint16_t)~0xFFFF, buf, len)`. Canonical check vector: `"123456789"` → `0x29B1`. |
 | Serial chunk size | 4096 bytes (decoded) | Base64-encoded in the wire form, ≈ 5.5 KB per `FW_CHUNK` line at 115200 baud (~0.5 s transit). |
 | ESP-NOW chunk size | 128 bytes | Per `OTA_DATA` frame; 1.2 MB image ≈ 9400 frames per padawan. |
 | Serial sliding window | 16 frames | Inflight bytes ≈ 64 KB. |

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -39,6 +39,7 @@ jobs:
             lib_native/AstrOsAnimationEngine
             lib_native/AstrOsEspNowProtocol
             lib_native/AstrOsEspNowPeers
+            lib_native/AstrOsBulkTransport
           )
           PATTERN='#include[[:space:]]*[<"](freertos/|esp_|driver/|nvs_|sdmmc_)'
           status=0

--- a/.gitignore
+++ b/.gitignore
@@ -504,3 +504,4 @@ lib_native/AstrOsUtility/src/version_generated.hpp
 
 
 .tmp
+dependencies.lock

--- a/lib_native/AstrOsBulkTransport/README
+++ b/lib_native/AstrOsBulkTransport/README
@@ -1,0 +1,38 @@
+AstrOsBulkTransport
+===================
+
+Pure, native-testable state machine for the chunk-based bulk transport
+used by the firmware OTA path. Consumes FW_CHUNK records (parsed by
+lib_native/AstrOsMessaging) and produces ACK/NAK decisions, with
+sliding-window backpressure metadata for the sender. Companion to the
+FW_* wire format that Phase 1 added to AstrOsMessaging; consumed by
+the MIXED OtaReceiver that Phase 3 will introduce.
+
+Purity rule
+-----------
+
+This library is unit-tested on the native host under [env:test], so it
+must not include any of:
+
+    freertos/*, esp_*, driver/*, nvs_*, sdmmc_*, esp_vfs*, esp_now*, esp_wifi*
+
+Enforced by the CI purity guard in .github/workflows/pr-validation.yml.
+
+Error-channel convention
+------------------------
+
+The state machine returns ChunkResult / EndResult structs with explicit
+Decision and Status fields. No exceptions, no logger injection. The
+MIXED caller (Phase 3 OtaReceiver) is responsible for translating
+results into wire-level FW_CHUNK_ACK / FW_CHUNK_NAK / FW_TRANSFER_END_ACK
+messages and for any ESP_LOGW logging at the boundary.
+
+CRC
+---
+
+This lib owns its own crc16_ccitt_false implementation. The CRC matches
+ESP-IDF's esp_crc16_le (poly 0x1021, init 0xFFFF, no reflection, no
+XOR-out) — they are byte-identical. The Phase 3 MIXED layer should call
+the PURE crc16_ccitt_false directly rather than esp_crc16_le; a single
+bench test confirming the two produce identical output for the same
+inputs is the only justification needed to keep both around.

--- a/lib_native/AstrOsBulkTransport/README
+++ b/lib_native/AstrOsBulkTransport/README
@@ -12,11 +12,15 @@ Purity rule
 -----------
 
 This library is unit-tested on the native host under [env:test], so it
-must not include any of:
+must not include any header whose path starts with one of:
 
-    freertos/*, esp_*, driver/*, nvs_*, sdmmc_*, esp_vfs*, esp_now*, esp_wifi*
+    freertos/, esp_, driver/, nvs_, sdmmc_
 
-Enforced by the CI purity guard in .github/workflows/pr-validation.yml.
+The esp_ prefix is intentionally broad — it covers esp_now*, esp_wifi*,
+esp_vfs*, esp_log.h, esp_rom_*, and anything else under ESP-IDF's
+top-level esp_*.h namespace. Enforced by the CI purity guard in
+.github/workflows/pr-validation.yml; the regex there mirrors this list
+exactly.
 
 Error-channel convention
 ------------------------

--- a/lib_native/AstrOsBulkTransport/README
+++ b/lib_native/AstrOsBulkTransport/README
@@ -30,9 +30,13 @@ messages and for any ESP_LOGW logging at the boundary.
 CRC
 ---
 
-This lib owns its own crc16_ccitt_false implementation. The CRC matches
-ESP-IDF's esp_crc16_le (poly 0x1021, init 0xFFFF, no reflection, no
-XOR-out) — they are byte-identical. The Phase 3 MIXED layer should call
-the PURE crc16_ccitt_false directly rather than esp_crc16_le; a single
-bench test confirming the two produce identical output for the same
-inputs is the only justification needed to keep both around.
+This lib owns its own crc16_ccitt_false implementation: poly 0x1021,
+init 0xFFFF, no input reflection, no output reflection, no XOR-out.
+Canonical check value: crc16_ccitt_false("123456789", 9) == 0x29B1.
+
+NOTE on ESP-IDF interop: this is NOT byte-identical to esp_crc16_le.
+esp_crc16_le is CRC-16/CCITT (reflected, init=0) — a different algorithm
+that produces different output for the same input. The matching ESP-IDF
+form requires the big-endian variant with a tilde wrapper:
+~esp_rom_crc16_be((uint16_t)~0xFFFF, buf, len). Phase 3 should call this
+PURE crc16_ccitt_false directly rather than going through esp_crc16_le.

--- a/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
+++ b/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
@@ -9,6 +9,11 @@ namespace AstrOsBulkTransport
     // reflection, no output reflection, no XOR-out. Canonical check value:
     // crc16_ccitt_false("123456789", 9) == 0x29B1.
     //
+    // Precondition: `data` must be non-null whenever `len > 0`. The
+    // (anything, 0) case is well-defined and returns the init value
+    // 0xFFFFu. Calling with (nullptr, len > 0) trips an assert (native
+    // tests) or panics + resets (target) — both deterministic, neither UB.
+    //
     // NOTE on ESP-IDF interop: this is NOT byte-identical to esp_crc16_le.
     // esp_crc16_le is CRC-16/CCITT (reflected, init=0) — a different
     // algorithm. The matching ESP-IDF variant is the big-endian one with a
@@ -80,18 +85,21 @@ namespace AstrOsBulkTransport
     // callers cannot aggregate-initialize impossible field combinations
     // (e.g. Decision::ACK with reason != NONE, or NAK with non-null
     // payload). Use the static factories: `ack`, `nakActive`,
-    // `nakInactive`. Fields stay public-readable so test code keeps the
-    // existing read-by-name idiom (`r.payload`, `r.reason`, etc.) —
-    // factories prevent the construction hazard without rewriting reads.
+    // `nakInactive`. Fields are public-readable AND `const` so that a
+    // returned result cannot be mutated into an invalid combination
+    // after the factory enforces consistency — test code keeps the
+    // read-by-name idiom (`r.payload`, `r.reason`, etc.) but cannot
+    // assign through it. Const fields disable copy/move assignment;
+    // copy-construction (`auto r = factory()`) still works.
     struct ChunkResult
     {
-        Decision decision = Decision::NAK;
-        uint32_t highestContiguousSeq = 0;
-        uint32_t nextExpectedSeq = 0;
-        uint8_t windowRemaining = 0;
-        NakReason reason = NakReason::NONE;
-        const uint8_t *payload = nullptr;
-        uint16_t payloadLen = 0;
+        const Decision decision;
+        const uint32_t highestContiguousSeq;
+        const uint32_t nextExpectedSeq;
+        const uint8_t windowRemaining;
+        const NakReason reason;
+        const uint8_t *const payload;
+        const uint16_t payloadLen;
 
         // ACK: the chunk committed. `committedSeq` is the seq we just
         // committed; `nextExpectedSeq` is committedSeq + 1; both go on
@@ -99,15 +107,8 @@ namespace AstrOsBulkTransport
         static ChunkResult ack(uint32_t committedSeq, uint32_t nextExpectedSeq, uint8_t windowSize,
                                const uint8_t *payload, uint16_t payloadLen)
         {
-            ChunkResult r;
-            r.decision = Decision::ACK;
-            r.reason = NakReason::NONE;
-            r.highestContiguousSeq = committedSeq;
-            r.nextExpectedSeq = nextExpectedSeq;
-            r.windowRemaining = windowSize;
-            r.payload = payload;
-            r.payloadLen = payloadLen;
-            return r;
+            return ChunkResult(Decision::ACK, committedSeq, nextExpectedSeq, windowSize, NakReason::NONE, payload,
+                               payloadLen);
         }
 
         // Active NAK: receiver is in a live transfer but the chunk was
@@ -117,13 +118,7 @@ namespace AstrOsBulkTransport
         static ChunkResult nakActive(NakReason reason, uint32_t highestContiguousSeq, uint32_t nextExpectedSeq,
                                      uint8_t windowSize)
         {
-            ChunkResult r;
-            r.decision = Decision::NAK;
-            r.reason = reason;
-            r.highestContiguousSeq = highestContiguousSeq;
-            r.nextExpectedSeq = nextExpectedSeq;
-            r.windowRemaining = windowSize;
-            return r;
+            return ChunkResult(Decision::NAK, highestContiguousSeq, nextExpectedSeq, windowSize, reason, nullptr, 0);
         }
 
         // Inactive NAK: chunk arrived while no transfer is live (begin()
@@ -131,15 +126,21 @@ namespace AstrOsBulkTransport
         // wire signal Phase 3 uses to say "abort + restart handshake."
         static ChunkResult nakInactive()
         {
-            ChunkResult r;
-            r.decision = Decision::NAK;
-            r.reason = NakReason::OUT_OF_ORDER;
-            // highestContiguousSeq, nextExpectedSeq, windowRemaining all 0.
-            return r;
+            return ChunkResult(Decision::NAK, /*highestContiguousSeq=*/0, /*nextExpectedSeq=*/0,
+                               /*windowRemaining=*/0, NakReason::OUT_OF_ORDER, /*payload=*/nullptr,
+                               /*payloadLen=*/0);
         }
 
     private:
-        ChunkResult() = default;
+        // Private all-args constructor — the factories are the only legal
+        // way to build a ChunkResult. Aggregate initialization is disabled
+        // by the user-declared constructor, so external code can't bypass
+        // the factory invariants by writing `ChunkResult{Decision::ACK, ...}`.
+        ChunkResult(Decision d, uint32_t hcs, uint32_t nes, uint8_t wr, NakReason r, const uint8_t *p, uint16_t pl)
+            : decision(d), highestContiguousSeq(hcs), nextExpectedSeq(nes), windowRemaining(wr), reason(r), payload(p),
+              payloadLen(pl)
+        {
+        }
     };
 
     // [[nodiscard]] forces every caller (including tests) to acknowledge

--- a/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
+++ b/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
@@ -76,6 +76,13 @@ namespace AstrOsBulkTransport
     //     `windowRemaining == 0` as the "not active, abort + restart the
     //     handshake" sentinel and any other value as "active-state
     //     mismatch; retransmit from `nextExpectedSeq`."
+    // Construction discipline: the default constructor is private so
+    // callers cannot aggregate-initialize impossible field combinations
+    // (e.g. Decision::ACK with reason != NONE, or NAK with non-null
+    // payload). Use the static factories: `ack`, `nakActive`,
+    // `nakInactive`. Fields stay public-readable so test code keeps the
+    // existing read-by-name idiom (`r.payload`, `r.reason`, etc.) —
+    // factories prevent the construction hazard without rewriting reads.
     struct ChunkResult
     {
         Decision decision = Decision::NAK;
@@ -85,6 +92,54 @@ namespace AstrOsBulkTransport
         NakReason reason = NakReason::NONE;
         const uint8_t *payload = nullptr;
         uint16_t payloadLen = 0;
+
+        // ACK: the chunk committed. `committedSeq` is the seq we just
+        // committed; `nextExpectedSeq` is committedSeq + 1; both go on
+        // the wire as FW_CHUNK_ACK fields.
+        static ChunkResult ack(uint32_t committedSeq, uint32_t nextExpectedSeq, uint8_t windowSize,
+                               const uint8_t *payload, uint16_t payloadLen)
+        {
+            ChunkResult r;
+            r.decision = Decision::ACK;
+            r.reason = NakReason::NONE;
+            r.highestContiguousSeq = committedSeq;
+            r.nextExpectedSeq = nextExpectedSeq;
+            r.windowRemaining = windowSize;
+            r.payload = payload;
+            r.payloadLen = payloadLen;
+            return r;
+        }
+
+        // Active NAK: receiver is in a live transfer but the chunk was
+        // rejected (CRC | SIZE | OUT_OF_ORDER | FLASH_FULL). `windowSize`
+        // here is the configured `windowSize` from begin() — used as the
+        // "still active, retransmit from nextExpectedSeq" wire signal.
+        static ChunkResult nakActive(NakReason reason, uint32_t highestContiguousSeq, uint32_t nextExpectedSeq,
+                                     uint8_t windowSize)
+        {
+            ChunkResult r;
+            r.decision = Decision::NAK;
+            r.reason = reason;
+            r.highestContiguousSeq = highestContiguousSeq;
+            r.nextExpectedSeq = nextExpectedSeq;
+            r.windowRemaining = windowSize;
+            return r;
+        }
+
+        // Inactive NAK: chunk arrived while no transfer is live (begin()
+        // not called or reset() was called). `windowRemaining = 0` is the
+        // wire signal Phase 3 uses to say "abort + restart handshake."
+        static ChunkResult nakInactive()
+        {
+            ChunkResult r;
+            r.decision = Decision::NAK;
+            r.reason = NakReason::OUT_OF_ORDER;
+            // highestContiguousSeq, nextExpectedSeq, windowRemaining all 0.
+            return r;
+        }
+
+    private:
+        ChunkResult() = default;
     };
 
     struct EndResult
@@ -146,6 +201,17 @@ namespace AstrOsBulkTransport
         void reset();
 
     private:
+        // The wire field FW_CHUNK_NAK::last-good-seq. 0 is overloaded:
+        // either "seq 0 was committed" or "nothing committed yet." Phase
+        // 3 disambiguates via `nextExpectedSeq == 0` (only true when
+        // nothing committed). Centralized here so the first-chunk-NAK
+        // contract lives in one place rather than duplicated at every
+        // NAK construction site.
+        uint32_t lastGoodSeq() const
+        {
+            return (nextSeq_ == 0) ? 0u : (nextSeq_ - 1u);
+        }
+
         uint8_t xferId_ = 0;
         uint32_t nextSeq_ = 0;
         uint32_t totalSize_ = 0;

--- a/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
+++ b/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
@@ -185,9 +185,9 @@ namespace AstrOsBulkTransport
         // and returns OK on matching totals or IO_ERROR on mismatch.
         enum class Status : uint8_t
         {
-            OK,
-            HASH_MISMATCH,
-            IO_ERROR
+            OK = 0,
+            HASH_MISMATCH = 1,
+            IO_ERROR = 2
         };
 
         // Populated when status != OK. NONE on the success path. Mirrors

--- a/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
+++ b/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
@@ -142,7 +142,39 @@ namespace AstrOsBulkTransport
         ChunkResult() = default;
     };
 
-    struct EndResult
+    // [[nodiscard]] forces every caller (including tests) to acknowledge
+    // the result — silently dropping `begin()` would leave the caller
+    // unable to distinguish "transfer started" from "BEGIN was rejected,
+    // receiver still inactive," which is precisely the silent-failure
+    // case the PR-toolkit pass flagged as Critical.
+    struct [[nodiscard]] BeginResult
+    {
+        // OK only when valid == true. Non-OK values describe why begin()
+        // refused to activate the receiver — caller should reject the
+        // wire-level FW_TRANSFER_BEGIN with a matching status code rather
+        // than silently NAK every subsequent chunk.
+        enum class Reason : uint8_t
+        {
+            OK = 0,
+            ZERO_CHUNK_SIZE = 1,
+            ZERO_TOTAL_CHUNKS = 2,
+            ZERO_WINDOW_SIZE = 3,
+            SIZE_INCONSISTENT = 4 // totalSize outside ((totalChunks - 1) * chunkSize, totalChunks * chunkSize]
+        };
+        bool valid = false;
+        Reason reason = Reason::ZERO_CHUNK_SIZE;
+
+        static BeginResult ok()
+        {
+            return {true, Reason::OK};
+        }
+        static BeginResult invalid(Reason r)
+        {
+            return {false, r};
+        }
+    };
+
+    struct [[nodiscard]] EndResult
     {
         // HASH_MISMATCH is reserved for the MIXED-layer caller (Phase 4
         // OtaReceiver, when the streaming SHA-256 context is added).
@@ -150,13 +182,36 @@ namespace AstrOsBulkTransport
         // HASH_MISMATCH; this PURE state machine never returns it either.
         // BulkReceiver::onEnd only validates chunk counts and returns
         // OK on matching totals or IO_ERROR on mismatch.
-        enum class Status
+        enum class Status : uint8_t
         {
             OK,
             HASH_MISMATCH,
             IO_ERROR
         };
+
+        // Populated when status != OK. NONE on the success path. Mirrors
+        // the NakReason pattern: distinct reasons that all happen to map
+        // to a single Status::IO_ERROR get surfaced so Phase 3 can log
+        // them and operators can debug WHICH IO_ERROR they hit.
+        enum class Reason : uint8_t
+        {
+            NONE = 0,
+            NOT_ACTIVE = 1,            // begin() not called or reset() was called
+            WRONG_XFER_ID = 2,         // xferId mismatch
+            SENDER_TOTAL_MISMATCH = 3, // sender's totalChunksSent != totalChunks_
+            RECEIVER_SHORT_COUNT = 4   // sender claims complete but nextSeq_ < totalChunks_
+        };
         Status status = Status::IO_ERROR;
+        Reason reason = Reason::NOT_ACTIVE;
+
+        static EndResult ok()
+        {
+            return {Status::OK, Reason::NONE};
+        }
+        static EndResult ioError(Reason r)
+        {
+            return {Status::IO_ERROR, r};
+        }
     };
 
     // Sequential chunk-receive state machine for the firmware OTA path.
@@ -179,7 +234,10 @@ namespace AstrOsBulkTransport
     //     transfer mid-stream.
     //   - `begin()` with `chunkSize == 0` or `totalChunks == 0` is treated
     //     as a protocol violation: the receiver is left inactive (callers
-    //     get OUT_OF_ORDER NAKs from `onChunk`).
+    //     get OUT_OF_ORDER NAKs from `onChunk`) AND `begin()` returns
+    //     `BeginResult { valid=false, reason=ZERO_CHUNK_SIZE | ZERO_TOTAL_CHUNKS }`.
+    //     The return value is `[[nodiscard]]`; the caller MUST check
+    //     `result.valid` before reporting a successful FW_TRANSFER_BEGIN_ACK.
     //
     // Usage:
     //   BulkReceiver r;
@@ -195,7 +253,8 @@ namespace AstrOsBulkTransport
     class BulkReceiver
     {
     public:
-        void begin(uint8_t xferId, uint32_t totalSize, uint32_t totalChunks, uint16_t chunkSize, uint8_t windowSize);
+        BeginResult begin(uint8_t xferId, uint32_t totalSize, uint32_t totalChunks, uint16_t chunkSize,
+                          uint8_t windowSize);
         ChunkResult onChunk(uint8_t xferId, uint32_t seq, uint16_t payloadLen, uint16_t crc16, const uint8_t *payload);
         EndResult onEnd(uint8_t xferId, uint32_t totalChunksSent);
         void reset();

--- a/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
+++ b/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
@@ -11,8 +11,11 @@ namespace AstrOsBulkTransport
     //
     // Precondition: `data` must be non-null whenever `len > 0`. The
     // (anything, 0) case is well-defined and returns the init value
-    // 0xFFFFu. Calling with (nullptr, len > 0) trips an assert (native
-    // tests) or panics + resets (target) — both deterministic, neither UB.
+    // 0xFFFFu. Calling with (nullptr, len > 0) aborts via std::abort()
+    // unconditionally (NDEBUG-safe — does not rely on assert remaining
+    // compiled in). On native test builds the assert that fires first
+    // gives the file:line + message; on ESP target abort() panics + resets.
+    // Either way, deterministic loud failure, never UB.
     //
     // NOTE on ESP-IDF interop: this is NOT byte-identical to esp_crc16_le.
     // esp_crc16_le is CRC-16/CCITT (reflected, init=0) — a different
@@ -243,7 +246,14 @@ namespace AstrOsBulkTransport
     //
     // Usage:
     //   BulkReceiver r;
-    //   r.begin(xferId, totalSize, totalChunks, chunkSize, windowSize);
+    //   auto br = r.begin(xferId, totalSize, totalChunks, chunkSize, windowSize);
+    //   if (!br.valid) {
+    //       // Reject FW_TRANSFER_BEGIN with a status code derived from
+    //       // br.reason (ZERO_CHUNK_SIZE | ZERO_TOTAL_CHUNKS |
+    //       // ZERO_WINDOW_SIZE | SIZE_INCONSISTENT). Do NOT send a
+    //       // success ACK — the receiver is inactive.
+    //       return;
+    //   }
     //   for each FW_CHUNK arrival:
     //       auto cr = r.onChunk(xferId, seq, payloadLen, crc16, payload);
     //       // On ACK: write cr.payload[0..cr.payloadLen-1] to flash,
@@ -251,6 +261,9 @@ namespace AstrOsBulkTransport
     //       // On NAK: send FW_CHUNK_NAK(last-good-seq=highestContiguousSeq,
     //       //         reason=cr.reason). Sender retransmits cr.nextExpectedSeq.
     //   auto er = r.onEnd(xferId, totalChunksSent);
+    //   // er.status == OK on success; on IO_ERROR, er.reason names the
+    //   // specific cause (NOT_ACTIVE | WRONG_XFER_ID |
+    //   // SENDER_TOTAL_MISMATCH | RECEIVER_SHORT_COUNT).
     //   r.reset();  // safe to call anytime; required before the next begin().
     class BulkReceiver
     {

--- a/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
+++ b/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
@@ -7,7 +7,87 @@ namespace AstrOsBulkTransport
 {
     // Single-frame CRC-16/CCITT-FALSE. Poly 0x1021, init 0xFFFF, no input
     // reflection, no output reflection, no XOR-out. Byte-identical to
-    // ESP-IDF's esp_crc16_le. Standalone (not a class method) so tests
-    // can pin behavior independently of the receiver state machine.
+    // ESP-IDF's esp_crc16_le.
     uint16_t crc16_ccitt_false(const uint8_t *data, size_t len);
+
+    enum class Decision
+    {
+        ACK,
+        NAK
+    };
+
+    // Internal NAK reasons map 1:1 to the wire-level FW_CHUNK_NAK reason
+    // codes (CRC | SIZE | OUT_OF_ORDER | FLASH_FULL). `WRONG_TRANSFER_ID`
+    // and `NOT_ACTIVE` are NOT distinct enum entries — those structural
+    // rejections all map to OUT_OF_ORDER, matching the wire protocol.
+    enum class NakReason : uint8_t
+    {
+        NONE = 0,
+        CRC = 1,
+        SIZE = 2,
+        OUT_OF_ORDER = 3,
+        FLASH_FULL = 4
+    };
+
+    struct ChunkResult
+    {
+        Decision decision = Decision::NAK;
+        uint32_t highestContiguousSeq = 0;
+        uint32_t nextExpectedSeq = 0;
+        uint8_t windowRemaining = 0;
+        NakReason reason = NakReason::NONE;
+        // On ACK only: the caller's input pointer + length pass straight
+        // through, unmodified. BulkReceiver does not own this memory and
+        // does not touch the bytes. nullptr/0 on NAK.
+        const uint8_t *payload = nullptr;
+        uint16_t payloadLen = 0;
+    };
+
+    struct EndResult
+    {
+        // HASH_MISMATCH is reserved for the MIXED-layer caller (Phase 3
+        // OtaReceiver) that owns the streaming SHA-256 context. This
+        // PURE state machine only knows about chunk counts; it returns
+        // OK on matching totals and IO_ERROR on mismatch.
+        enum class Status
+        {
+            OK,
+            HASH_MISMATCH,
+            IO_ERROR
+        };
+        Status status = Status::IO_ERROR;
+    };
+
+    // Sequential chunk-receive state machine for the firmware OTA path.
+    // The receiver commits chunks strictly in seq order — sliding window
+    // is a sender optimization, not a reorder buffer. After every ACK
+    // the receiver reports `windowRemaining = windowSize_` because it
+    // tracks no in-flight state (each ACK'd chunk is already consumed
+    // by the caller).
+    //
+    // Usage:
+    //   BulkReceiver r;
+    //   r.begin(xferId, totalSize, totalChunks, chunkSize, windowSize);
+    //   for each FW_CHUNK arrival:
+    //       auto cr = r.onChunk(xferId, seq, len, crc16, payload);
+    //       // caller acts on cr.decision (write bytes / send ACK / send NAK)
+    //   auto er = r.onEnd(xferId, totalChunksSent);
+    //   r.reset();  // ready for next transfer; safe to call anytime.
+    class BulkReceiver
+    {
+    public:
+        void begin(uint8_t xferId, uint32_t totalSize, uint32_t totalChunks, uint16_t chunkSize, uint8_t windowSize);
+        ChunkResult onChunk(uint8_t xferId, uint32_t seq, uint16_t payloadLen, uint16_t crc16, const uint8_t *payload);
+        EndResult onEnd(uint8_t xferId, uint32_t totalChunksSent);
+        void reset();
+
+    private:
+        uint8_t xferId_ = 0;
+        uint32_t nextSeq_ = 0;
+        uint32_t totalSize_ = 0;
+        uint32_t totalChunks_ = 0;
+        uint16_t chunkSize_ = 0;
+        uint8_t windowSize_ = 0;
+        bool active_ = false;
+    };
 } // namespace AstrOsBulkTransport

--- a/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
+++ b/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace AstrOsBulkTransport
+{
+    // Single-frame CRC-16/CCITT-FALSE. Poly 0x1021, init 0xFFFF, no input
+    // reflection, no output reflection, no XOR-out. Byte-identical to
+    // ESP-IDF's esp_crc16_le. Standalone (not a class method) so tests
+    // can pin behavior independently of the receiver state machine.
+    uint16_t crc16_ccitt_false(const uint8_t *data, size_t len);
+} // namespace AstrOsBulkTransport

--- a/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
+++ b/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
@@ -176,12 +176,13 @@ namespace AstrOsBulkTransport
 
     struct [[nodiscard]] EndResult
     {
-        // HASH_MISMATCH is reserved for the MIXED-layer caller (Phase 4
-        // OtaReceiver, when the streaming SHA-256 context is added).
-        // Phase 3 OtaReceiver sinks payload to /dev/null and never returns
-        // HASH_MISMATCH; this PURE state machine never returns it either.
-        // BulkReceiver::onEnd only validates chunk counts and returns
-        // OK on matching totals or IO_ERROR on mismatch.
+        // HASH_MISMATCH is reserved for the Phase 3+ MIXED layer once it
+        // has a hash context. The MIXED OtaReceiver introduced in Phase 3
+        // sinks payload to /dev/null and never returns HASH_MISMATCH;
+        // only the Phase 4 enhancement that adds the streaming SHA-256
+        // context will ever produce it. This PURE state machine itself
+        // never returns HASH_MISMATCH — onEnd only validates chunk counts
+        // and returns OK on matching totals or IO_ERROR on mismatch.
         enum class Status : uint8_t
         {
             OK,

--- a/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
+++ b/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
@@ -6,20 +6,30 @@
 namespace AstrOsBulkTransport
 {
     // Single-frame CRC-16/CCITT-FALSE. Poly 0x1021, init 0xFFFF, no input
-    // reflection, no output reflection, no XOR-out. Byte-identical to
-    // ESP-IDF's esp_crc16_le.
+    // reflection, no output reflection, no XOR-out. Canonical check value:
+    // crc16_ccitt_false("123456789", 9) == 0x29B1.
+    //
+    // NOTE on ESP-IDF interop: this is NOT byte-identical to esp_crc16_le.
+    // esp_crc16_le is CRC-16/CCITT (reflected, init=0) — a different
+    // algorithm. The matching ESP-IDF variant is the big-endian one with a
+    // tilde wrapper: `~esp_rom_crc16_be((uint16_t)~0xFFFF, buf, len)`. Phase
+    // 3 should call this PURE function directly rather than wiring up an
+    // ESP-IDF helper.
     uint16_t crc16_ccitt_false(const uint8_t *data, size_t len);
 
-    enum class Decision
+    enum class Decision : uint8_t
     {
         ACK,
         NAK
     };
 
-    // Internal NAK reasons map 1:1 to the wire-level FW_CHUNK_NAK reason
-    // codes (CRC | SIZE | OUT_OF_ORDER | FLASH_FULL). `WRONG_TRANSFER_ID`
-    // and `NOT_ACTIVE` are NOT distinct enum entries — those structural
-    // rejections all map to OUT_OF_ORDER, matching the wire protocol.
+    // Internal NAK reasons. Values `CRC` through `FLASH_FULL` map directly
+    // to the wire-level FW_CHUNK_NAK reason codes (CRC | SIZE | OUT_OF_ORDER
+    // | FLASH_FULL); the explicit numeric values are wire-stable and must
+    // not be reordered. `NONE` is used only on the ACK path and has no wire
+    // representation. `WRONG_TRANSFER_ID` and `NOT_ACTIVE` are NOT distinct
+    // enumerators — those structural rejections all collapse to OUT_OF_ORDER,
+    // matching the wire protocol's reason-code set.
     enum class NakReason : uint8_t
     {
         NONE = 0,
@@ -29,6 +39,43 @@ namespace AstrOsBulkTransport
         FLASH_FULL = 4
     };
 
+    // Result of `BulkReceiver::onChunk`. Carries both ACK and NAK information
+    // in a single struct.
+    //
+    // Always populated:
+    //   - `decision`         — ACK or NAK
+    //   - `highestContiguousSeq` — last seq committed (0 if none committed yet)
+    //   - `nextExpectedSeq`  — seq the sender should send next
+    //   - `windowRemaining`  — see semantics below
+    //
+    // NAK path additionally populates:
+    //   - `reason`           — CRC | SIZE | OUT_OF_ORDER | FLASH_FULL
+    //                          Phase 3 maps this directly into FW_CHUNK_NAK's
+    //                          reason-code field. highestContiguousSeq maps
+    //                          to FW_CHUNK_NAK's `last-good-seq`.
+    //                          IMPORTANT: on the first-chunk NAK (nextSeq_==0
+    //                          before any ACK), highestContiguousSeq is also
+    //                          0 — same as "seq 0 was committed." Phase 3
+    //                          must use `nextExpectedSeq == 0` as the
+    //                          sentinel for "nothing committed yet" rather
+    //                          than relying on highestContiguousSeq alone.
+    //
+    // ACK path additionally populates:
+    //   - `payload`/`payloadLen` — caller's input pointer + length pass
+    //                          straight through, unmodified. BulkReceiver
+    //                          does not own this memory and does not touch
+    //                          the bytes. nullptr/0 on NAK.
+    //
+    // windowRemaining semantics:
+    //   - On any reply from an active receiver (ACK, CRC NAK, SIZE NAK,
+    //     OUT_OF_ORDER NAK on an active-state mismatch): equals the
+    //     `windowSize` passed to `begin()`. The receiver tracks no
+    //     in-flight state.
+    //   - On a NAK from an inactive receiver (begin() not yet called or
+    //     reset() was called): always 0. Phase 3 should treat
+    //     `windowRemaining == 0` as the "not active, abort + restart the
+    //     handshake" sentinel and any other value as "active-state
+    //     mismatch; retransmit from `nextExpectedSeq`."
     struct ChunkResult
     {
         Decision decision = Decision::NAK;
@@ -36,19 +83,18 @@ namespace AstrOsBulkTransport
         uint32_t nextExpectedSeq = 0;
         uint8_t windowRemaining = 0;
         NakReason reason = NakReason::NONE;
-        // On ACK only: the caller's input pointer + length pass straight
-        // through, unmodified. BulkReceiver does not own this memory and
-        // does not touch the bytes. nullptr/0 on NAK.
         const uint8_t *payload = nullptr;
         uint16_t payloadLen = 0;
     };
 
     struct EndResult
     {
-        // HASH_MISMATCH is reserved for the MIXED-layer caller (Phase 3
-        // OtaReceiver) that owns the streaming SHA-256 context. This
-        // PURE state machine only knows about chunk counts; it returns
-        // OK on matching totals and IO_ERROR on mismatch.
+        // HASH_MISMATCH is reserved for the MIXED-layer caller (Phase 4
+        // OtaReceiver, when the streaming SHA-256 context is added).
+        // Phase 3 OtaReceiver sinks payload to /dev/null and never returns
+        // HASH_MISMATCH; this PURE state machine never returns it either.
+        // BulkReceiver::onEnd only validates chunk counts and returns
+        // OK on matching totals or IO_ERROR on mismatch.
         enum class Status
         {
             OK,
@@ -60,19 +106,37 @@ namespace AstrOsBulkTransport
 
     // Sequential chunk-receive state machine for the firmware OTA path.
     // The receiver commits chunks strictly in seq order — sliding window
-    // is a sender optimization, not a reorder buffer. After every ACK
-    // the receiver reports `windowRemaining = windowSize_` because it
-    // tracks no in-flight state (each ACK'd chunk is already consumed
-    // by the caller).
+    // is a sender optimization, not a reorder buffer.
+    //
+    // State machine contract:
+    //   - A NAK leaves `nextSeq_` unchanged. The sender MUST retransmit
+    //     the chunk identified by `cr.nextExpectedSeq` (same seq as the
+    //     rejected one).
+    //   - `windowRemaining` on every active-state reply (ACK or NAK)
+    //     equals the `windowSize` passed to `begin()`. The "not active"
+    //     case returns `windowRemaining = 0` as a distinct sentinel.
+    //   - `onEnd` does NOT auto-reset the receiver on IO_ERROR — the
+    //     caller can inspect `nextSeq_` (indirectly via subsequent
+    //     `onChunk` calls' nextExpectedSeq field) before calling `reset()`.
+    //   - Calling `begin()` on an already-active receiver is well-defined:
+    //     it reinitializes the receiver as if `reset()` + `begin()` had
+    //     been called. Useful when the caller decides to restart a
+    //     transfer mid-stream.
+    //   - `begin()` with `chunkSize == 0` or `totalChunks == 0` is treated
+    //     as a protocol violation: the receiver is left inactive (callers
+    //     get OUT_OF_ORDER NAKs from `onChunk`).
     //
     // Usage:
     //   BulkReceiver r;
     //   r.begin(xferId, totalSize, totalChunks, chunkSize, windowSize);
     //   for each FW_CHUNK arrival:
-    //       auto cr = r.onChunk(xferId, seq, len, crc16, payload);
-    //       // caller acts on cr.decision (write bytes / send ACK / send NAK)
+    //       auto cr = r.onChunk(xferId, seq, payloadLen, crc16, payload);
+    //       // On ACK: write cr.payload[0..cr.payloadLen-1] to flash,
+    //       //         send FW_CHUNK_ACK with the seq/window fields.
+    //       // On NAK: send FW_CHUNK_NAK(last-good-seq=highestContiguousSeq,
+    //       //         reason=cr.reason). Sender retransmits cr.nextExpectedSeq.
     //   auto er = r.onEnd(xferId, totalChunksSent);
-    //   r.reset();  // ready for next transfer; safe to call anytime.
+    //   r.reset();  // safe to call anytime; required before the next begin().
     class BulkReceiver
     {
     public:

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -59,6 +59,29 @@ namespace AstrOsBulkTransport
             reset();
             return BeginResult::invalid(BeginResult::Reason::ZERO_TOTAL_CHUNKS);
         }
+        // A zero windowSize defeats the windowRemaining-as-not-active-sentinel
+        // contract: every reply from an active receiver would report
+        // windowRemaining=0 (the configured size), making it indistinguishable
+        // from the inactive case (windowRemaining=0 sentinel). Phase 3's
+        // "abort + restart handshake" dispatch would fire on every chunk.
+        if (windowSize == 0)
+        {
+            reset();
+            return BeginResult::invalid(BeginResult::Reason::ZERO_WINDOW_SIZE);
+        }
+        // totalSize must be in the half-open interval
+        // ((totalChunks - 1) * chunkSize, totalChunks * chunkSize].
+        // Outside this range, the SIZE math at onChunk lines 27/28 either
+        // overflows or produces a meaningless expectedLen (underflow when
+        // totalSize < committedBytes). Computed in uint64_t to avoid the
+        // overflow itself happening in the check.
+        const uint64_t maxBytes = static_cast<uint64_t>(totalChunks) * chunkSize;
+        const uint64_t minBytes = (totalChunks == 1) ? 1u : (static_cast<uint64_t>(totalChunks - 1) * chunkSize) + 1u;
+        if (totalSize == 0 || totalSize > maxBytes || totalSize < minBytes)
+        {
+            reset();
+            return BeginResult::invalid(BeginResult::Reason::SIZE_INCONSISTENT);
+        }
 
         xferId_ = xferId;
         nextSeq_ = 0;
@@ -92,9 +115,14 @@ namespace AstrOsBulkTransport
             return ChunkResult::nakInactive();
         }
 
-        // Structural rejections: wrong xferId or out-of-seq. Both collapse
-        // to OUT_OF_ORDER per the wire-level reason-code set.
-        if (xferId != xferId_ || seq != nextSeq_)
+        // Structural rejections: wrong xferId, out-of-seq, or seq outside
+        // the chunk grid. Range guard prevents `seq * chunkSize_` from
+        // overflowing uint32_t in the SIZE math below — in well-behaved
+        // code the `seq != nextSeq_` reject catches this earlier (nextSeq_
+        // is bounded by totalChunks_), but defense-in-depth pins it as a
+        // structural property of onChunk rather than an emergent one. All
+        // three collapse to OUT_OF_ORDER per the wire-level reason-code set.
+        if (xferId != xferId_ || seq != nextSeq_ || seq >= totalChunks_)
         {
             return ChunkResult::nakActive(NakReason::OUT_OF_ORDER, lastGoodSeq(), nextSeq_, windowSize_);
         }

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -56,27 +56,58 @@ namespace AstrOsBulkTransport
     {
         ChunkResult result{};
         result.decision = Decision::NAK;
-        result.reason = NakReason::OUT_OF_ORDER;
-        // highestContiguousSeq / nextExpectedSeq / windowRemaining default to 0 for the not-active path.
+        // Reported window: always windowSize_ on every reply. The receiver
+        // tracks no in-flight state.
+        result.windowRemaining = active_ ? windowSize_ : 0;
 
+        // Structural rejections first: not-active, wrong xferId, out-of-seq.
+        // All collapse to OUT_OF_ORDER per the wire-level reason-code set.
         if (!active_ || xferId != xferId_ || seq != nextSeq_)
         {
-            // Subsequent tasks: explicit handling for CRC / SIZE / etc. For
-            // now, anything other than a matching in-order chunk on an
-            // active transfer NAKs as OUT_OF_ORDER.
+            result.reason = NakReason::OUT_OF_ORDER;
+            // highestContiguousSeq / nextExpectedSeq default to 0 on the
+            // not-active path; on an active mismatch they should reflect
+            // the receiver's actual state so the sender can resync.
+            if (active_)
+            {
+                result.highestContiguousSeq = (nextSeq_ == 0) ? 0 : (nextSeq_ - 1);
+                result.nextExpectedSeq = nextSeq_;
+            }
             return result;
         }
 
-        // Happy path: ACK and advance.
-        // CRC + SIZE validation come in Task 5/6; for now we trust the inputs
-        // to keep this task's diff focused on begin/reset/state.
-        (void)crc16;
-        (void)payloadLen;
+        // SIZE: compute the expected length for THIS seq. All chunks are
+        // chunkSize_ bytes except possibly the last one (totalSize_ may not
+        // be a clean multiple of chunkSize_).
+        uint32_t expectedLen = chunkSize_;
+        uint32_t committedBytes = static_cast<uint32_t>(seq) * chunkSize_;
+        if (committedBytes + chunkSize_ > totalSize_)
+        {
+            expectedLen = totalSize_ - committedBytes;
+        }
+        if (payloadLen != expectedLen)
+        {
+            result.reason = NakReason::SIZE;
+            result.highestContiguousSeq = (nextSeq_ == 0) ? 0 : (nextSeq_ - 1);
+            result.nextExpectedSeq = nextSeq_;
+            return result;
+        }
+
+        // CRC: recompute over the payload and compare.
+        uint16_t computed = crc16_ccitt_false(payload, payloadLen);
+        if (computed != crc16)
+        {
+            result.reason = NakReason::CRC;
+            result.highestContiguousSeq = (nextSeq_ == 0) ? 0 : (nextSeq_ - 1);
+            result.nextExpectedSeq = nextSeq_;
+            return result;
+        }
+
+        // ACK and advance.
         result.decision = Decision::ACK;
         result.reason = NakReason::NONE;
         result.highestContiguousSeq = seq;
         result.nextExpectedSeq = seq + 1;
-        result.windowRemaining = windowSize_;
         result.payload = payload;
         result.payloadLen = payloadLen;
         nextSeq_++;

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -1,6 +1,7 @@
 #include "AstrOsBulkTransport.hpp"
 
 #include <cassert>
+#include <cstdlib>
 #include <type_traits>
 
 namespace AstrOsBulkTransport
@@ -62,20 +63,27 @@ namespace AstrOsBulkTransport
         // Precondition: `data` must be non-null whenever `len > 0`.
         //   - (anything, 0) is the legitimate empty-input case and returns
         //     the init value 0xFFFFu.
-        //   - (nullptr, len > 0) is a caller programming error. We fail-fast
-        //     via assert rather than UB on the deref: native tests catch the
-        //     violation immediately; on ESP target assert() panics + resets,
-        //     which is louder than the silent garbage the deref would
-        //     produce. The earlier (data == nullptr || len == 0) form
-        //     silently returned 0xFFFFu in BOTH cases, which made a caller
-        //     passing `payload=nullptr, payloadLen=K, crc16=0xFFFFu` look
-        //     like a valid ACK candidate (computed CRC matched the claimed
-        //     CRC by coincidence). BulkReceiver::onChunk has its own
-        //     structural guard for nullptr-with-positive-len, but this
-        //     function is a public API — any future caller (including
-        //     code outside BulkReceiver) gets the same deterministic
-        //     failure mode.
-        assert(data != nullptr || len == 0);
+        //   - (nullptr, len > 0) is a caller programming error. The check
+        //     below uses an unconditional abort path (NOT bare assert) so
+        //     the precondition holds in NDEBUG/release builds too — assert()
+        //     alone would compile out and re-introduce the UB on deref.
+        //     The assert() is kept for the failure message (file:line +
+        //     expression text via __assert_func); abort() is the actual
+        //     terminator that runs regardless of NDEBUG.
+        //
+        // History: the earlier (data == nullptr || len == 0) form silently
+        // returned 0xFFFFu in BOTH cases, which made a caller passing
+        // `payload=nullptr, payloadLen=K, crc16=0xFFFFu` look like a valid
+        // ACK candidate (computed CRC matched the claimed CRC by
+        // coincidence). BulkReceiver::onChunk has its own structural guard
+        // for nullptr-with-positive-len, but this function is a public
+        // API — any future caller (including code outside BulkReceiver)
+        // gets the same deterministic failure mode.
+        if (data == nullptr && len > 0)
+        {
+            assert(false && "crc16_ccitt_false: data is nullptr but len > 0");
+            std::abort();
+        }
         if (len == 0)
         {
             return 0xFFFFu;
@@ -133,10 +141,13 @@ namespace AstrOsBulkTransport
         }
         // totalSize must be in the half-open interval
         // ((totalChunks - 1) * chunkSize, totalChunks * chunkSize].
-        // Outside this range, the SIZE math at onChunk lines 27/28 either
-        // overflows or produces a meaningless expectedLen (underflow when
-        // totalSize < committedBytes). Computed in uint64_t to avoid the
-        // overflow itself happening in the check.
+        // Outside this range, onChunk's `committedBytes` / `expectedLen`
+        // SIZE math either overflows (committedBytes + chunkSize_ wraps
+        // when totalSize is near UINT32_MAX) or underflows
+        // (totalSize_ - committedBytes when totalSize < committedBytes),
+        // producing meaningless expectedLen values and confusing SIZE
+        // NAKs. Computed in uint64_t to avoid the overflow itself
+        // happening in the check.
         const uint64_t maxBytes = static_cast<uint64_t>(totalChunks) * chunkSize;
         const uint64_t minBytes = (totalChunks == 1) ? 1u : (static_cast<uint64_t>(totalChunks - 1) * chunkSize) + 1u;
         if (totalSize == 0 || totalSize > maxBytes || totalSize < minBytes)

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -161,7 +161,7 @@ namespace AstrOsBulkTransport
 
     EndResult BulkReceiver::onEnd(uint8_t xferId, uint32_t totalChunksSent)
     {
-        // Three distinct IO_ERROR causes — surface each with its own
+        // Four distinct IO_ERROR causes — surface each with its own
         // Reason so Phase 3 can log them distinctly. The four conditions
         // intentionally check in order of caller-fault diagnosis: "is
         // the receiver even live?" → "are we talking about the same

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -2,11 +2,20 @@
 
 namespace AstrOsBulkTransport
 {
+    // NakReason wire stability: values CRC..FLASH_FULL are serialized into
+    // FW_CHUNK_NAK reason-code fields. Pin them at compile time so an
+    // accidental reorder breaks the build, not the protocol.
+    static_assert(static_cast<uint8_t>(NakReason::NONE) == 0);
+    static_assert(static_cast<uint8_t>(NakReason::CRC) == 1);
+    static_assert(static_cast<uint8_t>(NakReason::SIZE) == 2);
+    static_assert(static_cast<uint8_t>(NakReason::OUT_OF_ORDER) == 3);
+    static_assert(static_cast<uint8_t>(NakReason::FLASH_FULL) == 4);
+
     // CRC-16/CCITT-FALSE. Bit-by-bit reference implementation:
     //   poly = 0x1021, init = 0xFFFF, refIn = false, refOut = false, xorOut = 0.
-    // Table-based variants would be faster but the volume here (one chunk =
-    // ~4 KB per frame, ~5 MB/s peak throughput) doesn't justify the static
-    // table cost in a PURE lib that has no on-device performance pressure.
+    // Table-based variants would be faster but the FW_CHUNK rate is bounded
+    // by the 115200-baud serial link (~11 KB/s sustained, so each ~4 KB
+    // chunk's CRC completes in well under a millisecond). No table needed.
     uint16_t crc16_ccitt_false(const uint8_t *data, size_t len)
     {
         uint16_t crc = 0xFFFFu;
@@ -31,6 +40,19 @@ namespace AstrOsBulkTransport
     void BulkReceiver::begin(uint8_t xferId, uint32_t totalSize, uint32_t totalChunks, uint16_t chunkSize,
                              uint8_t windowSize)
     {
+        // Reject protocol-illegal parameters by leaving the receiver inactive.
+        // A zero chunkSize would make every chunk NAK with SIZE (because
+        // expectedLen would be 0 for any non-final seq) and would risk
+        // confusing the SIZE math; zero totalChunks would let onEnd return
+        // OK without ever receiving a chunk. The MIXED caller's
+        // FW_TRANSFER_BEGIN parser should catch these earlier, but the
+        // guard here keeps the state machine in a well-defined state.
+        if (chunkSize == 0 || totalChunks == 0)
+        {
+            reset();
+            return;
+        }
+
         xferId_ = xferId;
         nextSeq_ = 0;
         totalSize_ = totalSize;
@@ -56,8 +78,9 @@ namespace AstrOsBulkTransport
     {
         ChunkResult result{};
         result.decision = Decision::NAK;
-        // Reported window: always windowSize_ on every reply. The receiver
-        // tracks no in-flight state.
+        // Reported window: windowSize_ on every active-state reply (ACK or
+        // NAK) since the receiver tracks no in-flight state. 0 when the
+        // receiver is not active — Phase 3 dispatches on this sentinel.
         result.windowRemaining = active_ ? windowSize_ : 0;
 
         // Structural rejections first: not-active, wrong xferId, out-of-seq.

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -76,27 +76,19 @@ namespace AstrOsBulkTransport
     ChunkResult BulkReceiver::onChunk(uint8_t xferId, uint32_t seq, uint16_t payloadLen, uint16_t crc16,
                                       const uint8_t *payload)
     {
-        ChunkResult result{};
-        result.decision = Decision::NAK;
-        // Reported window: windowSize_ on every active-state reply (ACK or
-        // NAK) since the receiver tracks no in-flight state. 0 when the
-        // receiver is not active — Phase 3 dispatches on this sentinel.
-        result.windowRemaining = active_ ? windowSize_ : 0;
-
-        // Structural rejections first: not-active, wrong xferId, out-of-seq.
-        // All collapse to OUT_OF_ORDER per the wire-level reason-code set.
-        if (!active_ || xferId != xferId_ || seq != nextSeq_)
+        // Not-active: distinct from "active state mismatch" via the
+        // windowRemaining=0 sentinel that ChunkResult::nakInactive
+        // produces. Phase 3 dispatches differently on the two cases.
+        if (!active_)
         {
-            result.reason = NakReason::OUT_OF_ORDER;
-            // highestContiguousSeq / nextExpectedSeq default to 0 on the
-            // not-active path; on an active mismatch they should reflect
-            // the receiver's actual state so the sender can resync.
-            if (active_)
-            {
-                result.highestContiguousSeq = (nextSeq_ == 0) ? 0 : (nextSeq_ - 1);
-                result.nextExpectedSeq = nextSeq_;
-            }
-            return result;
+            return ChunkResult::nakInactive();
+        }
+
+        // Structural rejections: wrong xferId or out-of-seq. Both collapse
+        // to OUT_OF_ORDER per the wire-level reason-code set.
+        if (xferId != xferId_ || seq != nextSeq_)
+        {
+            return ChunkResult::nakActive(NakReason::OUT_OF_ORDER, lastGoodSeq(), nextSeq_, windowSize_);
         }
 
         // SIZE: compute the expected length for THIS seq. All chunks are
@@ -110,31 +102,16 @@ namespace AstrOsBulkTransport
         }
         if (payloadLen != expectedLen)
         {
-            result.reason = NakReason::SIZE;
-            result.highestContiguousSeq = (nextSeq_ == 0) ? 0 : (nextSeq_ - 1);
-            result.nextExpectedSeq = nextSeq_;
-            return result;
+            return ChunkResult::nakActive(NakReason::SIZE, lastGoodSeq(), nextSeq_, windowSize_);
         }
 
-        // CRC: recompute over the payload and compare.
-        uint16_t computed = crc16_ccitt_false(payload, payloadLen);
-        if (computed != crc16)
+        if (crc16_ccitt_false(payload, payloadLen) != crc16)
         {
-            result.reason = NakReason::CRC;
-            result.highestContiguousSeq = (nextSeq_ == 0) ? 0 : (nextSeq_ - 1);
-            result.nextExpectedSeq = nextSeq_;
-            return result;
+            return ChunkResult::nakActive(NakReason::CRC, lastGoodSeq(), nextSeq_, windowSize_);
         }
 
-        // ACK and advance.
-        result.decision = Decision::ACK;
-        result.reason = NakReason::NONE;
-        result.highestContiguousSeq = seq;
-        result.nextExpectedSeq = seq + 1;
-        result.payload = payload;
-        result.payloadLen = payloadLen;
         nextSeq_++;
-        return result;
+        return ChunkResult::ack(seq, seq + 1, windowSize_, payload, payloadLen);
     }
 
     EndResult BulkReceiver::onEnd(uint8_t xferId, uint32_t totalChunksSent)

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -18,6 +18,15 @@ namespace AstrOsBulkTransport
     // chunk's CRC completes in well under a millisecond). No table needed.
     uint16_t crc16_ccitt_false(const uint8_t *data, size_t len)
     {
+        // Defensive: the loop is gated by `len` so `data` is never dereferenced
+        // when len==0, but a hypothetical future single-byte fast-path
+        // refactor (e.g. an unrolled first iteration outside the loop)
+        // would silently UB on nullptr. Returning the init value here pins
+        // the contract that (nullptr, 0) is well-defined.
+        if (data == nullptr || len == 0)
+        {
+            return 0xFFFFu;
+        }
         uint16_t crc = 0xFFFFu;
         for (size_t i = 0; i < len; i++)
         {

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -1,5 +1,8 @@
 #include "AstrOsBulkTransport.hpp"
 
+#include <cassert>
+#include <type_traits>
+
 namespace AstrOsBulkTransport
 {
     // NakReason wire stability: values CRC..FLASH_FULL are serialized into
@@ -32,6 +35,23 @@ namespace AstrOsBulkTransport
     static_assert(static_cast<uint8_t>(EndResult::Reason::SENDER_TOTAL_MISMATCH) == 3);
     static_assert(static_cast<uint8_t>(EndResult::Reason::RECEIVER_SHORT_COUNT) == 4);
 
+    // ChunkResult immutability: every public field must be const so a
+    // factory-produced result can be inspected by callers but not mutated
+    // into an invalid combination after construction. Implicitly disables
+    // copy/move assignment (`r1 = r2` won't compile) while preserving
+    // copy-construction (`auto r1 = factory()` still works) and prvalue
+    // returns from the factories. Pinned at compile time so a future
+    // refactor that drops `const` from any field breaks the build.
+    static_assert(std::is_const_v<decltype(ChunkResult::decision)>);
+    static_assert(std::is_const_v<decltype(ChunkResult::highestContiguousSeq)>);
+    static_assert(std::is_const_v<decltype(ChunkResult::nextExpectedSeq)>);
+    static_assert(std::is_const_v<decltype(ChunkResult::windowRemaining)>);
+    static_assert(std::is_const_v<decltype(ChunkResult::reason)>);
+    static_assert(std::is_const_v<decltype(ChunkResult::payload)>);
+    static_assert(std::is_const_v<decltype(ChunkResult::payloadLen)>);
+    static_assert(!std::is_copy_assignable_v<ChunkResult>);
+    static_assert(std::is_copy_constructible_v<ChunkResult>);
+
     // CRC-16/CCITT-FALSE. Bit-by-bit reference implementation:
     //   poly = 0x1021, init = 0xFFFF, refIn = false, refOut = false, xorOut = 0.
     // Table-based variants would be faster but the FW_CHUNK rate is bounded
@@ -39,17 +59,23 @@ namespace AstrOsBulkTransport
     // chunk's CRC completes in well under a millisecond). No table needed.
     uint16_t crc16_ccitt_false(const uint8_t *data, size_t len)
     {
-        // (anything, 0) is the empty-input case and returns the init value
-        // 0xFFFFu. (nullptr, len > 0) is a caller programming error — the
-        // earlier (data == nullptr || len == 0) form silently returned
-        // 0xFFFFu in both cases, which made `payload=nullptr, payloadLen=K,
-        // crc16=0xFFFFu` a valid-looking ACK candidate (matching the empty-
-        // input CRC). Splitting the two cases makes the (nullptr, len>0)
-        // path explicit. The state-machine caller `onChunk` is responsible
-        // for rejecting nullptr-with-positive-len upstream (structural NAK);
-        // this function falls through to the loop for nullptr+positive-len
-        // and will UB on the deref, which is acceptable defense-in-depth
-        // because the upstream guard runs first.
+        // Precondition: `data` must be non-null whenever `len > 0`.
+        //   - (anything, 0) is the legitimate empty-input case and returns
+        //     the init value 0xFFFFu.
+        //   - (nullptr, len > 0) is a caller programming error. We fail-fast
+        //     via assert rather than UB on the deref: native tests catch the
+        //     violation immediately; on ESP target assert() panics + resets,
+        //     which is louder than the silent garbage the deref would
+        //     produce. The earlier (data == nullptr || len == 0) form
+        //     silently returned 0xFFFFu in BOTH cases, which made a caller
+        //     passing `payload=nullptr, payloadLen=K, crc16=0xFFFFu` look
+        //     like a valid ACK candidate (computed CRC matched the claimed
+        //     CRC by coincidence). BulkReceiver::onChunk has its own
+        //     structural guard for nullptr-with-positive-len, but this
+        //     function is a public API — any future caller (including
+        //     code outside BulkReceiver) gets the same deterministic
+        //     failure mode.
+        assert(data != nullptr || len == 0);
         if (len == 0)
         {
             return 0xFFFFu;

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -2,10 +2,29 @@
 
 namespace AstrOsBulkTransport
 {
+    // CRC-16/CCITT-FALSE. Bit-by-bit reference implementation:
+    //   poly = 0x1021, init = 0xFFFF, refIn = false, refOut = false, xorOut = 0.
+    // Table-based variants would be faster but the volume here (one chunk =
+    // ~4 KB per frame, ~5 MB/s peak throughput) doesn't justify the static
+    // table cost in a PURE lib that has no on-device performance pressure.
     uint16_t crc16_ccitt_false(const uint8_t *data, size_t len)
     {
-        (void)data;
-        (void)len;
-        return 0; // implemented in Task 2
+        uint16_t crc = 0xFFFFu;
+        for (size_t i = 0; i < len; i++)
+        {
+            crc ^= static_cast<uint16_t>(data[i]) << 8;
+            for (int bit = 0; bit < 8; bit++)
+            {
+                if (crc & 0x8000u)
+                {
+                    crc = static_cast<uint16_t>((crc << 1) ^ 0x1021u);
+                }
+                else
+                {
+                    crc = static_cast<uint16_t>(crc << 1);
+                }
+            }
+        }
+        return crc;
     }
 } // namespace AstrOsBulkTransport

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -1,0 +1,11 @@
+#include "AstrOsBulkTransport.hpp"
+
+namespace AstrOsBulkTransport
+{
+    uint16_t crc16_ccitt_false(const uint8_t *data, size_t len)
+    {
+        (void)data;
+        (void)len;
+        return 0; // implemented in Task 2
+    }
+} // namespace AstrOsBulkTransport

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -116,9 +116,23 @@ namespace AstrOsBulkTransport
 
     EndResult BulkReceiver::onEnd(uint8_t xferId, uint32_t totalChunksSent)
     {
-        // Stub for Task 4: prevents linker error. Real implementation lands in Task 7.
-        (void)xferId;
-        (void)totalChunksSent;
-        return EndResult{};
+        EndResult result{};
+        result.status = EndResult::Status::IO_ERROR;
+
+        if (!active_ || xferId != xferId_)
+        {
+            return result;
+        }
+        if (totalChunksSent != totalChunks_)
+        {
+            return result;
+        }
+        if (nextSeq_ != totalChunks_)
+        {
+            return result;
+        }
+
+        result.status = EndResult::Status::OK;
+        return result;
     }
 } // namespace AstrOsBulkTransport

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -27,4 +27,67 @@ namespace AstrOsBulkTransport
         }
         return crc;
     }
+
+    void BulkReceiver::begin(uint8_t xferId, uint32_t totalSize, uint32_t totalChunks, uint16_t chunkSize,
+                             uint8_t windowSize)
+    {
+        xferId_ = xferId;
+        nextSeq_ = 0;
+        totalSize_ = totalSize;
+        totalChunks_ = totalChunks;
+        chunkSize_ = chunkSize;
+        windowSize_ = windowSize;
+        active_ = true;
+    }
+
+    void BulkReceiver::reset()
+    {
+        xferId_ = 0;
+        nextSeq_ = 0;
+        totalSize_ = 0;
+        totalChunks_ = 0;
+        chunkSize_ = 0;
+        windowSize_ = 0;
+        active_ = false;
+    }
+
+    ChunkResult BulkReceiver::onChunk(uint8_t xferId, uint32_t seq, uint16_t payloadLen, uint16_t crc16,
+                                      const uint8_t *payload)
+    {
+        ChunkResult result{};
+        result.decision = Decision::NAK;
+        result.reason = NakReason::OUT_OF_ORDER;
+        // highestContiguousSeq / nextExpectedSeq / windowRemaining default to 0 for the not-active path.
+
+        if (!active_ || xferId != xferId_ || seq != nextSeq_)
+        {
+            // Subsequent tasks: explicit handling for CRC / SIZE / etc. For
+            // now, anything other than a matching in-order chunk on an
+            // active transfer NAKs as OUT_OF_ORDER.
+            return result;
+        }
+
+        // Happy path: ACK and advance.
+        // CRC + SIZE validation come in Task 5/6; for now we trust the inputs
+        // to keep this task's diff focused on begin/reset/state.
+        (void)crc16;
+        (void)payloadLen;
+        result.decision = Decision::ACK;
+        result.reason = NakReason::NONE;
+        result.highestContiguousSeq = seq;
+        result.nextExpectedSeq = seq + 1;
+        result.windowRemaining = windowSize_;
+        result.payload = payload;
+        result.payloadLen = payloadLen;
+        nextSeq_++;
+        return result;
+    }
+
+    EndResult BulkReceiver::onEnd(uint8_t xferId, uint32_t totalChunksSent)
+    {
+        // Stub for Task 4: prevents linker error. Real implementation lands in Task 7.
+        (void)xferId;
+        (void)totalChunksSent;
+        return EndResult{};
+    }
 } // namespace AstrOsBulkTransport

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -11,6 +11,27 @@ namespace AstrOsBulkTransport
     static_assert(static_cast<uint8_t>(NakReason::OUT_OF_ORDER) == 3);
     static_assert(static_cast<uint8_t>(NakReason::FLASH_FULL) == 4);
 
+    // API-stable enums consumed by Phase 3 dispatch via switch statements.
+    // Not wire-serialized — these values won't end up on the bus — but a
+    // future reorder would silently change which `case` fires for which
+    // failure cause, with no compiler diagnostic to catch the bug. Pin
+    // them here so the build breaks, not the dispatch.
+    static_assert(static_cast<uint8_t>(BeginResult::Reason::OK) == 0);
+    static_assert(static_cast<uint8_t>(BeginResult::Reason::ZERO_CHUNK_SIZE) == 1);
+    static_assert(static_cast<uint8_t>(BeginResult::Reason::ZERO_TOTAL_CHUNKS) == 2);
+    static_assert(static_cast<uint8_t>(BeginResult::Reason::ZERO_WINDOW_SIZE) == 3);
+    static_assert(static_cast<uint8_t>(BeginResult::Reason::SIZE_INCONSISTENT) == 4);
+
+    static_assert(static_cast<uint8_t>(EndResult::Status::OK) == 0);
+    static_assert(static_cast<uint8_t>(EndResult::Status::HASH_MISMATCH) == 1);
+    static_assert(static_cast<uint8_t>(EndResult::Status::IO_ERROR) == 2);
+
+    static_assert(static_cast<uint8_t>(EndResult::Reason::NONE) == 0);
+    static_assert(static_cast<uint8_t>(EndResult::Reason::NOT_ACTIVE) == 1);
+    static_assert(static_cast<uint8_t>(EndResult::Reason::WRONG_XFER_ID) == 2);
+    static_assert(static_cast<uint8_t>(EndResult::Reason::SENDER_TOTAL_MISMATCH) == 3);
+    static_assert(static_cast<uint8_t>(EndResult::Reason::RECEIVER_SHORT_COUNT) == 4);
+
     // CRC-16/CCITT-FALSE. Bit-by-bit reference implementation:
     //   poly = 0x1021, init = 0xFFFF, refIn = false, refOut = false, xorOut = 0.
     // Table-based variants would be faster but the FW_CHUNK rate is bounded
@@ -18,12 +39,18 @@ namespace AstrOsBulkTransport
     // chunk's CRC completes in well under a millisecond). No table needed.
     uint16_t crc16_ccitt_false(const uint8_t *data, size_t len)
     {
-        // Defensive: the loop is gated by `len` so `data` is never dereferenced
-        // when len==0, but a hypothetical future single-byte fast-path
-        // refactor (e.g. an unrolled first iteration outside the loop)
-        // would silently UB on nullptr. Returning the init value here pins
-        // the contract that (nullptr, 0) is well-defined.
-        if (data == nullptr || len == 0)
+        // (anything, 0) is the empty-input case and returns the init value
+        // 0xFFFFu. (nullptr, len > 0) is a caller programming error — the
+        // earlier (data == nullptr || len == 0) form silently returned
+        // 0xFFFFu in both cases, which made `payload=nullptr, payloadLen=K,
+        // crc16=0xFFFFu` a valid-looking ACK candidate (matching the empty-
+        // input CRC). Splitting the two cases makes the (nullptr, len>0)
+        // path explicit. The state-machine caller `onChunk` is responsible
+        // for rejecting nullptr-with-positive-len upstream (structural NAK);
+        // this function falls through to the loop for nullptr+positive-len
+        // and will UB on the deref, which is acceptable defense-in-depth
+        // because the upstream guard runs first.
+        if (len == 0)
         {
             return 0xFFFFu;
         }
@@ -124,14 +151,21 @@ namespace AstrOsBulkTransport
             return ChunkResult::nakInactive();
         }
 
-        // Structural rejections: wrong xferId, out-of-seq, or seq outside
-        // the chunk grid. Range guard prevents `seq * chunkSize_` from
-        // overflowing uint32_t in the SIZE math below — in well-behaved
-        // code the `seq != nextSeq_` reject catches this earlier (nextSeq_
-        // is bounded by totalChunks_), but defense-in-depth pins it as a
-        // structural property of onChunk rather than an emergent one. All
-        // three collapse to OUT_OF_ORDER per the wire-level reason-code set.
-        if (xferId != xferId_ || seq != nextSeq_ || seq >= totalChunks_)
+        // Structural rejections: wrong xferId, out-of-seq, seq outside the
+        // chunk grid, or null payload with non-zero length. Range guard
+        // prevents `seq * chunkSize_` from overflowing uint32_t in the SIZE
+        // math below — in well-behaved code the `seq != nextSeq_` reject
+        // catches this earlier (nextSeq_ is bounded by totalChunks_), but
+        // defense-in-depth pins it as a structural property of onChunk
+        // rather than an emergent one. The nullptr-payload check closes a
+        // genuine collision the CRC-empty-buffer guard would otherwise
+        // create: crc16_ccitt_false(nullptr, len) returns 0xFFFFu by
+        // contract, so a caller passing (payload=nullptr, payloadLen=K,
+        // crc16=0xFFFF) would pass SIZE (K matches expectedLen) AND CRC
+        // (computed == claimed), producing an ACK with payload=nullptr
+        // that Phase 3 would deref. All four cases collapse to
+        // OUT_OF_ORDER per the wire-level reason-code set.
+        if (xferId != xferId_ || seq != nextSeq_ || seq >= totalChunks_ || (payloadLen > 0 && payload == nullptr))
         {
             return ChunkResult::nakActive(NakReason::OUT_OF_ORDER, lastGoodSeq(), nextSeq_, windowSize_);
         }

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -37,8 +37,8 @@ namespace AstrOsBulkTransport
         return crc;
     }
 
-    void BulkReceiver::begin(uint8_t xferId, uint32_t totalSize, uint32_t totalChunks, uint16_t chunkSize,
-                             uint8_t windowSize)
+    BeginResult BulkReceiver::begin(uint8_t xferId, uint32_t totalSize, uint32_t totalChunks, uint16_t chunkSize,
+                                    uint8_t windowSize)
     {
         // Reject protocol-illegal parameters by leaving the receiver inactive.
         // A zero chunkSize would make every chunk NAK with SIZE (because
@@ -46,11 +46,18 @@ namespace AstrOsBulkTransport
         // confusing the SIZE math; zero totalChunks would let onEnd return
         // OK without ever receiving a chunk. The MIXED caller's
         // FW_TRANSFER_BEGIN parser should catch these earlier, but the
-        // guard here keeps the state machine in a well-defined state.
-        if (chunkSize == 0 || totalChunks == 0)
+        // guard here keeps the state machine in a well-defined state and
+        // surfaces the specific rejection reason so Phase 3 can emit a
+        // matching FW_TRANSFER_BEGIN_ACK status code.
+        if (chunkSize == 0)
         {
             reset();
-            return;
+            return BeginResult::invalid(BeginResult::Reason::ZERO_CHUNK_SIZE);
+        }
+        if (totalChunks == 0)
+        {
+            reset();
+            return BeginResult::invalid(BeginResult::Reason::ZERO_TOTAL_CHUNKS);
         }
 
         xferId_ = xferId;
@@ -60,6 +67,7 @@ namespace AstrOsBulkTransport
         chunkSize_ = chunkSize;
         windowSize_ = windowSize;
         active_ = true;
+        return BeginResult::ok();
     }
 
     void BulkReceiver::reset()
@@ -116,23 +124,28 @@ namespace AstrOsBulkTransport
 
     EndResult BulkReceiver::onEnd(uint8_t xferId, uint32_t totalChunksSent)
     {
-        EndResult result{};
-        result.status = EndResult::Status::IO_ERROR;
-
-        if (!active_ || xferId != xferId_)
+        // Three distinct IO_ERROR causes — surface each with its own
+        // Reason so Phase 3 can log them distinctly. The four conditions
+        // intentionally check in order of caller-fault diagnosis: "is
+        // the receiver even live?" → "are we talking about the same
+        // transfer?" → "does the sender agree with us on the total?" →
+        // "did we actually receive all the chunks?"
+        if (!active_)
         {
-            return result;
+            return EndResult::ioError(EndResult::Reason::NOT_ACTIVE);
+        }
+        if (xferId != xferId_)
+        {
+            return EndResult::ioError(EndResult::Reason::WRONG_XFER_ID);
         }
         if (totalChunksSent != totalChunks_)
         {
-            return result;
+            return EndResult::ioError(EndResult::Reason::SENDER_TOTAL_MISMATCH);
         }
         if (nextSeq_ != totalChunks_)
         {
-            return result;
+            return EndResult::ioError(EndResult::Reason::RECEIVER_SHORT_COUNT);
         }
-
-        result.status = EndResult::Status::OK;
-        return result;
+        return EndResult::ok();
     }
 } // namespace AstrOsBulkTransport

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -61,7 +61,7 @@ TEST(BulkTransport, Crc16DeterministicAcrossCalls)
 TEST(BulkTransport, BeginThenSingleChunkInOrderAcks)
 {
     AstrOsBulkTransport::BulkReceiver r;
-    r.begin(/*xferId=*/7, /*totalSize=*/12, /*totalChunks=*/1, /*chunkSize=*/12, /*windowSize=*/16);
+    ASSERT_TRUE(r.begin(/*xferId=*/7, /*totalSize=*/12, /*totalChunks=*/1, /*chunkSize=*/12, /*windowSize=*/16).valid);
 
     const uint8_t payload[] = {'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd', '!'};
     uint16_t expectedCrc = AstrOsBulkTransport::crc16_ccitt_false(payload, sizeof(payload));
@@ -97,7 +97,7 @@ TEST(BulkTransport, OnChunkBeforeBeginNaksOutOfOrder)
 TEST(BulkTransport, ResetReturnsToInactive)
 {
     AstrOsBulkTransport::BulkReceiver r;
-    r.begin(/*xferId=*/7, /*totalSize=*/100, /*totalChunks=*/1, /*chunkSize=*/100, /*windowSize=*/8);
+    ASSERT_TRUE(r.begin(/*xferId=*/7, /*totalSize=*/100, /*totalChunks=*/1, /*chunkSize=*/100, /*windowSize=*/8).valid);
     r.reset();
 
     const uint8_t payload[] = {0x01, 0x02};
@@ -113,7 +113,7 @@ TEST(BulkTransport, ResetReturnsToInactive)
 TEST(BulkTransport, BeginAfterEndReusesReceiver)
 {
     AstrOsBulkTransport::BulkReceiver r;
-    r.begin(/*xferId=*/7, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16);
+    ASSERT_TRUE(r.begin(/*xferId=*/7, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16).valid);
 
     const uint8_t firstPayload[] = {'a', 'b', 'c', 'd'};
     uint16_t firstCrc = AstrOsBulkTransport::crc16_ccitt_false(firstPayload, 4);
@@ -122,7 +122,7 @@ TEST(BulkTransport, BeginAfterEndReusesReceiver)
 
     // Reset, begin a new transfer with a different xferId, and accept its first chunk.
     r.reset();
-    r.begin(/*xferId=*/9, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16);
+    ASSERT_TRUE(r.begin(/*xferId=*/9, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16).valid);
 
     const uint8_t secondPayload[] = {'e', 'f', 'g', 'h'};
     uint16_t secondCrc = AstrOsBulkTransport::crc16_ccitt_false(secondPayload, 4);
@@ -138,7 +138,7 @@ TEST(BulkTransport, BeginOnActiveReceiverReinitializes)
     // The contract says begin() on an already-active receiver reinitializes
     // it as if reset() + begin() had been called.
     AstrOsBulkTransport::BulkReceiver r;
-    r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16);
+    ASSERT_TRUE(r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16).valid);
 
     const uint8_t payload[] = {'a', 'b', 'c', 'd'};
     uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
@@ -146,7 +146,7 @@ TEST(BulkTransport, BeginOnActiveReceiverReinitializes)
 
     // Call begin() again with a different xferId mid-transfer, without
     // an intervening reset(). nextSeq_ should be zeroed back to 0.
-    r.begin(/*xferId=*/9, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16);
+    ASSERT_TRUE(r.begin(/*xferId=*/9, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16).valid);
 
     auto result = r.onChunk(/*xferId=*/9, /*seq=*/0, 4, crc, payload);
     EXPECT_EQ(AstrOsBulkTransport::Decision::ACK, result.decision);
@@ -157,7 +157,13 @@ TEST(BulkTransport, BeginOnActiveReceiverReinitializes)
 TEST(BulkTransport, BeginWithZeroChunkSizeLeavesReceiverInactive)
 {
     AstrOsBulkTransport::BulkReceiver r;
-    r.begin(/*xferId=*/7, /*totalSize=*/100, /*totalChunks=*/1, /*chunkSize=*/0, /*windowSize=*/16);
+    auto br = r.begin(/*xferId=*/7, /*totalSize=*/100, /*totalChunks=*/1, /*chunkSize=*/0, /*windowSize=*/16);
+
+    // BeginResult surfaces the specific rejection reason so Phase 3 can
+    // emit a matching FW_TRANSFER_BEGIN_ACK status code rather than
+    // silently NAK every subsequent chunk.
+    EXPECT_FALSE(br.valid);
+    EXPECT_EQ(AstrOsBulkTransport::BeginResult::Reason::ZERO_CHUNK_SIZE, br.reason);
 
     // Receiver should be inactive — onChunk reports the not-active sentinel.
     const uint8_t payload[] = {0x01};
@@ -172,7 +178,10 @@ TEST(BulkTransport, BeginWithZeroChunkSizeLeavesReceiverInactive)
 TEST(BulkTransport, BeginWithZeroTotalChunksLeavesReceiverInactive)
 {
     AstrOsBulkTransport::BulkReceiver r;
-    r.begin(/*xferId=*/7, /*totalSize=*/0, /*totalChunks=*/0, /*chunkSize=*/4, /*windowSize=*/16);
+    auto br = r.begin(/*xferId=*/7, /*totalSize=*/0, /*totalChunks=*/0, /*chunkSize=*/4, /*windowSize=*/16);
+
+    EXPECT_FALSE(br.valid);
+    EXPECT_EQ(AstrOsBulkTransport::BeginResult::Reason::ZERO_TOTAL_CHUNKS, br.reason);
 
     const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
     uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
@@ -181,9 +190,11 @@ TEST(BulkTransport, BeginWithZeroTotalChunksLeavesReceiverInactive)
     EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
     EXPECT_EQ(0u, result.windowRemaining);
 
-    // onEnd on the inactive receiver should not return OK.
+    // onEnd on the inactive receiver should not return OK, and should
+    // surface NOT_ACTIVE as the distinct IO_ERROR reason.
     auto end = r.onEnd(7, 0);
     EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::IO_ERROR, end.status);
+    EXPECT_EQ(AstrOsBulkTransport::EndResult::Reason::NOT_ACTIVE, end.reason);
 }
 
 //=================================================================================================
@@ -193,7 +204,7 @@ TEST(BulkTransport, BeginWithZeroTotalChunksLeavesReceiverInactive)
 TEST(BulkTransport, OnChunkBadCrcNaks)
 {
     AstrOsBulkTransport::BulkReceiver r;
-    r.begin(/*xferId=*/7, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16);
+    ASSERT_TRUE(r.begin(/*xferId=*/7, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16).valid);
 
     const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
     uint16_t realCrc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
@@ -213,7 +224,8 @@ TEST(BulkTransport, OnChunkPayloadLenMismatchNaksSize)
 {
     AstrOsBulkTransport::BulkReceiver r;
     // totalSize = 4096, chunkSize = 1024 -> 4 chunks of 1024 bytes each.
-    r.begin(/*xferId=*/7, /*totalSize=*/4096, /*totalChunks=*/4, /*chunkSize=*/1024, /*windowSize=*/16);
+    ASSERT_TRUE(
+        r.begin(/*xferId=*/7, /*totalSize=*/4096, /*totalChunks=*/4, /*chunkSize=*/1024, /*windowSize=*/16).valid);
 
     // Sender claims this is chunk 0 with len=500 — wrong; should be 1024.
     std::vector<uint8_t> payload(500, 0xAA);
@@ -234,7 +246,8 @@ TEST(BulkTransport, OnChunkLastShortChunkAcks)
 {
     AstrOsBulkTransport::BulkReceiver r;
     // totalSize = 2500, chunkSize = 1024 -> chunks of 1024, 1024, 452.
-    r.begin(/*xferId=*/7, /*totalSize=*/2500, /*totalChunks=*/3, /*chunkSize=*/1024, /*windowSize=*/16);
+    ASSERT_TRUE(
+        r.begin(/*xferId=*/7, /*totalSize=*/2500, /*totalChunks=*/3, /*chunkSize=*/1024, /*windowSize=*/16).valid);
 
     // Commit chunks 0 and 1.
     std::vector<uint8_t> fullChunk(1024, 0xCC);
@@ -257,7 +270,8 @@ TEST(BulkTransport, OnChunkWrongPayloadLenOnLastChunkNaksSize)
 {
     AstrOsBulkTransport::BulkReceiver r;
     // totalSize = 2500, chunkSize = 1024 -> last chunk expected = 452 bytes.
-    r.begin(/*xferId=*/7, /*totalSize=*/2500, /*totalChunks=*/3, /*chunkSize=*/1024, /*windowSize=*/16);
+    ASSERT_TRUE(
+        r.begin(/*xferId=*/7, /*totalSize=*/2500, /*totalChunks=*/3, /*chunkSize=*/1024, /*windowSize=*/16).valid);
 
     std::vector<uint8_t> fullChunk(1024, 0xCC);
     uint16_t fullCrc = AstrOsBulkTransport::crc16_ccitt_false(fullChunk.data(), fullChunk.size());
@@ -287,7 +301,7 @@ TEST(BulkTransport, OnChunkWrongPayloadLenOnLastChunkNaksSize)
 TEST(BulkTransport, OnChunkDuplicateSeqNaksOutOfOrder)
 {
     AstrOsBulkTransport::BulkReceiver r;
-    r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16);
+    ASSERT_TRUE(r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16).valid);
 
     const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
     uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
@@ -312,7 +326,7 @@ TEST(BulkTransport, OnChunkDuplicateSeqNaksOutOfOrder)
 TEST(BulkTransport, OnChunkSkipForwardNaksOutOfOrder)
 {
     AstrOsBulkTransport::BulkReceiver r;
-    r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16);
+    ASSERT_TRUE(r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16).valid);
 
     const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
     uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
@@ -329,7 +343,7 @@ TEST(BulkTransport, OnChunkSkipForwardNaksOutOfOrder)
 TEST(BulkTransport, OnChunkWrongXferIdNaksOutOfOrder)
 {
     AstrOsBulkTransport::BulkReceiver r;
-    r.begin(/*xferId=*/7, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16);
+    ASSERT_TRUE(r.begin(/*xferId=*/7, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16).valid);
 
     const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
     uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
@@ -356,7 +370,7 @@ TEST(BulkTransport, OnChunkWrongXferIdNaksOutOfOrder)
 TEST(BulkTransport, OnEndAfterAllChunksReturnsOk)
 {
     AstrOsBulkTransport::BulkReceiver r;
-    r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16);
+    ASSERT_TRUE(r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16).valid);
 
     const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
     uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
@@ -382,7 +396,7 @@ TEST(BulkTransport, OnEndBeforeBeginReturnsIoError)
 TEST(BulkTransport, OnEndWrongXferIdReturnsIoError)
 {
     AstrOsBulkTransport::BulkReceiver r;
-    r.begin(/*xferId=*/7, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16);
+    ASSERT_TRUE(r.begin(/*xferId=*/7, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16).valid);
 
     const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
     uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
@@ -396,7 +410,7 @@ TEST(BulkTransport, OnEndWrongXferIdReturnsIoError)
 TEST(BulkTransport, OnEndSenderTotalMismatchReturnsIoError)
 {
     AstrOsBulkTransport::BulkReceiver r;
-    r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16);
+    ASSERT_TRUE(r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16).valid);
 
     const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
     uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
@@ -411,7 +425,7 @@ TEST(BulkTransport, OnEndSenderTotalMismatchReturnsIoError)
 TEST(BulkTransport, OnEndReceiverShortChunkCountReturnsIoError)
 {
     AstrOsBulkTransport::BulkReceiver r;
-    r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16);
+    ASSERT_TRUE(r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16).valid);
 
     const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
     uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
@@ -435,7 +449,7 @@ TEST(BulkTransport, EndToEndTenChunkTransferWithMidStreamRetransmit)
     constexpr uint8_t kWindowSize = 16;
 
     AstrOsBulkTransport::BulkReceiver r;
-    r.begin(kXferId, kTotalSize, kTotalChunks, kChunkSize, kWindowSize);
+    ASSERT_TRUE(r.begin(kXferId, kTotalSize, kTotalChunks, kChunkSize, kWindowSize).valid);
 
     // 9 full chunks + 1 short tail.
     std::vector<uint8_t> fullPayload(kChunkSize, 0xA5);
@@ -489,7 +503,7 @@ TEST(BulkTransport, EndToEndTransferWithMidStreamSizeRetransmit)
     constexpr uint8_t kWindowSize = 16;
 
     AstrOsBulkTransport::BulkReceiver r;
-    r.begin(kXferId, kTotalSize, kTotalChunks, kChunkSize, kWindowSize);
+    ASSERT_TRUE(r.begin(kXferId, kTotalSize, kTotalChunks, kChunkSize, kWindowSize).valid);
 
     const uint8_t fullPayload[] = {0xDE, 0xAD, 0xBE, 0xEF};
     uint16_t fullCrc = AstrOsBulkTransport::crc16_ccitt_false(fullPayload, 4);

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -175,8 +175,61 @@ TEST(BulkTransport, BeginWithZeroChunkSizeLeavesReceiverInactive)
     EXPECT_EQ(0u, result.windowRemaining); // not-active sentinel
 }
 
+TEST(BulkTransport, BeginWithZeroWindowSizeLeavesReceiverInactive)
+{
+    // Zero windowSize would defeat the windowRemaining=0 not-active
+    // sentinel: every reply from an active receiver would also report
+    // windowRemaining=0 (the configured size). begin() must reject so
+    // Phase 3's "abort + restart" dispatch isn't permanently armed.
+    AstrOsBulkTransport::BulkReceiver r;
+    auto br = r.begin(/*xferId=*/7, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/0);
+
+    EXPECT_FALSE(br.valid);
+    EXPECT_EQ(AstrOsBulkTransport::BeginResult::Reason::ZERO_WINDOW_SIZE, br.reason);
+}
+
+TEST(BulkTransport, BeginWithTotalSizeAboveChunkGridLeavesReceiverInactive)
+{
+    // totalChunks=2, chunkSize=4 -> at most 8 bytes can fit. totalSize=9
+    // means the sender claims more data than the chunk grid can hold:
+    // structurally impossible. Reject before the SIZE math can be confused.
+    AstrOsBulkTransport::BulkReceiver r;
+    auto br = r.begin(/*xferId=*/7, /*totalSize=*/9, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16);
+
+    EXPECT_FALSE(br.valid);
+    EXPECT_EQ(AstrOsBulkTransport::BeginResult::Reason::SIZE_INCONSISTENT, br.reason);
+}
+
+TEST(BulkTransport, BeginWithTotalSizeBelowChunkGridLeavesReceiverInactive)
+{
+    // totalChunks=2, chunkSize=4 -> minimum valid totalSize is 5 (one
+    // full chunk + at least one byte in the second). totalSize=4 means
+    // the second chunk would have to be zero bytes, which the wire
+    // protocol disallows.
+    AstrOsBulkTransport::BulkReceiver r;
+    auto br = r.begin(/*xferId=*/7, /*totalSize=*/4, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16);
+
+    EXPECT_FALSE(br.valid);
+    EXPECT_EQ(AstrOsBulkTransport::BeginResult::Reason::SIZE_INCONSISTENT, br.reason);
+}
+
+TEST(BulkTransport, BeginWithZeroTotalSizeLeavesReceiverInactive)
+{
+    // A zero-byte image is structurally meaningless — caught by the
+    // explicit `totalSize == 0` arm of the consistency check.
+    AstrOsBulkTransport::BulkReceiver r;
+    auto br = r.begin(/*xferId=*/7, /*totalSize=*/0, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16);
+
+    EXPECT_FALSE(br.valid);
+    EXPECT_EQ(AstrOsBulkTransport::BeginResult::Reason::SIZE_INCONSISTENT, br.reason);
+}
+
 TEST(BulkTransport, BeginWithZeroTotalChunksLeavesReceiverInactive)
 {
+    // Note: the zero-totalChunks check runs BEFORE the zero-windowSize and
+    // SIZE_INCONSISTENT checks (consistent with the order in begin()), so
+    // a degenerate-on-multiple-axes BEGIN reports ZERO_TOTAL_CHUNKS — the
+    // first structural problem the receiver hits.
     AstrOsBulkTransport::BulkReceiver r;
     auto br = r.begin(/*xferId=*/7, /*totalSize=*/0, /*totalChunks=*/0, /*chunkSize=*/4, /*windowSize=*/16);
 

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -341,3 +341,56 @@ TEST(BulkTransport, OnEndReceiverShortChunkCountReturnsIoError)
     auto end = r.onEnd(/*xferId=*/7, /*totalChunksSent=*/2);
     EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::IO_ERROR, end.status);
 }
+
+//=================================================================================================
+// BulkReceiver — end-to-end happy path with one mid-stream CRC retransmit
+//=================================================================================================
+
+TEST(BulkTransport, EndToEndTenChunkTransferWithMidStreamRetransmit)
+{
+    constexpr uint32_t kTotalSize = 9500;
+    constexpr uint16_t kChunkSize = 1024;
+    constexpr uint32_t kTotalChunks = 10; // 9 full chunks + 1 short (9500 - 9216 = 284 bytes)
+    constexpr uint8_t kXferId = 42;
+    constexpr uint8_t kWindowSize = 16;
+
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(kXferId, kTotalSize, kTotalChunks, kChunkSize, kWindowSize);
+
+    // 9 full chunks + 1 short tail.
+    std::vector<uint8_t> fullPayload(kChunkSize, 0xA5);
+    uint16_t fullCrc = AstrOsBulkTransport::crc16_ccitt_false(fullPayload.data(), fullPayload.size());
+
+    for (uint32_t seq = 0; seq < kTotalChunks - 1; seq++)
+    {
+        if (seq == 5)
+        {
+            // Mid-stream CRC error: sender sends correct payload with a corrupted CRC field.
+            auto nakResult =
+                r.onChunk(kXferId, seq, kChunkSize, static_cast<uint16_t>(fullCrc ^ 0x00FFu), fullPayload.data());
+            ASSERT_EQ(AstrOsBulkTransport::Decision::NAK, nakResult.decision);
+            ASSERT_EQ(AstrOsBulkTransport::NakReason::CRC, nakResult.reason);
+            EXPECT_EQ(4u, nakResult.highestContiguousSeq);
+            EXPECT_EQ(5u, nakResult.nextExpectedSeq);
+            // Sender retransmits seq=5 with the correct CRC.
+        }
+        auto okResult = r.onChunk(kXferId, seq, kChunkSize, fullCrc, fullPayload.data());
+        ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, okResult.decision) << "ACK failed at seq=" << seq;
+        ASSERT_EQ(seq + 1, okResult.nextExpectedSeq);
+    }
+
+    // Final short chunk: 9500 - 9 * 1024 = 9500 - 9216 = 284 bytes.
+    constexpr uint16_t kTailLen = 284;
+    std::vector<uint8_t> tail(kTailLen, 0xC3);
+    uint16_t tailCrc = AstrOsBulkTransport::crc16_ccitt_false(tail.data(), tail.size());
+    auto tailResult = r.onChunk(kXferId, kTotalChunks - 1, kTailLen, tailCrc, tail.data());
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, tailResult.decision);
+    EXPECT_EQ(kTotalChunks - 1, tailResult.highestContiguousSeq);
+    EXPECT_EQ(kTotalChunks, tailResult.nextExpectedSeq);
+
+    // End of transfer.
+    auto endResult = r.onEnd(kXferId, kTotalChunks);
+    EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::OK, endResult.status);
+
+    r.reset();
+}

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -53,3 +53,77 @@ TEST(BulkTransport, Crc16DeterministicAcrossCalls)
     uint16_t second = AstrOsBulkTransport::crc16_ccitt_false(data, 4);
     EXPECT_EQ(first, second);
 }
+
+//=================================================================================================
+// BulkReceiver::begin + reset + minimal onChunk happy path
+//=================================================================================================
+
+TEST(BulkTransport, BeginThenSingleChunkInOrderAcks)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/12, /*totalChunks=*/1, /*chunkSize=*/12, /*windowSize=*/16);
+
+    const uint8_t payload[] = {'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd', '!'};
+    uint16_t expectedCrc = AstrOsBulkTransport::crc16_ccitt_false(payload, sizeof(payload));
+
+    auto result = r.onChunk(/*xferId=*/7, /*seq=*/0, sizeof(payload), expectedCrc, payload);
+
+    EXPECT_EQ(AstrOsBulkTransport::Decision::ACK, result.decision);
+    EXPECT_EQ(AstrOsBulkTransport::NakReason::NONE, result.reason);
+    EXPECT_EQ(0u, result.highestContiguousSeq);
+    EXPECT_EQ(1u, result.nextExpectedSeq);
+    EXPECT_EQ(16u, result.windowRemaining); // matches the windowSize passed to begin()
+    EXPECT_EQ(payload, result.payload);     // pointer passes through unmodified
+    EXPECT_EQ(sizeof(payload), result.payloadLen);
+}
+
+TEST(BulkTransport, OnChunkBeforeBeginNaksOutOfOrder)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    // No begin() called.
+    const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
+
+    auto result = r.onChunk(/*xferId=*/7, /*seq=*/0, 4, crc, payload);
+
+    EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
+    EXPECT_EQ(AstrOsBulkTransport::NakReason::OUT_OF_ORDER, result.reason);
+}
+
+TEST(BulkTransport, ResetReturnsToInactive)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/100, /*totalChunks=*/1, /*chunkSize=*/100, /*windowSize=*/8);
+    r.reset();
+
+    // After reset, onChunk should behave the same as if begin() had never been called.
+    const uint8_t payload[] = {0x01, 0x02};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 2);
+    auto result = r.onChunk(/*xferId=*/7, /*seq=*/0, 2, crc, payload);
+
+    EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
+    EXPECT_EQ(AstrOsBulkTransport::NakReason::OUT_OF_ORDER, result.reason);
+}
+
+TEST(BulkTransport, BeginAfterEndReusesReceiver)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t firstPayload[] = {'a', 'b', 'c', 'd'};
+    uint16_t firstCrc = AstrOsBulkTransport::crc16_ccitt_false(firstPayload, 4);
+    auto first = r.onChunk(7, 0, 4, firstCrc, firstPayload);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, first.decision);
+
+    // Reset, begin a new transfer with a different xferId, and accept its first chunk.
+    r.reset();
+    r.begin(/*xferId=*/9, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t secondPayload[] = {'e', 'f', 'g', 'h'};
+    uint16_t secondCrc = AstrOsBulkTransport::crc16_ccitt_false(secondPayload, 4);
+    auto second = r.onChunk(9, 0, 4, secondCrc, secondPayload);
+
+    EXPECT_EQ(AstrOsBulkTransport::Decision::ACK, second.decision);
+    EXPECT_EQ(0u, second.highestContiguousSeq);
+    EXPECT_EQ(1u, second.nextExpectedSeq);
+}

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -411,6 +411,31 @@ TEST(BulkTransport, OnChunkSkipForwardNaksOutOfOrder)
     EXPECT_EQ(nullptr, skipped.payload);
 }
 
+TEST(BulkTransport, OnChunkNullPayloadWithPositiveLenNaksOutOfOrder)
+{
+    // Regression guard for a real bug: crc16_ccitt_false's empty-input case
+    // returns 0xFFFFu. The naive `if (data == nullptr || len == 0)` form of
+    // that guard made (nullptr, K, 0xFFFFu) look like a valid ACK candidate
+    // because:
+    //   - payloadLen=K matches expectedLen (SIZE check passes),
+    //   - crc16_ccitt_false(nullptr, K) returns 0xFFFFu (CRC check passes),
+    //   - onChunk returns ACK with payload=nullptr → Phase 3 derefs null.
+    // Closed by the upstream structural guard in onChunk and by tightening
+    // crc16_ccitt_false to only short-circuit on len==0. This test pins
+    // both: a nullptr payload with positive payloadLen MUST NAK, and the
+    // ChunkResult MUST NOT carry a non-null payload pointer.
+    AstrOsBulkTransport::BulkReceiver r;
+    ASSERT_TRUE(r.begin(/*xferId=*/7, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16).valid);
+
+    auto result = r.onChunk(/*xferId=*/7, /*seq=*/0, /*payloadLen=*/4, /*crc16=*/0xFFFFu, /*payload=*/nullptr);
+    EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
+    EXPECT_EQ(AstrOsBulkTransport::NakReason::OUT_OF_ORDER, result.reason);
+    EXPECT_EQ(nullptr, result.payload);
+    EXPECT_EQ(0u, result.payloadLen);
+    EXPECT_EQ(0u, result.nextExpectedSeq); // first-chunk sentinel
+    EXPECT_EQ(16u, result.windowRemaining);
+}
+
 TEST(BulkTransport, OnChunkWrongXferIdNaksOutOfOrder)
 {
     AstrOsBulkTransport::BulkReceiver r;

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -1,0 +1,55 @@
+#include <AstrOsBulkTransport.hpp>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace
+{
+    // Helper: compute CRC over a string literal (excluding null terminator).
+    uint16_t crc(const char *s)
+    {
+        return AstrOsBulkTransport::crc16_ccitt_false(reinterpret_cast<const uint8_t *>(s), std::strlen(s));
+    }
+} // namespace
+
+//=================================================================================================
+// CRC-16/CCITT-FALSE (poly 0x1021, init 0xFFFF, no reflection, no XOR-out)
+//=================================================================================================
+
+TEST(BulkTransport, Crc16EmptyInputReturnsInitValue)
+{
+    // Empty input: CRC equals the init value 0xFFFF.
+    EXPECT_EQ(0xFFFFu, AstrOsBulkTransport::crc16_ccitt_false(nullptr, 0));
+}
+
+TEST(BulkTransport, Crc16CanonicalCheckVector)
+{
+    // "123456789" -> 0x29B1 per the canonical CCITT-FALSE test vector.
+    EXPECT_EQ(0x29B1u, crc("123456789"));
+}
+
+TEST(BulkTransport, Crc16SingleZeroByte)
+{
+    // A single 0x00 byte: well-known CCITT-FALSE result 0xE1F0.
+    const uint8_t data[] = {0x00};
+    EXPECT_EQ(0xE1F0u, AstrOsBulkTransport::crc16_ccitt_false(data, 1));
+}
+
+TEST(BulkTransport, Crc16SingleFfByte)
+{
+    // A single 0xFF byte: well-known CCITT-FALSE result 0xFF00.
+    const uint8_t data[] = {0xFF};
+    EXPECT_EQ(0xFF00u, AstrOsBulkTransport::crc16_ccitt_false(data, 1));
+}
+
+TEST(BulkTransport, Crc16DeterministicAcrossCalls)
+{
+    // Same input on two separate invocations must produce the same output —
+    // a regression guard for any future caching/state mistake.
+    const uint8_t data[] = {0xDE, 0xAD, 0xBE, 0xEF};
+    uint16_t first = AstrOsBulkTransport::crc16_ccitt_false(data, 4);
+    uint16_t second = AstrOsBulkTransport::crc16_ccitt_false(data, 4);
+    EXPECT_EQ(first, second);
+}

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -268,3 +268,21 @@ TEST(BulkTransport, OnChunkWrongXferIdNaksOutOfOrder)
     EXPECT_EQ(AstrOsBulkTransport::Decision::ACK, recovery.decision);
     EXPECT_EQ(1u, recovery.nextExpectedSeq);
 }
+
+//=================================================================================================
+// BulkReceiver::onEnd — happy path
+//=================================================================================================
+
+TEST(BulkTransport, OnEndAfterAllChunksReturnsOk)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(7, 0, 4, crc, payload).decision);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(7, 1, 4, crc, payload).decision);
+
+    auto end = r.onEnd(/*xferId=*/7, /*totalChunksSent=*/2);
+    EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::OK, end.status);
+}

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -122,8 +122,19 @@ TEST(BulkTransport, ResetReturnsToInactive)
     EXPECT_EQ(nullptr, result.payload);
 }
 
-TEST(BulkTransport, BeginAfterEndReusesReceiver)
+TEST(BulkTransport, ResetThenBeginAcceptsNewTransfer)
 {
+    // Pins that reset() returns the receiver to pre-begin state cleanly:
+    // a follow-up begin() with a different xferId activates a fresh
+    // transfer, and the first onChunk on that new transfer ACKs with
+    // the resume cursor reinitialized to (highestContiguousSeq=0,
+    // nextExpectedSeq=1).
+    //
+    // NOTE: this test does NOT cover the begin-after-end case (commit
+    // a successful transfer end-to-end, then begin a new one). That's
+    // covered by OnEndOkLeavesReceiverInPostOkState in combination with
+    // BeginOnActiveReceiverReinitializes (which pins that begin() on
+    // an already-active receiver reinit's correctly).
     AstrOsBulkTransport::BulkReceiver r;
     ASSERT_TRUE(r.begin(/*xferId=*/7, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16).valid);
 
@@ -132,7 +143,8 @@ TEST(BulkTransport, BeginAfterEndReusesReceiver)
     auto first = r.onChunk(7, 0, 4, firstCrc, firstPayload);
     ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, first.decision);
 
-    // Reset, begin a new transfer with a different xferId, and accept its first chunk.
+    // Reset (without ending the transfer first), begin a new transfer
+    // with a different xferId, and accept its first chunk.
     r.reset();
     ASSERT_TRUE(r.begin(/*xferId=*/9, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16).valid);
 

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -54,6 +54,18 @@ TEST(BulkTransport, Crc16DeterministicAcrossCalls)
     EXPECT_EQ(first, second);
 }
 
+TEST(BulkTransport, Crc16MultiByteNonStringVector)
+{
+    // Pin a multi-byte non-printable input to its known value. The canonical
+    // "123456789" -> 0x29B1 catches polynomial swaps; this catches more subtle
+    // bugs in the high-bit XOR feedback path where the polynomial is correct
+    // but, say, the shift direction or XOR mask gets flipped — those would
+    // still produce a deterministic-but-wrong value, which the determinism
+    // test alone would not detect.
+    const uint8_t data[] = {0xDE, 0xAD, 0xBE, 0xEF};
+    EXPECT_EQ(0x4097u, AstrOsBulkTransport::crc16_ccitt_false(data, 4));
+}
+
 //=================================================================================================
 // BulkReceiver::begin + reset + minimal onChunk happy path
 //=================================================================================================
@@ -317,6 +329,12 @@ TEST(BulkTransport, OnChunkLastShortChunkAcks)
     EXPECT_EQ(AstrOsBulkTransport::Decision::ACK, r2.decision);
     EXPECT_EQ(2u, r2.highestContiguousSeq);
     EXPECT_EQ(3u, r2.nextExpectedSeq);
+    // Pin payload pass-through on the short-tail chunk specifically: this is
+    // the only seq where the SIZE math computes a non-full expectedLen, and a
+    // hypothetical bug that assigned chunkSize_ to payloadLen instead of the
+    // caller's payloadLen would silently corrupt the final flash write.
+    EXPECT_EQ(tail.data(), r2.payload);
+    EXPECT_EQ(452u, r2.payloadLen);
 }
 
 TEST(BulkTransport, OnChunkWrongPayloadLenOnLastChunkNaksSize)
@@ -444,6 +462,7 @@ TEST(BulkTransport, OnEndBeforeBeginReturnsIoError)
     // No begin() called.
     auto end = r.onEnd(/*xferId=*/7, /*totalChunksSent=*/1);
     EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::IO_ERROR, end.status);
+    EXPECT_EQ(AstrOsBulkTransport::EndResult::Reason::NOT_ACTIVE, end.reason);
 }
 
 TEST(BulkTransport, OnEndWrongXferIdReturnsIoError)
@@ -458,6 +477,7 @@ TEST(BulkTransport, OnEndWrongXferIdReturnsIoError)
     // Caller claims this END is for a different xferId.
     auto end = r.onEnd(/*xferId=*/9, /*totalChunksSent=*/1);
     EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::IO_ERROR, end.status);
+    EXPECT_EQ(AstrOsBulkTransport::EndResult::Reason::WRONG_XFER_ID, end.reason);
 }
 
 TEST(BulkTransport, OnEndSenderTotalMismatchReturnsIoError)
@@ -473,6 +493,7 @@ TEST(BulkTransport, OnEndSenderTotalMismatchReturnsIoError)
     // Sender claims 3 chunks were sent, but begin() said 2.
     auto end = r.onEnd(/*xferId=*/7, /*totalChunksSent=*/3);
     EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::IO_ERROR, end.status);
+    EXPECT_EQ(AstrOsBulkTransport::EndResult::Reason::SENDER_TOTAL_MISMATCH, end.reason);
 }
 
 TEST(BulkTransport, OnEndReceiverShortChunkCountReturnsIoError)
@@ -487,6 +508,47 @@ TEST(BulkTransport, OnEndReceiverShortChunkCountReturnsIoError)
 
     auto end = r.onEnd(/*xferId=*/7, /*totalChunksSent=*/2);
     EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::IO_ERROR, end.status);
+    // RECEIVER_SHORT_COUNT is distinct from SENDER_TOTAL_MISMATCH: here the
+    // sender's totalChunksSent agrees with the receiver's declared total,
+    // but the receiver actually committed fewer chunks (probably lost some
+    // to NAKs the sender didn't resend). Phase 3 needs the distinction so
+    // the operator log says "lost some chunks" vs "sender lied about total."
+    EXPECT_EQ(AstrOsBulkTransport::EndResult::Reason::RECEIVER_SHORT_COUNT, end.reason);
+}
+
+TEST(BulkTransport, OnEndOkLeavesReceiverInPostOkState)
+{
+    // Contract pin: onEnd(OK) does NOT auto-reset the receiver. nextSeq_
+    // is left at totalChunks_, active_ stays true. The state machine remains
+    // queryable via onChunk — a stray retransmit chunk arriving after a
+    // successful END must produce a deterministic, well-defined NAK rather
+    // than corrupt internal state. Phase 3 is responsible for calling
+    // reset() before begin()-ing the next transfer (which begin() itself
+    // does internally on reinit, per the BeginOnActiveReceiverReinitializes
+    // contract).
+    AstrOsBulkTransport::BulkReceiver r;
+    ASSERT_TRUE(r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16).valid);
+    const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(7, 0, 4, crc, payload).decision);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(7, 1, 4, crc, payload).decision);
+    ASSERT_EQ(AstrOsBulkTransport::EndResult::Status::OK, r.onEnd(7, 2).status);
+
+    // A stray retransmit (seq=2 = totalChunks_) arrives after the OK END.
+    // The seq >= totalChunks_ structural guard from the hardening commit
+    // catches it as OUT_OF_ORDER, with the active-state sync fields
+    // (windowRemaining = configured windowSize, nextExpectedSeq = nextSeq_).
+    auto stray = r.onChunk(7, 2, 4, crc, payload);
+    EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, stray.decision);
+    EXPECT_EQ(AstrOsBulkTransport::NakReason::OUT_OF_ORDER, stray.reason);
+    EXPECT_EQ(16u, stray.windowRemaining); // still active — NOT the inactive sentinel
+    EXPECT_EQ(2u, stray.nextExpectedSeq);  // == totalChunks_; tells sender "no more chunks"
+
+    // A second onEnd is idempotent: returns OK again because all totals
+    // still match. This isn't a "transfer finished twice" — it just means
+    // the contract is "OK is the steady state after success."
+    auto secondEnd = r.onEnd(7, 2);
+    EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::OK, secondEnd.status);
 }
 
 //=================================================================================================

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -127,3 +127,82 @@ TEST(BulkTransport, BeginAfterEndReusesReceiver)
     EXPECT_EQ(0u, second.highestContiguousSeq);
     EXPECT_EQ(1u, second.nextExpectedSeq);
 }
+
+//=================================================================================================
+// BulkReceiver::onChunk — CRC + SIZE rejection
+//=================================================================================================
+
+TEST(BulkTransport, OnChunkBadCrcNaks)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
+    uint16_t realCrc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
+    auto result = r.onChunk(7, 0, 4, /*crc16=*/static_cast<uint16_t>(realCrc ^ 0xFFFFu), payload);
+
+    EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
+    EXPECT_EQ(AstrOsBulkTransport::NakReason::CRC, result.reason);
+    // No chunk committed yet -> reported as 0/0.
+    EXPECT_EQ(0u, result.highestContiguousSeq);
+    EXPECT_EQ(0u, result.nextExpectedSeq);
+    EXPECT_EQ(16u, result.windowRemaining);
+}
+
+TEST(BulkTransport, OnChunkPayloadLenMismatchNaksSize)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    // totalSize = 4096, chunkSize = 1024 -> 4 chunks of 1024 bytes each.
+    r.begin(/*xferId=*/7, /*totalSize=*/4096, /*totalChunks=*/4, /*chunkSize=*/1024, /*windowSize=*/16);
+
+    // Sender claims this is chunk 0 with len=500 — wrong; should be 1024.
+    std::vector<uint8_t> payload(500, 0xAA);
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload.data(), payload.size());
+    auto result = r.onChunk(7, 0, static_cast<uint16_t>(payload.size()), crc, payload.data());
+
+    EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
+    EXPECT_EQ(AstrOsBulkTransport::NakReason::SIZE, result.reason);
+}
+
+TEST(BulkTransport, OnChunkLastShortChunkAcks)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    // totalSize = 2500, chunkSize = 1024 -> chunks of 1024, 1024, 452.
+    r.begin(/*xferId=*/7, /*totalSize=*/2500, /*totalChunks=*/3, /*chunkSize=*/1024, /*windowSize=*/16);
+
+    // Commit chunks 0 and 1.
+    std::vector<uint8_t> fullChunk(1024, 0xCC);
+    uint16_t fullCrc = AstrOsBulkTransport::crc16_ccitt_false(fullChunk.data(), fullChunk.size());
+    auto r0 = r.onChunk(7, 0, 1024, fullCrc, fullChunk.data());
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r0.decision);
+    auto r1 = r.onChunk(7, 1, 1024, fullCrc, fullChunk.data());
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r1.decision);
+
+    // Last chunk: 452 bytes — the short tail.
+    std::vector<uint8_t> tail(452, 0xDD);
+    uint16_t tailCrc = AstrOsBulkTransport::crc16_ccitt_false(tail.data(), tail.size());
+    auto r2 = r.onChunk(7, 2, 452, tailCrc, tail.data());
+    EXPECT_EQ(AstrOsBulkTransport::Decision::ACK, r2.decision);
+    EXPECT_EQ(2u, r2.highestContiguousSeq);
+    EXPECT_EQ(3u, r2.nextExpectedSeq);
+}
+
+TEST(BulkTransport, OnChunkWrongPayloadLenOnLastChunkNaksSize)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    // totalSize = 2500, chunkSize = 1024 -> last chunk expected = 452 bytes.
+    r.begin(/*xferId=*/7, /*totalSize=*/2500, /*totalChunks=*/3, /*chunkSize=*/1024, /*windowSize=*/16);
+
+    std::vector<uint8_t> fullChunk(1024, 0xCC);
+    uint16_t fullCrc = AstrOsBulkTransport::crc16_ccitt_false(fullChunk.data(), fullChunk.size());
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(7, 0, 1024, fullCrc, fullChunk.data()).decision);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(7, 1, 1024, fullCrc, fullChunk.data()).decision);
+
+    // Last chunk: sender sends 1024 bytes but only 452 are expected.
+    std::vector<uint8_t> wrongTail(1024, 0xDD);
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(wrongTail.data(), wrongTail.size());
+    auto result = r.onChunk(7, 2, 1024, crc, wrongTail.data());
+
+    EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
+    EXPECT_EQ(AstrOsBulkTransport::NakReason::SIZE, result.reason);
+}

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -206,3 +206,65 @@ TEST(BulkTransport, OnChunkWrongPayloadLenOnLastChunkNaksSize)
     EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
     EXPECT_EQ(AstrOsBulkTransport::NakReason::SIZE, result.reason);
 }
+
+//=================================================================================================
+// BulkReceiver::onChunk — duplicate + wrong-xferId rejection
+//=================================================================================================
+
+TEST(BulkTransport, OnChunkDuplicateSeqNaksOutOfOrder)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
+
+    // ACK seq=0 cleanly.
+    auto first = r.onChunk(7, 0, 4, crc, payload);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, first.decision);
+    EXPECT_EQ(1u, first.nextExpectedSeq);
+
+    // Sender retransmits seq=0 — receiver has already moved on.
+    auto duplicate = r.onChunk(7, 0, 4, crc, payload);
+    EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, duplicate.decision);
+    EXPECT_EQ(AstrOsBulkTransport::NakReason::OUT_OF_ORDER, duplicate.reason);
+    // Reports we last committed seq=0, expect seq=1 next.
+    EXPECT_EQ(0u, duplicate.highestContiguousSeq);
+    EXPECT_EQ(1u, duplicate.nextExpectedSeq);
+}
+
+TEST(BulkTransport, OnChunkSkipForwardNaksOutOfOrder)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
+
+    // Sender jumps to seq=1 without sending seq=0.
+    auto skipped = r.onChunk(7, 1, 4, crc, payload);
+    EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, skipped.decision);
+    EXPECT_EQ(AstrOsBulkTransport::NakReason::OUT_OF_ORDER, skipped.reason);
+    EXPECT_EQ(0u, skipped.nextExpectedSeq);
+}
+
+TEST(BulkTransport, OnChunkWrongXferIdNaksOutOfOrder)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
+
+    // Send a chunk claiming xferId=9 on a receiver bound to xferId=7.
+    auto result = r.onChunk(/*xferId=*/9, 0, 4, crc, payload);
+    EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
+    EXPECT_EQ(AstrOsBulkTransport::NakReason::OUT_OF_ORDER, result.reason);
+    EXPECT_EQ(0u, result.nextExpectedSeq);
+
+    // The receiver state must not have been corrupted: a correct chunk for
+    // xferId=7 still gets ACK'd cleanly afterward.
+    auto recovery = r.onChunk(7, 0, 4, crc, payload);
+    EXPECT_EQ(AstrOsBulkTransport::Decision::ACK, recovery.decision);
+    EXPECT_EQ(1u, recovery.nextExpectedSeq);
+}

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -286,3 +286,58 @@ TEST(BulkTransport, OnEndAfterAllChunksReturnsOk)
     auto end = r.onEnd(/*xferId=*/7, /*totalChunksSent=*/2);
     EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::OK, end.status);
 }
+
+//=================================================================================================
+// BulkReceiver::onEnd — IO_ERROR reject paths
+//=================================================================================================
+
+TEST(BulkTransport, OnEndBeforeBeginReturnsIoError)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    // No begin() called.
+    auto end = r.onEnd(/*xferId=*/7, /*totalChunksSent=*/1);
+    EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::IO_ERROR, end.status);
+}
+
+TEST(BulkTransport, OnEndWrongXferIdReturnsIoError)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(7, 0, 4, crc, payload).decision);
+
+    // Caller claims this END is for a different xferId.
+    auto end = r.onEnd(/*xferId=*/9, /*totalChunksSent=*/1);
+    EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::IO_ERROR, end.status);
+}
+
+TEST(BulkTransport, OnEndSenderTotalMismatchReturnsIoError)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(7, 0, 4, crc, payload).decision);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(7, 1, 4, crc, payload).decision);
+
+    // Sender claims 3 chunks were sent, but begin() said 2.
+    auto end = r.onEnd(/*xferId=*/7, /*totalChunksSent=*/3);
+    EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::IO_ERROR, end.status);
+}
+
+TEST(BulkTransport, OnEndReceiverShortChunkCountReturnsIoError)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(7, 0, 4, crc, payload).decision);
+    // Only one chunk was sent; sender claims 2 to match the declared total.
+
+    auto end = r.onEnd(/*xferId=*/7, /*totalChunksSent=*/2);
+    EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::IO_ERROR, end.status);
+}

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -88,6 +88,10 @@ TEST(BulkTransport, OnChunkBeforeBeginNaksOutOfOrder)
 
     EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
     EXPECT_EQ(AstrOsBulkTransport::NakReason::OUT_OF_ORDER, result.reason);
+    // Not-active sentinel: windowRemaining == 0, no payload pass-through.
+    EXPECT_EQ(0u, result.windowRemaining);
+    EXPECT_EQ(nullptr, result.payload);
+    EXPECT_EQ(0u, result.payloadLen);
 }
 
 TEST(BulkTransport, ResetReturnsToInactive)
@@ -96,13 +100,14 @@ TEST(BulkTransport, ResetReturnsToInactive)
     r.begin(/*xferId=*/7, /*totalSize=*/100, /*totalChunks=*/1, /*chunkSize=*/100, /*windowSize=*/8);
     r.reset();
 
-    // After reset, onChunk should behave the same as if begin() had never been called.
     const uint8_t payload[] = {0x01, 0x02};
     uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 2);
     auto result = r.onChunk(/*xferId=*/7, /*seq=*/0, 2, crc, payload);
 
     EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
     EXPECT_EQ(AstrOsBulkTransport::NakReason::OUT_OF_ORDER, result.reason);
+    EXPECT_EQ(0u, result.windowRemaining);
+    EXPECT_EQ(nullptr, result.payload);
 }
 
 TEST(BulkTransport, BeginAfterEndReusesReceiver)
@@ -128,6 +133,59 @@ TEST(BulkTransport, BeginAfterEndReusesReceiver)
     EXPECT_EQ(1u, second.nextExpectedSeq);
 }
 
+TEST(BulkTransport, BeginOnActiveReceiverReinitializes)
+{
+    // The contract says begin() on an already-active receiver reinitializes
+    // it as if reset() + begin() had been called.
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/8, /*totalChunks=*/2, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t payload[] = {'a', 'b', 'c', 'd'};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(7, 0, 4, crc, payload).decision);
+
+    // Call begin() again with a different xferId mid-transfer, without
+    // an intervening reset(). nextSeq_ should be zeroed back to 0.
+    r.begin(/*xferId=*/9, /*totalSize=*/4, /*totalChunks=*/1, /*chunkSize=*/4, /*windowSize=*/16);
+
+    auto result = r.onChunk(/*xferId=*/9, /*seq=*/0, 4, crc, payload);
+    EXPECT_EQ(AstrOsBulkTransport::Decision::ACK, result.decision);
+    EXPECT_EQ(0u, result.highestContiguousSeq);
+    EXPECT_EQ(1u, result.nextExpectedSeq);
+}
+
+TEST(BulkTransport, BeginWithZeroChunkSizeLeavesReceiverInactive)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/100, /*totalChunks=*/1, /*chunkSize=*/0, /*windowSize=*/16);
+
+    // Receiver should be inactive — onChunk reports the not-active sentinel.
+    const uint8_t payload[] = {0x01};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 1);
+    auto result = r.onChunk(7, 0, 1, crc, payload);
+
+    EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
+    EXPECT_EQ(AstrOsBulkTransport::NakReason::OUT_OF_ORDER, result.reason);
+    EXPECT_EQ(0u, result.windowRemaining); // not-active sentinel
+}
+
+TEST(BulkTransport, BeginWithZeroTotalChunksLeavesReceiverInactive)
+{
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(/*xferId=*/7, /*totalSize=*/0, /*totalChunks=*/0, /*chunkSize=*/4, /*windowSize=*/16);
+
+    const uint8_t payload[] = {0x01, 0x02, 0x03, 0x04};
+    uint16_t crc = AstrOsBulkTransport::crc16_ccitt_false(payload, 4);
+    auto result = r.onChunk(7, 0, 4, crc, payload);
+
+    EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
+    EXPECT_EQ(0u, result.windowRemaining);
+
+    // onEnd on the inactive receiver should not return OK.
+    auto end = r.onEnd(7, 0);
+    EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::IO_ERROR, end.status);
+}
+
 //=================================================================================================
 // BulkReceiver::onChunk — CRC + SIZE rejection
 //=================================================================================================
@@ -147,6 +205,8 @@ TEST(BulkTransport, OnChunkBadCrcNaks)
     EXPECT_EQ(0u, result.highestContiguousSeq);
     EXPECT_EQ(0u, result.nextExpectedSeq);
     EXPECT_EQ(16u, result.windowRemaining);
+    EXPECT_EQ(nullptr, result.payload);
+    EXPECT_EQ(0u, result.payloadLen);
 }
 
 TEST(BulkTransport, OnChunkPayloadLenMismatchNaksSize)
@@ -162,6 +222,12 @@ TEST(BulkTransport, OnChunkPayloadLenMismatchNaksSize)
 
     EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
     EXPECT_EQ(AstrOsBulkTransport::NakReason::SIZE, result.reason);
+    // First-chunk NAK: highestContiguousSeq=0, nextExpectedSeq=0 (sentinel).
+    EXPECT_EQ(0u, result.highestContiguousSeq);
+    EXPECT_EQ(0u, result.nextExpectedSeq);
+    EXPECT_EQ(16u, result.windowRemaining);
+    EXPECT_EQ(nullptr, result.payload);
+    EXPECT_EQ(0u, result.payloadLen);
 }
 
 TEST(BulkTransport, OnChunkLastShortChunkAcks)
@@ -205,10 +271,17 @@ TEST(BulkTransport, OnChunkWrongPayloadLenOnLastChunkNaksSize)
 
     EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
     EXPECT_EQ(AstrOsBulkTransport::NakReason::SIZE, result.reason);
+    // Mid-stream NAK after committing seq 0 and 1: highestContiguousSeq=1,
+    // nextExpectedSeq=2, full window. Verifies the SIZE-NAK sync fields
+    // when nextSeq_ > 0.
+    EXPECT_EQ(1u, result.highestContiguousSeq);
+    EXPECT_EQ(2u, result.nextExpectedSeq);
+    EXPECT_EQ(16u, result.windowRemaining);
+    EXPECT_EQ(nullptr, result.payload);
 }
 
 //=================================================================================================
-// BulkReceiver::onChunk — duplicate + wrong-xferId rejection
+// BulkReceiver::onChunk — duplicate, skip-forward + wrong-xferId rejection
 //=================================================================================================
 
 TEST(BulkTransport, OnChunkDuplicateSeqNaksOutOfOrder)
@@ -231,6 +304,9 @@ TEST(BulkTransport, OnChunkDuplicateSeqNaksOutOfOrder)
     // Reports we last committed seq=0, expect seq=1 next.
     EXPECT_EQ(0u, duplicate.highestContiguousSeq);
     EXPECT_EQ(1u, duplicate.nextExpectedSeq);
+    EXPECT_EQ(16u, duplicate.windowRemaining); // active receiver -> full window
+    EXPECT_EQ(nullptr, duplicate.payload);
+    EXPECT_EQ(0u, duplicate.payloadLen);
 }
 
 TEST(BulkTransport, OnChunkSkipForwardNaksOutOfOrder)
@@ -246,6 +322,8 @@ TEST(BulkTransport, OnChunkSkipForwardNaksOutOfOrder)
     EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, skipped.decision);
     EXPECT_EQ(AstrOsBulkTransport::NakReason::OUT_OF_ORDER, skipped.reason);
     EXPECT_EQ(0u, skipped.nextExpectedSeq);
+    EXPECT_EQ(16u, skipped.windowRemaining);
+    EXPECT_EQ(nullptr, skipped.payload);
 }
 
 TEST(BulkTransport, OnChunkWrongXferIdNaksOutOfOrder)
@@ -261,6 +339,8 @@ TEST(BulkTransport, OnChunkWrongXferIdNaksOutOfOrder)
     EXPECT_EQ(AstrOsBulkTransport::Decision::NAK, result.decision);
     EXPECT_EQ(AstrOsBulkTransport::NakReason::OUT_OF_ORDER, result.reason);
     EXPECT_EQ(0u, result.nextExpectedSeq);
+    EXPECT_EQ(16u, result.windowRemaining);
+    EXPECT_EQ(nullptr, result.payload);
 
     // The receiver state must not have been corrupted: a correct chunk for
     // xferId=7 still gets ACK'd cleanly afterward.
@@ -372,8 +452,9 @@ TEST(BulkTransport, EndToEndTenChunkTransferWithMidStreamRetransmit)
             ASSERT_EQ(AstrOsBulkTransport::NakReason::CRC, nakResult.reason);
             EXPECT_EQ(4u, nakResult.highestContiguousSeq);
             EXPECT_EQ(5u, nakResult.nextExpectedSeq);
-            // Sender retransmits seq=5 with the correct CRC.
         }
+        // Falls through on every iteration: when seq == 5, this is the
+        // retransmit with the correct CRC. Otherwise it is the normal send.
         auto okResult = r.onChunk(kXferId, seq, kChunkSize, fullCrc, fullPayload.data());
         ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, okResult.decision) << "ACK failed at seq=" << seq;
         ASSERT_EQ(seq + 1, okResult.nextExpectedSeq);
@@ -393,4 +474,44 @@ TEST(BulkTransport, EndToEndTenChunkTransferWithMidStreamRetransmit)
     EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::OK, endResult.status);
 
     r.reset();
+}
+
+//=================================================================================================
+// BulkReceiver — end-to-end happy path with one mid-stream SIZE retransmit
+//=================================================================================================
+
+TEST(BulkTransport, EndToEndTransferWithMidStreamSizeRetransmit)
+{
+    constexpr uint32_t kTotalSize = 12;
+    constexpr uint16_t kChunkSize = 4;
+    constexpr uint32_t kTotalChunks = 3;
+    constexpr uint8_t kXferId = 11;
+    constexpr uint8_t kWindowSize = 16;
+
+    AstrOsBulkTransport::BulkReceiver r;
+    r.begin(kXferId, kTotalSize, kTotalChunks, kChunkSize, kWindowSize);
+
+    const uint8_t fullPayload[] = {0xDE, 0xAD, 0xBE, 0xEF};
+    uint16_t fullCrc = AstrOsBulkTransport::crc16_ccitt_false(fullPayload, 4);
+
+    // seq=0 ACK clean.
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(kXferId, 0, 4, fullCrc, fullPayload).decision);
+
+    // seq=1: sender erroneously claims 3 bytes (should be 4). NAK reason=SIZE.
+    // CRC is computed over the (truncated) buffer the sender actually sends.
+    const uint8_t shortPayload[] = {0xDE, 0xAD, 0xBE};
+    uint16_t shortCrc = AstrOsBulkTransport::crc16_ccitt_false(shortPayload, 3);
+    auto sizeNak = r.onChunk(kXferId, 1, 3, shortCrc, shortPayload);
+    ASSERT_EQ(AstrOsBulkTransport::Decision::NAK, sizeNak.decision);
+    ASSERT_EQ(AstrOsBulkTransport::NakReason::SIZE, sizeNak.reason);
+    EXPECT_EQ(0u, sizeNak.highestContiguousSeq);
+    EXPECT_EQ(1u, sizeNak.nextExpectedSeq);
+
+    // Sender retransmits seq=1 with the correct 4-byte payload.
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(kXferId, 1, 4, fullCrc, fullPayload).decision);
+    // seq=2 final.
+    ASSERT_EQ(AstrOsBulkTransport::Decision::ACK, r.onChunk(kXferId, 2, 4, fullCrc, fullPayload).decision);
+
+    auto end = r.onEnd(kXferId, kTotalChunks);
+    EXPECT_EQ(AstrOsBulkTransport::EndResult::Status::OK, end.status);
 }


### PR DESCRIPTION
## Summary

Phase 2 of the ESP-side OTA firmware work — the bulk-transport state
machine. Adds `lib_native/AstrOsBulkTransport` as a new PURE library
that owns chunk receive logic (CRC validation, SIZE validation,
sliding-window-style ACK/NAK decisions, end-of-transfer reconciliation)
for the firmware OTA path. **No firmware behavior change yet** — this
phase is the algorithmic core; Phase 3 will wire it into the
`AstrOsSerialMsgHandler` dispatch path with a FreeRTOS task + queue,
and Phase 4 will add the SD writer + streaming SHA-256 hash check.

Design: `.docs/plans/20260514-1941-firmware-ota-esp-master-serial-receive-design.md`
Plan: `.docs/plans/20260514-2300-firmware-ota-phase2-bulk-transport.md`
Protocol: `.docs/protocol.md` (small precision update — see "Cross-repo pairing" below)

**Cross-repo pairing constraint:** This PR's `.docs/protocol.md` change
must merge in lockstep with the paired AstrOs.Server PR on
`feature/ota-phase2-protocol-sync`. The two `protocol.md` files are
byte-identical by contract; merging only one side breaks the invariant
the FW_CHUNK_NAK amendment introduced.

Adds:

- New PURE lib `lib_native/AstrOsBulkTransport/` with public API:
  - `crc16_ccitt_false(data, len)` — standalone CRC helper, poly 0x1021, init 0xFFFF, no input/output reflection, no XOR-out. NOT the same as ESP-IDF's `esp_crc16_le` (which is reflected, init=0); the matching ESP-IDF form is `~esp_rom_crc16_be((uint16_t)~0xFFFF, buf, len)`. Canonical check vector `"123456789"` → `0x29B1`.
  - `BulkReceiver` class with `begin` / `onChunk` / `onEnd` / `reset` methods.
  - Public result types: `[[nodiscard]] BeginResult { valid, reason }`, `ChunkResult` (with factory methods only — no direct construction), `[[nodiscard]] EndResult { status, reason }`.
  - Public enums: `Decision`, `NakReason`, `BeginResult::Reason`, `EndResult::Status`, `EndResult::Reason`. Wire-stable enumerator values pinned with `static_assert`.
- 32 new native tests in `test/test_native/bulk_transport_tests.cpp` covering: 5 CRC pin-tests (canonical + empty/zero/FF/multi-byte), all 3 `begin()` success and 4 rejection paths, 9 `onChunk` paths (happy ACK with payload pass-through, first-chunk CRC NAK, first-chunk SIZE NAK, mid-stream SIZE NAK, short-tail ACK, OUT_OF_ORDER NAK on duplicate/skip/wrong-xferId, post-OK stray retransmit), all 4 `onEnd` IO_ERROR `Reason` values, and a 10-chunk end-to-end integration test with mid-stream CRC retransmit. **293/293 total native tests pass** (261 pre-existing + 32 from Phase 2).
- CI purity-guard registration for the new lib in `.github/workflows/pr-validation.yml`.
- `.docs/protocol.md` precision update for the CRC algorithm at line 26: explicitly names CCITT-FALSE (no reflection, no XOR-out), warns that `esp_crc16_le` is the wrong helper, and documents the canonical check vector.

**Design discipline:** the wire-protocol receiver lives in a PURE layer
(no FreeRTOS, no ESP-IDF) so the entire state machine — including all
CRC/SIZE/seq edge cases — can be exercised against gtest on the host.
Phase 3's MIXED `OtaReceiver` will sit between this PURE state machine
and the FreeRTOS task/queue plumbing; Phase 4 enhances it with SD
writer + streaming SHA-256 hash check. Phase 5 then hardens failure
modes (operator panic-stop interaction, padawan reboot races,
disk-corruption fallbacks).

## Hardening from two passes of PR-toolkit review

Five-reviewer parallel passes (code-reviewer, comment-analyzer,
pr-test-analyzer, silent-failure-hunter, type-design-analyzer) found
issues in two waves. Pass 1: 6 Critical, 14 Important, 14 Minor.
Pass 2: 1 Critical (my own typo in a commit-message attestation), 3
Important (all plan-doc rot), 13 Minor. Pass 2's 5 reviewers
independently reached "noise floor" verdicts on the code itself.

Pass-1 substantive code changes (all merged into this branch):

- **`begin()` totalSize consistency validation.** Previously accepted any `totalSize` value, including 0 and values inconsistent with `totalChunks * chunkSize`. A `totalSize=4, totalChunks=2, chunkSize=4` BEGIN would underflow the SIZE math at seq=1. Now begin() rejects with `BeginResult::Reason::SIZE_INCONSISTENT` when totalSize falls outside `((totalChunks - 1) * chunkSize, totalChunks * chunkSize]` (uint64 math to avoid the check overflowing itself; special-cased `totalChunks==1` minimum). 2-way convergent.
- **`seq * chunkSize_` overflow guard.** SIZE math computes `committedBytes = seq * chunkSize_` in uint32. In well-behaved code the existing `seq != nextSeq_` reject catches out-of-range seqs, but a Phase 3 caller that reused the receiver after `onEnd(OK)` without `reset()` could reach the math with `seq * chunkSize_` near the wrap point. Added `seq >= totalChunks_` to the structural-reject clause: all three out-of-range cases collapse to OUT_OF_ORDER NAK before any size math runs. 2-way convergent.
- **`begin()` now returns `[[nodiscard]] BeginResult`** instead of void. Pre-fix: a buggy server-side BEGIN parameter would silently reject inside `begin()` and leave the receiver inactive — caller had no signal, would ACK the BEGIN and then see every chunk NAK with OUT_OF_ORDER until the transfer timed out. Now compiler refuses to compile a call site that drops the result. 2-way convergent (silent-failure-hunter + type-design-analyzer).
- **`onEnd` collapses 4 distinct IO_ERROR causes** (not-active, wrong-xferId, sender total mismatch, receiver short count) into a single Status::IO_ERROR. Phase 3 trying to log a failed transfer had no way to distinguish the cases. Added `EndResult::Reason` enum; each negative path emits a distinct reason. 2-way convergent.
- **`ChunkResult` invariant via factory methods.** The flat struct allowed structurally invalid combinations (Decision::ACK with non-NONE reason, NAK with non-null payload, active receiver with windowRemaining=0). Refactor: private default constructor + three named factories (`ack`, `nakActive`, `nakInactive`) that map to the three legitimate result shapes. Construction-time invalid combinations are now unrepresentable. Fields stay public-readable so test code's read-by-name idiom is unchanged. 3-way convergent (strongest signal of either pass).
- **`lastGoodSeq()` private helper.** First-chunk-NAK contract (`nextSeq_ == 0 ? 0 : nextSeq_ - 1`) was duplicated at 3 NAK sites. Folded into one `const inline` helper so a future refactor can't drift one NAK site away from the others. 2-way convergent.
- **`begin()` zero-windowSize rejection.** A `windowSize == 0` would set `windowRemaining=0` on every active-state reply — indistinguishable from the not-active sentinel that Phase 3 uses to dispatch "abort + restart handshake." Pre-fix the contract was load-bearing on a value `begin()` never enforced. Now rejected with `BeginResult::Reason::ZERO_WINDOW_SIZE`.
- **`crc16_ccitt_false(nullptr, 0)` explicit guard.** Loop is len-gated so data is never dereferenced when len==0, but the contract was implicit. Explicit early return pins the (nullptr, 0) → 0xFFFFu behavior against a future single-byte fast-path refactor.

Pass-2 substantive changes (commits `06e3851`):

- Fixed a Critical attestation typo (`writeResumePoint` was named in the plan's spec-coverage list, but the shipped helper is `lastGoodSeq()`).
- Fixed re-stale test counts in the plan-doc amendment header (cleanup commits aged the header I introduced; updated to truthful counts and broke out the three growth waves).
- Fixed a "Three"/"Four" off-by-one in the `onEnd` cpp doxygen.
- Added a "NOTE — superseded by cleanup commit `cbd000a`" inline block above the plan's Task-3 EndResult skeleton (HASH_MISMATCH ownership shifted from Phase 3 to Phase 4 during cleanup; the body skeleton hadn't been updated).
- Added an honest "plan-body skeletons are historical, NOT current code" disclaimer to the amendment header so a re-executor knows to consult the shipped `.hpp`/`.cpp` for the final API rather than building from the original task skeletons.

## Test plan

- [x] `pio test -e test` passes (293/293)
- [x] `pio run -e metro_s3` builds clean
- [x] `pio run -e lolin_d32_pro` builds clean
- [x] clang-format clean on changed files (pre-commit hook enforced)
- [x] CI native-purity guard regex matches the lib's README purity list exactly
- [x] Two PR-toolkit review passes — all 5 reviewers converged on "noise floor" for the code in pass 2
- [x] Cross-repo `.docs/protocol.md` verified byte-identical to AstrOs.Server's copy on the paired `feature/ota-phase2-protocol-sync` branch
- [ ] End-to-end OTA happy path — gated on Phase 3 wire-up landing. Until then, `bulk_transport_tests.cpp` exercises the full state machine on the host but no real chunk transits the wire.

## Cross-repo pairing

Must merge in lockstep with the paired AstrOs.Server PR.

| Repo | Branch | Scope |
|---|---|---|
| AstrOs.ESP | `feature/ota-phase2-bulk-transport` | New PURE lib, plan doc, protocol.md CRC precision update |
| AstrOs.Server | `feature/ota-phase2-protocol-sync` | Mirror of the protocol.md CRC precision update (doc-only on the Server side) |

The protocol.md change is small but the byte-identity invariant is
load-bearing — the cross-repo contract says both `.docs/protocol.md`
copies must always match. Merging only one side leaves the spec
drifted. The Server-side commit is a 1-line doc fix paired with this
PR.

## Commit-by-commit

**Original Phase 2 work (12 commits, task-by-task TDD):**

- `4cb653c` docs(plan): firmware OTA Phase 2 — bulk-transport state machine
- `34f148b` feat(bulk-transport): scaffold lib_native/AstrOsBulkTransport
- `781dd27` feat(bulk-transport): crc16_ccitt_false standalone helper
- `d771570` feat(bulk-transport): public type definitions + BulkReceiver shape
- `6269e95` feat(bulk-transport): begin + reset + minimal onChunk happy path
- `dba64fa` feat(bulk-transport): onChunk CRC + SIZE validation
- `b06175d` test(bulk-transport): duplicate + skip-forward + wrong-xferId coverage
- `a462c15` feat(bulk-transport): onEnd happy path returns OK
- `4c4418e` test(bulk-transport): onEnd IO_ERROR reject paths
- `963107c` test(bulk-transport): end-to-end 10-chunk transfer with CRC retransmit
- `6123a6a` fix(bulk-transport): correct CRC docs + harden begin() input validation
- `fe87535` test(bulk-transport): strengthen assertions + add 4 coverage tests

**PR-toolkit pass 1 cleanup (5 commits):**

- `f9fa22e` docs(plan): Phase 2 plan doc — correct CRC interop claim + test counts
- `3d0e506` refactor(bulk-transport): ChunkResult factory methods + lastGoodSeq helper
- `b9a8267` feat(bulk-transport): BeginResult return + EndResult::Reason enum
- `cc8b749` fix(bulk-transport): tighten begin() validation + seq overflow guard
- `cbd000a` test+docs(bulk-transport): pin Reason values on every onEnd path + polish

**PR-toolkit pass 2 cleanup (1 commit):**

- `06e3851` docs: PR-toolkit pass 2 — fix amendment-header rot + 'Three'/'Four' typo

## Known backlog (out of scope for Phase 2)

Pass-2 reviewers flagged several items that are sub-confidence-threshold
or genuinely better-addressed when Phase 3 introduces the first consumer:

- **`ChunkResult` fields are public-mutable.** The factory methods prevent construction of invalid combinations, but a returned `ChunkResult` can still be field-mutated into an invalid state by the caller. Comment claims "public-readable" which the code doesn't enforce. Fix is `const` fields + factory rewrite to use member-initializer lists (~5 lines). Defer to Phase 3 — no consumer exists yet to inform whether the const-ness is worth the slight ergonomics cost.
- **`EndResult::Status::HASH_MISMATCH` is dead in the PURE layer.** This state machine never returns it; Phase 4's SHA-streaming context is the actual producer. The enumerator should arguably move to a Phase 3 MIXED-layer wrapping result type, leaving the PURE contract as "OK or IO_ERROR, period." Layering decision better made when Phase 3 lands.
- **`lastGoodSeq()` name overpromises.** Returns 0 in two semantically-distinct cases (seq 0 committed; nothing committed yet). Disambiguation lives in the wire-layer sentinel contract (`nextExpectedSeq == 0` is the actual "nothing committed" tell). Either rename to `lastGoodSeqOrZero()` or add a one-line comment at the helper. Private helper, blast radius is the file.
- **`ChunkResult` lacks `[[nodiscard]]` while `BeginResult`/`EndResult` have it.** Asymmetry is defensible (chunk results drive immediate wire sends, harder to drop accidentally) but uniform expectations are cheaper than asymmetry. Add for symmetry in Phase 3.
- **`NakReason::NONE` is in-band with wire-stable enumerators.** Same shape concern as `BeginResult::Reason::OK` and `EndResult::Reason::NONE` — present so the "successful path" can fit in the same enum. Defensible because `Decision` discriminates, but a stricter shape would split into two enums. Tag-variant refactor is the bigger fix; defer until a real consumer forces the decision.
- **Boundary test for smallest valid transfer (`totalSize=1, totalChunks=1, chunkSize=1`).** Math is correct (special case for `totalChunks==1` minBytes=1), but no test pins the corner. Minor hedge against future bounds-formula edits.
- **Post-OK `highestContiguousSeq` not asserted** in `OnEndOkLeavesReceiverInPostOkState`. The test verifies `nextExpectedSeq` and `windowRemaining` on the stray retransmit; adding the `highestContiguousSeq` assertion would catch a hypothetical regression in `lastGoodSeq()` for the post-OK state specifically.
- **`transferId` type boundary.** PURE layer uses `uint8_t xferId`; wire layer uses `std::string transferId`. Phase 3 will own the translation; whether to harmonize in the PURE direction (accept `std::string_view`) or the wire direction (overload `getFwChunkAck` etc. to take `uint8_t`) is best decided when the translation is actually being written.
- **`crc16_ccitt_false` typed `uint16_t`** at every site, sharing arg slots with `seq`/`payloadLen`/`xferId`. Transposition risk that strong types (`struct Crc16 { uint16_t value; };`) would prevent. Phase 3 will be the first place this matters at a real call site.
- **`begin()` parameter order is 5 adjacent integer-shaped values.** A `BeginParams` struct with designated initializers would prevent silent transpositions. Currently mitigated by 19 `/*paramName=*/value` comments at test call sites. Phase 3 single integration point makes this lower-stakes; revisit if a second consumer appears.

