### PR TITLE
Feature/ota phase4 sd writer sha256

### DIFF
--- a/.docs/plans/20260517-0756-firmware-ota-phase4-sd-writer-sha256.md
+++ b/.docs/plans/20260517-0756-firmware-ota-phase4-sd-writer-sha256.md
@@ -1,0 +1,282 @@
+# OTA Phase 4 — SD writer + streaming SHA-256 (plan)
+
+## Context
+
+Phases 1-3 of the firmware OTA feature shipped through PR #32 (May 16) plus three
+post-merge hardening commits (poll-gating, idle watchdog, PR-review fixes). The
+end-to-end serial pipeline is working: server can drive a 1.2 MB transfer, the
+master's `OtaReceiver` consumes `OTA_MSG_BEGIN`/`CHUNK`/`END`/`DEPLOY_BEGIN`,
+the `BulkReceiver` validates each chunk's CRC and sequence, and ACK/NAK replies
+flow back. But every payload byte is currently discarded — the receiver acts
+as a `/dev/null` sink.
+
+Phase 4 makes the master actually keep what it receives. It adds two pieces of
+streaming state to `OtaReceiver` (`FILE *staging_` and `mbedtls_sha256_context
+shaCtx_`), drives them from the existing BEGIN/CHUNK/END handlers, and on a
+clean END renames the staged file to its content-addressed final name so it
+survives reboot and can be consumed by the future mesh-forwarder phase. The
+design contract is frozen in `.docs/plans/20260514-1941-firmware-ota-esp-master-serial-receive-design.md`
+(§ "Phase 4 — SD writer + streaming SHA-256"); this plan implements it without
+amendment.
+
+User-confirmed decisions (2026-05-17):
+- Scope matches the design exactly. Wall-clock deadline, FW_BACKPRESSURE, and
+  full negative-path QA stay deferred to Phase 5.
+- Final filename is content-addressed: `/sdcard/firmware/<sha256-hex[0..16)>.bin`.
+
+## Critical files
+
+**Modified:**
+- `lib/OtaReceiver/include/OtaReceiver.hpp` — add `FILE *staging_`,
+  `mbedtls_sha256_context shaCtx_`, `bool shaActive_`, plus private helpers
+  `openStaging()`, `closeStaging(bool keep)`, `resetCryptoAndFile()`.
+- `lib/OtaReceiver/src/OtaReceiver.cpp` — wire the three state-machine handlers
+  to file + SHA operations and to the new status codes. The `handleEnd` OK
+  branch now emits the *locally computed* hash, not the echoed `finalShaIn`.
+- `lib/AstrOsStorageManager/include/AstrOsStorageManager.hpp` — declare
+  `uint64_t freeSpaceSdBytes()` and `bool ensureSdFirmwareDir()`.
+- `lib/AstrOsStorageManager/src/AstOsStorageManager.cpp` — implement both
+  helpers. `freeSpaceSdBytes` wraps `f_getfree` (the FATFS card pointer is
+  already held at file scope as `static sdmmc_card_t *card`).
+  `ensureSdFirmwareDir` calls `mkdir("/sdcard/firmware", 0775)` and treats
+  `EEXIST` as success.
+
+**Unchanged but load-bearing — read before editing:**
+- `.docs/plans/20260514-1941-firmware-ota-esp-master-serial-receive-design.md`
+  §§ "Phase 4", "Buffer ownership", "Error handling matrix" — the contract.
+- `lib/AstrOsSerialMsgHandler/src/AstrOsSerialMsgHandler.cpp:317-322` —
+  `sendFwTransferEndAck(msgId, transferId, status, computedSha256Hex)` already
+  takes the hash; Phase 4 just stops passing the server's hash and starts
+  passing the local one.
+- `lib_native/AstrOsBulkTransport/.../AstrOsBulkTransport.hpp` —
+  `ChunkResult.payload`/`payloadLen` are the validated bytes we write.
+- `lib/OtaReceiver/include/OtaQueueMessage.h:39-46` — `SHA256_HEX_LEN = 64`
+  inline buffer convention.
+- `lib/OtaReceiver/README` — already states the lib lands `<mbedtls/sha256.h>`
+  and is MIXED; no classification change needed.
+
+## Approach
+
+### State held across chunks of one transfer
+
+```cpp
+// OtaReceiver.hpp additions (private)
+FILE *staging_ = nullptr;          // open between BEGIN OK and END / abort
+mbedtls_sha256_context shaCtx_;    // raw ctx; init'd lazily in handleBegin
+bool shaActive_ = false;           // tracks whether shaCtx_ needs mbedtls_sha256_free
+```
+
+The pair `(staging_, shaCtx_)` is *only* mutated on `otaReceiverTask` (matches
+the existing single-task-state invariant in the header docstring). Every exit
+path goes through `resetCryptoAndFile()` so abort/success/watchdog-fire all
+land in the same clean state.
+
+### Per-handler changes
+
+**`handleBegin`** — after the existing busy/parse-strict-u8/BulkReceiver
+`.begin()` checks succeed, in order:
+
+1. `AstrOs_Storage.ensureSdFirmwareDir()` — fail → `io_error`.
+2. `uint64_t freeBytes = AstrOs_Storage.freeSpaceSdBytes()` — if
+   `freeBytes < msg.begin.totalSize` reply `sd_full` (new status string —
+   already in the wire contract per `.docs/protocol.md`; handler-side string
+   constant added if missing).
+3. `staging_ = fopen("/sdcard/firmware/staging.bin", "wb")` — fail →
+   `io_error`. The `"wb"` mode truncates so a leftover from a prior
+   `HASH_MISMATCH` is replaced cleanly.
+4. `mbedtls_sha256_init(&shaCtx_); mbedtls_sha256_starts(&shaCtx_, 0);
+   shaActive_ = true;`
+5. Only now flip `active_ = true`, send `BEGIN_ACK status=OK`, start watchdog.
+
+Order matters: nothing past step 1 mutates `active_`, so any early-return
+leaves `OtaReceiver` in the same idle state it was in before BEGIN arrived.
+
+**`handleChunk`** — after `bulk_.onChunk` returns ACK and *before* sending the
+`FW_CHUNK_ACK`:
+
+```cpp
+size_t w = fwrite(cr.payload, 1, cr.payloadLen, staging_);
+if (w != cr.payloadLen) {
+    ESP_LOGE(TAG, "fwrite short: wrote=%zu of %u — aborting transfer", w, cr.payloadLen);
+    AstrOs_SerialMsgHandler.sendFwChunkNak(transferIdIn, cr.highestContiguousSeq,
+                                           cr.nextExpectedSeq, "FLASH_FULL");
+    resetCryptoAndFile(/*keepStaging=*/false);
+    bulk_.reset(); active_ = false; transferIdStr_.clear(); watchdogStop();
+    return;
+}
+mbedtls_sha256_update(&shaCtx_, cr.payload, cr.payloadLen);
+```
+
+The fwrite-failure path mirrors the design's error-handling matrix:
+`FW_CHUNK_NAK reason=FLASH_FULL` and the transfer goes inactive. The server's
+next BEGIN starts a fresh staging.bin (truncating mode). NAK path on bad CRC
+is unchanged — no write, no SHA update.
+
+**`handleEnd`** — replace the current "echo server's hash" line. When
+`bulk_.onEnd` returns OK:
+
+```cpp
+// Close and flush before hashing — fclose drains stdio buffers.
+if (fclose(staging_) != 0) { /* IO_ERROR + computedHex="" + cleanup */ }
+staging_ = nullptr;
+
+uint8_t digest[32];
+mbedtls_sha256_finish(&shaCtx_, digest);
+mbedtls_sha256_free(&shaCtx_);
+shaActive_ = false;
+
+char computedHex[SHA256_HEX_LEN + 1];
+toHexLower(digest, 32, computedHex);  // small static helper in this TU
+
+if (strcmp(computedHex, msg.end.finalSha256Hex) == 0) {
+    char finalPath[64];
+    snprintf(finalPath, sizeof(finalPath), "/sdcard/firmware/%.16s.bin", computedHex);
+    unlink(finalPath);  // tolerate same-firmware re-upload
+    if (rename("/sdcard/firmware/staging.bin", finalPath) != 0) {
+        // Rename failure is the only post-verify error path. Keep staging.bin
+        // so a follow-up phase can still consume it. Reply IO_ERROR.
+        AstrOs_SerialMsgHandler.sendFwTransferEndAck(msgId, transferIdIn, "IO_ERROR", computedHex);
+    } else {
+        ESP_LOGI(TAG, "FW_TRANSFER_END OK: %s sha=%s", finalPath, computedHex);
+        AstrOs_SerialMsgHandler.sendFwTransferEndAck(msgId, transferIdIn, "OK", computedHex);
+    }
+} else {
+    ESP_LOGW(TAG, "FW_TRANSFER_END HASH_MISMATCH: got=%s expected=%s — staging.bin preserved",
+             computedHex, msg.end.finalSha256Hex);
+    AstrOs_SerialMsgHandler.sendFwTransferEndAck(msgId, transferIdIn, "HASH_MISMATCH", computedHex);
+    // Do NOT unlink staging.bin — forensic preservation per design.
+}
+```
+
+`bulk_.onEnd` returning anything but OK keeps the existing IO_ERROR path, but
+now also routes through `resetCryptoAndFile(/*keepStaging=*/true)` so the file
+handle is closed and SHA context freed.
+
+**`handleWatchdogFire`** — append `resetCryptoAndFile(/*keepStaging=*/false)`
+before the existing `active_ = false; transferIdStr_.clear();`. Discarding
+staging.bin is correct here because no END was seen and the bytes are
+unverified.
+
+**`handleBegin` (busy path) and parse-rejects** — must NOT touch `staging_` /
+`shaCtx_`. Those belong to the in-flight transfer that's still running.
+
+### Cleanup helper
+
+```cpp
+void OtaReceiver::resetCryptoAndFile(bool keepStaging) {
+    if (staging_ != nullptr) {
+        fclose(staging_);
+        staging_ = nullptr;
+        if (!keepStaging) unlink("/sdcard/firmware/staging.bin");
+    }
+    if (shaActive_) {
+        mbedtls_sha256_free(&shaCtx_);
+        shaActive_ = false;
+    }
+}
+```
+
+Idempotent. Called from `handleEnd` (both branches), `handleChunk` fwrite-fail
+branch, `handleWatchdogFire`, and the destructor (with `keepStaging=true` —
+shutdown is not a transfer outcome).
+
+### StorageManager helpers
+
+`freeSpaceSdBytes()` — use `f_getfree("0:", &nclust, &fs)` where `fs` is the
+FATFS pointer reachable through the existing mounted card; multiply
+`nclust * fs->csize * fs->ssize`. Returns `0` if SD is unmounted (forces the
+caller into `io_error` rather than a false-positive "plenty of room").
+
+`ensureSdFirmwareDir()` — `mkdir("/sdcard/firmware", 0775) == 0 || errno == EEXIST`.
+Idempotent so it can be called every BEGIN without conditionalizing on a
+"first transfer" flag.
+
+## Reused, not re-implemented
+
+- `AstrOs_Storage` (singleton in `lib/AstrOsStorageManager`) — already mounts
+  the SD card at boot and exposes the `card` pointer needed for `f_getfree`.
+- `mbedtls/base64.h` is already linked via
+  `lib/AstrOsSerialMsgHandler/src/AstrOsSerialMsgHandler.cpp:10` — same
+  mbedtls component covers `<mbedtls/sha256.h>` without platformio.ini
+  changes.
+- `sendFwTransferBeginAck` / `sendFwTransferEndAck` / `sendFwChunkNak`
+  signatures already carry the fields Phase 4 needs (status strings, computed
+  hash). No wire-format or builder changes.
+- `BulkReceiver`'s `ChunkResult.payload` / `payloadLen` already deliver
+  validated bytes — Phase 4 just consumes them. No PURE-lib changes.
+
+## Task checklist
+
+- [ ] Task 1 — Add `freeSpaceSdBytes()` and `ensureSdFirmwareDir()` to
+      `AstrOsStorageManager` (header + impl). Log on failure; return safe
+      defaults.
+- [ ] Task 2 — Extend `OtaReceiver.hpp` with `staging_`, `shaCtx_`,
+      `shaActive_`, and the private `resetCryptoAndFile` helper. Add
+      `<mbedtls/sha256.h>` and `<cstdio>` includes.
+- [ ] Task 3 — Rewrite `handleBegin` to add the ensure-dir / free-space /
+      fopen / sha-start sequence. Map failures to the documented
+      `io_error` / `sd_full` / `busy` status strings.
+- [ ] Task 4 — Rewrite `handleChunk` ACK branch to `fwrite` + `sha256_update`.
+      Add the `FLASH_FULL` NAK path with full state teardown.
+- [ ] Task 5 — Rewrite `handleEnd` OK branch: `fclose`, `sha256_finish`, hex
+      encode, content-addressed rename (with `unlink` of target first),
+      `HASH_MISMATCH` preserves staging.bin. Wire all paths through
+      `resetCryptoAndFile`.
+- [ ] Task 6 — Update `handleWatchdogFire` (and any other abort surfaces) to
+      call `resetCryptoAndFile(false)`. Audit the destructor.
+- [ ] Task 7 — Extend `.docs/qa/ota-master-serial-receive.md` with the Phase 4
+      "pop SD, verify on-disk SHA-256" expectation (per design § Phase 4
+      review checkpoint). Bump `otaReceiverTask` stack size only if the
+      bench run produces the HWM warning.
+
+## Verification
+
+**Native unit tests** (`pio test -e test`):
+- No new PURE-lib code in this phase. Existing `bulk_transport_tests.cpp` and
+  `astros_serial_messages_tests.cpp` must continue to pass — they cover the
+  CRC, sequence, and wire-format contracts Phase 4 depends on. Expect 293+
+  tests, 100% pass.
+
+**Build matrix:**
+- `pio run -e metro_s3` clean.
+- `pio run -e lolin_d32_pro` clean.
+- `clang-format` clean on changed files.
+
+**Bench QA (Phase 4 review checkpoint, mirrors design §):**
+1. Flash master with this branch on `metro_s3`. SD card inserted, formatted FAT.
+2. From `AstrOs.Server` Firmware view, upload a known-good `.bin` whose
+   SHA-256 is recorded out-of-band (`sha256sum file.bin`).
+3. Expected serial-log flow:
+   `BEGIN accepted → CHUNK_ACK ×N → END_ACK status=OK computedHex=<full-hash>
+   → DEPLOY_DONE all-FAILED not_implemented` (DEPLOY stub from Phase 3 is
+   unchanged).
+4. Pull SD card. On the host: `ls /sdcard/firmware/` shows
+   `<sha-prefix>.bin` and no `staging.bin`. `sha256sum <sha-prefix>.bin`
+   matches the recorded value byte-for-byte.
+5. Negative spot-check (not the full Phase 5 matrix): unplug serial mid-transfer.
+   After ≥10 s watchdog fire shows in logs and `staging.bin` is gone (because
+   `keepStaging=false` on watchdog abort).
+6. Re-run the upload immediately after step 5 — verify the master accepts
+   the new BEGIN cleanly (state was reset) and the second upload completes.
+
+**Stack-pressure check:** watch for the "500 bytes remaining" HWM warning on
+`otaReceiverTask` during a full 1.2 MB transfer. The new on-stack
+`mbedtls_sha256_context` (~108 bytes) + temporary `digest[32]` /
+`computedHex[65]` / `finalPath[64]` are small, but the current 4 KB stack
+already runs Phase 3's BulkReceiver path; if the warning fires, bump to 5 KB
+in `main.cpp`'s `xTaskCreatePinnedToCore` call (separate commit, justified
+by observed HWM).
+
+## Out of scope (deferred to Phase 5)
+
+- Wall-clock max-transfer deadline (5-min `esp_timer` backstop). The idle
+  watchdog from Phase 3 already covers the dominant failure mode.
+- `FW_BACKPRESSURE PAUSE/RESUME`. Only build if SD-write throughput
+  measurements during Phase 4 QA show the master falling behind.
+- Full negative-path QA matrix (server-side wrong-sha injection, pre-fill SD
+  for `sd_full`, mid-transfer CRC injection). Spot-check above proves the
+  cleanup paths; the systematic matrix is Phase 5's job.
+- Cleanup/eviction of stale `<sha-prefix>.bin` files. Owned by the future
+  mesh-forwarder phase that first consumes them.
+- ESP-NOW OTA packet types and any `esp_ota_*` calls. Belongs to the
+  cross-repo sub-project (b) phase 2, not this milestone.

--- a/.docs/plans/20260517-0756-firmware-ota-phase4-sd-writer-sha256.md
+++ b/.docs/plans/20260517-0756-firmware-ota-phase4-sd-writer-sha256.md
@@ -207,27 +207,27 @@ Idempotent so it can be called every BEGIN without conditionalizing on a
 
 ## Task checklist
 
-- [ ] Task 1 — Add `freeSpaceSdBytes()` and `ensureSdFirmwareDir()` to
+- [x] Task 1 — Add `freeSpaceSdBytes()` and `ensureSdFirmwareDir()` to
       `AstrOsStorageManager` (header + impl). Log on failure; return safe
       defaults.
-- [ ] Task 2 — Extend `OtaReceiver.hpp` with `staging_`, `shaCtx_`,
+- [x] Task 2 — Extend `OtaReceiver.hpp` with `staging_`, `shaCtx_`,
       `shaActive_`, and the private `resetCryptoAndFile` helper. Add
       `<mbedtls/sha256.h>` and `<cstdio>` includes.
-- [ ] Task 3 — Rewrite `handleBegin` to add the ensure-dir / free-space /
+- [x] Task 3 — Rewrite `handleBegin` to add the ensure-dir / free-space /
       fopen / sha-start sequence. Map failures to the documented
       `io_error` / `sd_full` / `busy` status strings.
-- [ ] Task 4 — Rewrite `handleChunk` ACK branch to `fwrite` + `sha256_update`.
+- [x] Task 4 — Rewrite `handleChunk` ACK branch to `fwrite` + `sha256_update`.
       Add the `FLASH_FULL` NAK path with full state teardown.
-- [ ] Task 5 — Rewrite `handleEnd` OK branch: `fclose`, `sha256_finish`, hex
+- [x] Task 5 — Rewrite `handleEnd` OK branch: `fclose`, `sha256_finish`, hex
       encode, content-addressed rename (with `unlink` of target first),
       `HASH_MISMATCH` preserves staging.bin. Wire all paths through
       `resetCryptoAndFile`.
-- [ ] Task 6 — Update `handleWatchdogFire` (and any other abort surfaces) to
+- [x] Task 6 — Update `handleWatchdogFire` (and any other abort surfaces) to
       call `resetCryptoAndFile(false)`. Audit the destructor.
 - [ ] Task 7 — Extend `.docs/qa/ota-master-serial-receive.md` with the Phase 4
       "pop SD, verify on-disk SHA-256" expectation (per design § Phase 4
       review checkpoint). Bump `otaReceiverTask` stack size only if the
-      bench run produces the HWM warning.
+      bench run produces the HWM warning. (QA doc done; native tests pass; firmware build in progress.)
 
 ## Verification
 

--- a/.docs/qa/ota-master-serial-receive.md
+++ b/.docs/qa/ota-master-serial-receive.md
@@ -162,7 +162,7 @@ I OtaReceiver: FW_DEPLOY_BEGIN: transferId=<id> target-count=<N> — all-FAILED 
 - SD inspection:
   - `staging.bin` is **absent** (renamed on success).
   - A single file named `<first-16-hex-chars-of-sha>.bin` exists.
-  - `sha256sum` of that file matches the value recorded in step 0 byte-for-byte.
+  - `sha256sum` of that file matches the recorded SHA-256 value byte-for-byte.
 - No `OTA Receiver Stack HWM:` warning (would mean the 4 KB task stack is
   too small after adding the on-stack `mbedtls_sha256_context`; bump to 5120
   if it fires).

--- a/.docs/qa/ota-master-serial-receive.md
+++ b/.docs/qa/ota-master-serial-receive.md
@@ -125,3 +125,97 @@ I OtaReceiver: FW_DEPLOY_BEGIN: transferId=<id> target-count=<N> — all-FAILED 
   e.g., a CHUNK every 9 s indefinitely. Polling stays paused for the duration.
   The deadline-based watchdog will land alongside Phase 4 deploy/flash work where
   the abort semantics are decided together with disk-write timeouts.
+
+## Phase 4 — SD writer + streaming SHA-256
+
+### Preconditions
+
+- Master flashed with `feature/ota-phase4-sd-writer-sha256` (or `develop` once merged).
+- AstrOs.Server `develop` running, pointed at the master's serial port.
+- A known-good 1.2 MB `.bin`. Record its SHA-256 out-of-band:
+  `sha256sum firmware.bin` → save the hex digest.
+- SD card present, FAT-formatted, with at least ~5 MB free (well above the
+  1.2 MB pre-check threshold). The receiver auto-creates `/sdcard/firmware/`
+  on the first BEGIN.
+
+### Happy-path steps
+
+1. From the AstrOs.Server Firmware view, upload the recorded `.bin`.
+2. Click `Send to master`.
+3. After the UI reports "transfer complete", power down the master and pull
+   the SD card.
+4. On the host: `ls /sdcard/firmware/` and `sha256sum
+   /sdcard/firmware/<sha-prefix>.bin`.
+
+### Expected results
+
+- Master serial log (timestamps and exact values will differ):
+
+```
+I OtaReceiver: FW_TRANSFER_BEGIN accepted: transferId=<id> totalSize=1228800 chunks=300 sha=<full-hex>
+I OtaReceiver: FW_TRANSFER_END OK: transferId=<id> totalChunks=300 path=/sdcard/firmware/<sha-prefix>.bin sha=<full-hex>
+I OtaReceiver: FW_DEPLOY_BEGIN: transferId=<id> target-count=<N> — all-FAILED not_implemented
+```
+
+- The END_ACK now carries the **locally computed** hash, not the server's echo.
+  The server compares it to its own digest and reports OK if they match.
+- SD inspection:
+  - `staging.bin` is **absent** (renamed on success).
+  - A single file named `<first-16-hex-chars-of-sha>.bin` exists.
+  - `sha256sum` of that file matches the value recorded in step 0 byte-for-byte.
+- No `OTA Receiver Stack HWM:` warning (would mean the 4 KB task stack is
+  too small after adding the on-stack `mbedtls_sha256_context`; bump to 5120
+  if it fires).
+
+### Negative path 6 — Watchdog discards staging.bin on stuck transfer
+
+**Preconditions:** A transfer is in flight (BEGIN ACK received, chunks streaming),
+SD card contains an in-progress `staging.bin`.
+
+**Steps:**
+1. Pull the serial cable mid-transfer.
+2. Wait ≥10 s for the idle watchdog to fire (visible in logs as
+   `OTA watchdog fired: transferId=<id> idle >10000ms — aborting transfer`).
+3. Reattach the serial cable.
+4. From the server, upload again with a different `.bin`.
+
+**Expected:**
+- After step 2, the watchdog log line appears and the receiver returns to idle
+  (`isActive()` becomes false). Note: confirming `staging.bin` is absent here
+  requires removing the SD card, which interrupts the test — defer the on-disk
+  check to step 5 below if needed.
+- The second BEGIN in step 4 is accepted cleanly (no `busy` reject).
+- The second transfer completes with its own `<sha-prefix>.bin` on the SD card.
+
+**Pass/Fail:** Pass if (a) the watchdog log fires within ~11 s, (b) the second
+upload completes OK, and (c) the SD card eventually shows only the **second**
+firmware's `<sha-prefix>.bin` (no leftover from the first attempt — the
+watchdog's `keepStaging=false` policy removes it).
+
+### Negative path 7 — Same-firmware re-upload is idempotent
+
+**Preconditions:** A successful Phase 4 transfer has already landed
+`/sdcard/firmware/<sha-prefix>.bin` on the card.
+
+**Steps:**
+1. Without changing the `.bin`, upload it again from the server.
+
+**Expected:**
+- BEGIN_ACK OK, normal chunk flow, END_ACK OK with the same computed hash.
+- On the SD card after success: still exactly one `<sha-prefix>.bin` with the
+  same name and same contents. The `unlink` before `rename` makes the
+  same-path-target case work; no `staging.bin` left behind.
+
+**Pass/Fail:** Pass if the second upload completes cleanly and the SD card
+state is unchanged.
+
+### Out of scope for Phase 4 (deferred to Phase 5)
+
+- Server-side wrong-hash injection (synthetic HASH_MISMATCH) — verifies the
+  forensic-preserve path leaves `staging.bin` on disk.
+- Pre-filled SD card to force `sd_full` — verifies the BEGIN free-space gate.
+- Mid-transfer CRC injection persisting across retries — verifies the
+  receiver still completes after server-side retransmits.
+- 5-min whole-transfer wall-clock deadline. The Phase 3 idle watchdog covers
+  the dominant failure mode; the deadline backstop will be evaluated against
+  measured throughput before being built.

--- a/.docs/qa/ota-master-serial-receive.md
+++ b/.docs/qa/ota-master-serial-receive.md
@@ -209,10 +209,41 @@ watchdog's `keepStaging=false` policy removes it).
 **Pass/Fail:** Pass if the second upload completes cleanly and the SD card
 state is unchanged.
 
+### Negative path 8 — HASH_MISMATCH preserves staging.bin
+
+**Preconditions:** Master idle, SD card empty of any prior `/sdcard/firmware/`
+contents.
+
+**Steps:**
+1. From the server, drive a transfer with a deliberately wrong END hash. The
+   simplest path is a server-side debug toggle that flips one byte of
+   `finalSha256Hex` in the `FW_TRANSFER_END` frame before sending; if the
+   toggle doesn't exist yet, hand-craft the frame from a serial console
+   after recording the real chunk stream.
+2. Watch the master serial log.
+3. Power the master down, pull the SD card.
+
+**Expected:**
+- Master serial log includes a single LOGW like
+  `FW_TRANSFER_END HASH_MISMATCH: transferId=<id> computed=<a> expected=<b> — staging.bin preserved`.
+- `FW_TRANSFER_END_ACK status=HASH_MISMATCH computedHex=<a>` reaches the
+  server.
+- SD inspection:
+  - `/sdcard/firmware/staging.bin` is **present** and its size equals
+    `totalSize` from BEGIN.
+  - **No** `<computed-prefix>.bin` or `<expected-prefix>.bin` was created.
+- A subsequent BEGIN truncates `staging.bin` cleanly — verify by uploading
+  the real firmware next and confirming the rename to `<prefix>.bin`
+  succeeds and `staging.bin` is gone afterward.
+
+**Pass/Fail:** Pass if the HASH_MISMATCH log fires, `staging.bin` survives
+on disk, and no renamed file was created. This is the **only** path that
+exercises the forensic-preserve contract — a regression here (e.g., an
+errant `resetCryptoAndFile(false)` on the HASH_MISMATCH branch) would
+silently destroy evidence operators rely on for post-mortem investigation.
+
 ### Out of scope for Phase 4 (deferred to Phase 5)
 
-- Server-side wrong-hash injection (synthetic HASH_MISMATCH) — verifies the
-  forensic-preserve path leaves `staging.bin` on disk.
 - Pre-filled SD card to force `sd_full` — verifies the BEGIN free-space gate.
 - Mid-transfer CRC injection persisting across retries — verifies the
   receiver still completes after server-side retransmits.

--- a/lib/AstrOsStorageManager/include/AstrOsStorageManager.hpp
+++ b/lib/AstrOsStorageManager/include/AstrOsStorageManager.hpp
@@ -1,6 +1,7 @@
 #ifndef ASTROSSTORAGEMANAGER_HPP
 #define ASTROSSTORAGEMANAGER_HPP
 
+#include <cstdint>
 #include <esp_err.h>
 #include <esp_log.h>
 #include <string>
@@ -60,6 +61,11 @@ public:
     std::vector<std::string> listFiles(std::string folder);
 
     esp_err_t formatSdCard();
+
+    // OTA staging support. Both query the SD card; calling them when the card
+    // is unmounted returns the safe default (0 bytes free / false).
+    uint64_t freeSpaceSdBytes();
+    bool ensureSdFirmwareDir();
 };
 
 extern AstrOsStorageManager AstrOs_Storage;

--- a/lib/AstrOsStorageManager/include/AstrOsStorageManager.hpp
+++ b/lib/AstrOsStorageManager/include/AstrOsStorageManager.hpp
@@ -63,11 +63,8 @@ public:
 
     esp_err_t formatSdCard();
 
-    // OTA staging support. Both query the SD card.
-    // freeSpaceSdBytes returns nullopt when the card is unmounted or the
-    // FATFS query fails — callers must distinguish that from a legitimate 0
-    // (truly full card) and surface a different error to the operator.
-    // ensureSdFirmwareDir returns false on any non-EEXIST mkdir failure.
+    // nullopt distinguishes a probe failure (card unmounted, FATFS error)
+    // from a legitimate 0-bytes-free reading.
     std::optional<uint64_t> freeSpaceSdBytes();
     bool ensureSdFirmwareDir();
 };

--- a/lib/AstrOsStorageManager/include/AstrOsStorageManager.hpp
+++ b/lib/AstrOsStorageManager/include/AstrOsStorageManager.hpp
@@ -66,7 +66,11 @@ public:
     // nullopt distinguishes a probe failure (card unmounted, FATFS error)
     // from a legitimate 0-bytes-free reading.
     std::optional<uint64_t> freeSpaceSdBytes();
+#ifndef USE_SPIFFS
+    // OTA-only: hard-codes /sdcard/firmware. Absent from SPIFFS builds so
+    // callers fail to link rather than silently writing to the wrong volume.
     bool ensureSdFirmwareDir();
+#endif
 };
 
 extern AstrOsStorageManager AstrOs_Storage;

--- a/lib/AstrOsStorageManager/include/AstrOsStorageManager.hpp
+++ b/lib/AstrOsStorageManager/include/AstrOsStorageManager.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <esp_err.h>
 #include <esp_log.h>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -62,9 +63,12 @@ public:
 
     esp_err_t formatSdCard();
 
-    // OTA staging support. Both query the SD card; calling them when the card
-    // is unmounted returns the safe default (0 bytes free / false).
-    uint64_t freeSpaceSdBytes();
+    // OTA staging support. Both query the SD card.
+    // freeSpaceSdBytes returns nullopt when the card is unmounted or the
+    // FATFS query fails — callers must distinguish that from a legitimate 0
+    // (truly full card) and surface a different error to the operator.
+    // ensureSdFirmwareDir returns false on any non-EEXIST mkdir failure.
+    std::optional<uint64_t> freeSpaceSdBytes();
     bool ensureSdFirmwareDir();
 };
 

--- a/lib/AstrOsStorageManager/src/AstOsStorageManager.cpp
+++ b/lib/AstrOsStorageManager/src/AstOsStorageManager.cpp
@@ -548,22 +548,21 @@ esp_err_t AstrOsStorageManager::formatSdCard()
     return ESP_OK;
 }
 
-uint64_t AstrOsStorageManager::freeSpaceSdBytes()
+std::optional<uint64_t> AstrOsStorageManager::freeSpaceSdBytes()
 {
     if (card == nullptr)
     {
-        ESP_LOGW(TAG, "freeSpaceSdBytes: card not mounted, returning 0");
-        return 0;
+        ESP_LOGE(TAG, "freeSpaceSdBytes: card not mounted");
+        return std::nullopt;
     }
     FATFS *fs = nullptr;
     DWORD freeClusters = 0;
-    // "0:" is the same drive prefix f_mkfs uses above; the FATFS layer keys
-    // off the mount point we passed to esp_vfs_fat_sdspi_mount.
+    // "0:" is the FATFS drive prefix matching the esp_vfs_fat_sdspi_mount call.
     FRESULT res = f_getfree("0:", &freeClusters, &fs);
     if (res != FR_OK || fs == nullptr)
     {
-        ESP_LOGW(TAG, "freeSpaceSdBytes: f_getfree failed (res=%d)", res);
-        return 0;
+        ESP_LOGE(TAG, "freeSpaceSdBytes: f_getfree failed (res=%d)", res);
+        return std::nullopt;
     }
     return static_cast<uint64_t>(freeClusters) * fs->csize * card->csd.sector_size;
 }

--- a/lib/AstrOsStorageManager/src/AstOsStorageManager.cpp
+++ b/lib/AstrOsStorageManager/src/AstOsStorageManager.cpp
@@ -567,9 +567,14 @@ std::optional<uint64_t> AstrOsStorageManager::freeSpaceSdBytes()
     return static_cast<uint64_t>(freeClusters) * fs->csize * card->csd.sector_size;
 }
 
+#ifndef USE_SPIFFS
 bool AstrOsStorageManager::ensureSdFirmwareDir()
 {
-    const char *path = MOUNT_POINT "/firmware";
+    // Hard-coded /sdcard to match the rest of the OTA path constants
+    // (AstrOsPathUtils::FIRMWARE_DIR, kStagingPath). MOUNT_POINT is "/sdcard"
+    // in this build by construction of the #ifndef, so don't dress it up as
+    // portable when it isn't.
+    const char *path = "/sdcard/firmware";
     if (mkdir(path, 0775) == 0 || errno == EEXIST)
     {
         return true;
@@ -577,6 +582,7 @@ bool AstrOsStorageManager::ensureSdFirmwareDir()
     ESP_LOGE(TAG, "ensureSdFirmwareDir: mkdir(%s) failed: errno=%d (%s)", path, errno, strerror(errno));
     return false;
 }
+#endif
 
 esp_err_t AstrOsStorageManager::mountSdCard()
 {

--- a/lib/AstrOsStorageManager/src/AstOsStorageManager.cpp
+++ b/lib/AstrOsStorageManager/src/AstOsStorageManager.cpp
@@ -548,6 +548,37 @@ esp_err_t AstrOsStorageManager::formatSdCard()
     return ESP_OK;
 }
 
+uint64_t AstrOsStorageManager::freeSpaceSdBytes()
+{
+    if (card == nullptr)
+    {
+        ESP_LOGW(TAG, "freeSpaceSdBytes: card not mounted, returning 0");
+        return 0;
+    }
+    FATFS *fs = nullptr;
+    DWORD freeClusters = 0;
+    // "0:" is the same drive prefix f_mkfs uses above; the FATFS layer keys
+    // off the mount point we passed to esp_vfs_fat_sdspi_mount.
+    FRESULT res = f_getfree("0:", &freeClusters, &fs);
+    if (res != FR_OK || fs == nullptr)
+    {
+        ESP_LOGW(TAG, "freeSpaceSdBytes: f_getfree failed (res=%d)", res);
+        return 0;
+    }
+    return static_cast<uint64_t>(freeClusters) * fs->csize * card->csd.sector_size;
+}
+
+bool AstrOsStorageManager::ensureSdFirmwareDir()
+{
+    const char *path = MOUNT_POINT "/firmware";
+    if (mkdir(path, 0775) == 0 || errno == EEXIST)
+    {
+        return true;
+    }
+    ESP_LOGE(TAG, "ensureSdFirmwareDir: mkdir(%s) failed: errno=%d (%s)", path, errno, strerror(errno));
+    return false;
+}
+
 esp_err_t AstrOsStorageManager::mountSdCard()
 {
     esp_err_t err;

--- a/lib/OtaReceiver/README
+++ b/lib/OtaReceiver/README
@@ -9,8 +9,9 @@ replies via AstrOs_SerialMsgHandler.
 Classification
 --------------
 
-MIXED — includes <freertos/...>, <esp_log.h>, and (when SD persistence
-lands) <mbedtls/sha256.h>. Does NOT compile under [env:test].
+MIXED — includes <freertos/...>, <esp_log.h>, and <mbedtls/sha256.h>
+(streaming hash for the SD-staging path). Does NOT compile under
+[env:test].
 
 Queue ownership invariants
 --------------------------

--- a/lib/OtaReceiver/include/OtaReceiver.hpp
+++ b/lib/OtaReceiver/include/OtaReceiver.hpp
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <cstdio>
 #include <string>
 
 // needed for QueueHandle_t, must be in this order
@@ -13,6 +14,7 @@
 #include <freertos/queue.h>
 
 #include <esp_timer.h>
+#include <mbedtls/sha256.h>
 
 // Threading: all members are accessed only from otaReceiverTask via
 // `process(...)`. The one exception is `active_` (see its declaration), which
@@ -42,6 +44,14 @@ private:
     esp_timer_handle_t watchdog_ = nullptr;
     QueueHandle_t otaQueue_ = nullptr;
     static constexpr uint64_t kWatchdogIdleUs = 10ULL * 1000ULL * 1000ULL; // 10 s
+
+    // Staging-file handle and streaming SHA-256 context. Both are live only
+    // between a successful BEGIN and the terminating END / abort. Every exit
+    // path routes through resetCryptoAndFile() so we never leak an open FILE*
+    // or an mbedtls_sha256_context into the next transfer.
+    FILE *staging_ = nullptr;
+    mbedtls_sha256_context shaCtx_;
+    bool shaActive_ = false;
 
 public:
     OtaReceiver();
@@ -82,6 +92,10 @@ private:
 
     // esp_timer callback indirection — arg is `this`.
     static void watchdogTimerCb(void *arg);
+
+    // Closes staging_ (unlinking unless keepStaging) and releases shaCtx_.
+    // Idempotent so callers don't need to track which fields are live.
+    void resetCryptoAndFile(bool keepStaging);
 };
 
 extern OtaReceiver AstrOs_OtaReceiver;

--- a/lib/OtaReceiver/src/OtaReceiver.cpp
+++ b/lib/OtaReceiver/src/OtaReceiver.cpp
@@ -421,11 +421,15 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
         // power loss after END_ACK OK would otherwise leave the renamed file
         // short. The hash itself was computed from cr.payload in handleChunk,
         // so it is independent of this flush.
-        bool closeOk = (staging_ != nullptr) && (fclose(staging_) == 0);
+        bool fileOpen = (staging_ != nullptr);
+        bool fcloseOk = fileOpen && (fclose(staging_) == 0);
         staging_ = nullptr;
 
         uint8_t digest[32];
-        bool hashOk = shaActive_ && (mbedtls_sha256_finish(&shaCtx_, digest) == 0);
+        // Capture the active flag before teardown so the diagnostic below can
+        // distinguish "never initialized" from "finish failed".
+        bool shaWasActive = shaActive_;
+        bool hashOk = shaWasActive && (mbedtls_sha256_finish(&shaCtx_, digest) == 0);
         if (shaActive_)
         {
             mbedtls_sha256_free(&shaCtx_);
@@ -441,10 +445,30 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
             AstrOsStringUtils::toHexLower(digest, sizeof(digest), computedHex);
         }
 
-        if (!closeOk || !hashOk)
+        if (!fcloseOk || !hashOk)
         {
-            ESP_LOGE(TAG, "FW_TRANSFER_END finalize failed (closeOk=%d hashOk=%d) — replying IO_ERROR", (int)closeOk,
-                     (int)hashOk);
+            // Split the diagnostic into the three distinct failure modes so
+            // an operator chasing the LOGE doesn't have to bisect three
+            // possible causes at once.
+            if (!fileOpen)
+            {
+                ESP_LOGE(TAG, "FW_TRANSFER_END finalize: staging_ was null (BEGIN/chunk-handler bug)");
+            }
+            else if (!fcloseOk)
+            {
+                ESP_LOGE(TAG, "FW_TRANSFER_END finalize: fclose failed errno=%d (%s)", errno, strerror(errno));
+            }
+            if (!hashOk)
+            {
+                if (!shaWasActive)
+                {
+                    ESP_LOGE(TAG, "FW_TRANSFER_END finalize: SHA context was never initialized (BEGIN bug)");
+                }
+                else
+                {
+                    ESP_LOGE(TAG, "FW_TRANSFER_END finalize: mbedtls_sha256_finish returned error");
+                }
+            }
             // Keep staging.bin so a follow-up can inspect what was written.
             AstrOs_SerialMsgHandler.sendFwTransferEndAck(msgId, transferIdIn, "IO_ERROR", computedHex);
         }

--- a/lib/OtaReceiver/src/OtaReceiver.cpp
+++ b/lib/OtaReceiver/src/OtaReceiver.cpp
@@ -31,8 +31,7 @@ OtaReceiver::~OtaReceiver()
         esp_timer_delete(watchdog_);
         watchdog_ = nullptr;
     }
-    // Shutdown is not a transfer outcome — preserve any in-flight staging.bin
-    // for the next boot rather than deleting it.
+    // Shutdown isn't a transfer outcome — keep any in-flight staging.bin.
     resetCryptoAndFile(/*keepStaging=*/true);
 }
 
@@ -123,18 +122,15 @@ void OtaReceiver::resetCryptoAndFile(bool keepStaging)
     {
         if (fclose(staging_) != 0)
         {
-            // On keepStaging=true (HASH_MISMATCH, dtor, server-bug teardown), a
-            // failed fclose can leave buffered bytes off-disk, so the
-            // "preserved" file an operator opens later may be short. Surfacing
-            // this turns a silent corruption into a grepable LOGE.
+            // Buffered bytes may not have reached disk; a preserved file
+            // could be short.
             ESP_LOGE(TAG, "fclose(staging_) failed: errno=%d (%s) — preserved file may be truncated", errno,
                      strerror(errno));
         }
         staging_ = nullptr;
         if (!keepStaging)
         {
-            // unlink may fail if the file was already renamed (END OK path);
-            // ignore — the goal is to leave the path absent.
+            // Best-effort — may already be absent if rename succeeded.
             unlink(kStagingPath);
         }
     }
@@ -185,13 +181,12 @@ void OtaReceiver::handleWatchdogFire()
     ESP_LOGW(TAG, "OTA watchdog fired: transferId=%s idle >%llums — aborting transfer", transferIdStr_.c_str(),
              kWatchdogIdleUs / 1000ULL);
     bulk_.reset();
-    // No END means no hash check — unlike HASH_MISMATCH (which preserves for
-    // forensics), discard the unverified bytes.
+    // No END means no hash check — discard the unverified bytes (HASH_MISMATCH
+    // is the path that preserves).
     resetCryptoAndFile(/*keepStaging=*/false);
     active_ = false;
     transferIdStr_.clear();
-    // No server notification — chunk_streamer has its own timeout. The
-    // master's job is to be ready for the next BEGIN.
+    // No server notification; the sender times out independently.
 }
 
 void OtaReceiver::handleBegin(queue_ota_msg_t &msg)
@@ -417,10 +412,9 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
 
     if (er.status == AstrOsBulkTransport::EndResult::Status::OK)
     {
-        // Close before rename so any stdio-buffered bytes hit disk first; a
-        // power loss after END_ACK OK would otherwise leave the renamed file
-        // short. The hash itself was computed from cr.payload in handleChunk,
-        // so it is independent of this flush.
+        // Close before rename so stdio-buffered bytes hit disk; a power loss
+        // after END_ACK OK would otherwise truncate the renamed file. The hash
+        // was fed from chunk payloads, independent of this flush.
         bool fileOpen = (staging_ != nullptr);
         bool fcloseOk = fileOpen && (fclose(staging_) == 0);
         staging_ = nullptr;
@@ -437,8 +431,7 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
         }
 
         // Encode whenever the SHA succeeded — a fclose-only failure can still
-        // report the digest of bytes we actually processed, which is more
-        // useful to the server than an empty string.
+        // report the digest of bytes we processed.
         char computedHex[SHA256_HEX_LEN + 1] = {0};
         if (hashOk)
         {
@@ -447,9 +440,6 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
 
         if (!fcloseOk || !hashOk)
         {
-            // Split the diagnostic into the three distinct failure modes so
-            // an operator chasing the LOGE doesn't have to bisect three
-            // possible causes at once.
             if (!fileOpen)
             {
                 ESP_LOGE(TAG, "FW_TRANSFER_END finalize: staging_ was null (BEGIN/chunk-handler bug)");
@@ -486,16 +476,14 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
             }
             else if (strcmp(computedHex, expectedHex) == 0)
             {
-                // unlink-then-rename — FAT rename onto an existing path can fail.
-                // Track whether unlink actually removed a stale file. If rename
-                // later fails, knowing we destroyed prior good firmware is the
-                // difference between "no-op retry" and "operator lost a file".
+                // unlink-then-rename — FAT rename onto an existing path can
+                // fail. `removedPrior` lets the rename-failure branch below
+                // distinguish "no-op retry" from "operator lost a file".
                 int unlinkRc = unlink(finalPath);
                 bool removedPrior = (unlinkRc == 0);
                 if (unlinkRc != 0 && errno != ENOENT)
                 {
-                    // Non-ENOENT failure — log the real first error before the
-                    // rename overwrites errno.
+                    // Capture errno before rename clobbers it.
                     ESP_LOGW(TAG, "pre-rename unlink(%s) failed: errno=%d (%s)", finalPath, errno, strerror(errno));
                 }
                 if (rename(kStagingPath, finalPath) == 0)
@@ -509,8 +497,6 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
                     int renameErrno = errno;
                     if (removedPrior)
                     {
-                        // Worst case: stale firmware was the only valid copy
-                        // and we just deleted it without replacing it.
                         ESP_LOGE(
                             TAG,
                             "FW_TRANSFER_END: rename failed after removing prior %s — operator lost prior firmware",
@@ -581,8 +567,8 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
         transferIdStr_.clear();
         bulk_.reset();
         watchdogStop();
-        // Idempotent — preserve staging.bin for forensics; the OK path
-        // already renamed it away.
+        // Keep staging.bin so HASH_MISMATCH preserves the artifact; the OK
+        // path's rename has already moved it out of the way.
         resetCryptoAndFile(/*keepStaging=*/true);
     }
 }

--- a/lib/OtaReceiver/src/OtaReceiver.cpp
+++ b/lib/OtaReceiver/src/OtaReceiver.cpp
@@ -184,7 +184,8 @@ void OtaReceiver::handleWatchdogFire()
     ESP_LOGW(TAG, "OTA watchdog fired: transferId=%s idle >%llums — aborting transfer", transferIdStr_.c_str(),
              kWatchdogIdleUs / 1000ULL);
     bulk_.reset();
-    // No END means no hash check; discard the unverified bytes.
+    // No END means no hash check — unlike HASH_MISMATCH (which preserves for
+    // forensics), discard the unverified bytes.
     resetCryptoAndFile(/*keepStaging=*/false);
     active_ = false;
     transferIdStr_.clear();
@@ -430,29 +431,39 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
             shaActive_ = false;
         }
 
+        // Encode whenever the SHA succeeded — a fclose-only failure can still
+        // report the digest of bytes we actually processed, which is more
+        // useful to the server than an empty string.
+        char computedHex[SHA256_HEX_LEN + 1] = {0};
+        if (hashOk)
+        {
+            AstrOsStringUtils::toHexLower(digest, sizeof(digest), computedHex);
+        }
+
         if (!closeOk || !hashOk)
         {
             ESP_LOGE(TAG, "FW_TRANSFER_END finalize failed (closeOk=%d hashOk=%d) — replying IO_ERROR", (int)closeOk,
                      (int)hashOk);
             // Keep staging.bin so a follow-up can inspect what was written.
-            AstrOs_SerialMsgHandler.sendFwTransferEndAck(msgId, transferIdIn, "IO_ERROR", "");
+            AstrOs_SerialMsgHandler.sendFwTransferEndAck(msgId, transferIdIn, "IO_ERROR", computedHex);
         }
         else
         {
-            char computedHex[SHA256_HEX_LEN + 1];
-            AstrOsStringUtils::toHexLower(digest, sizeof(digest), computedHex);
-
             const char *expectedHex = msg.end.finalSha256Hex;
             if (strcmp(computedHex, expectedHex) == 0)
             {
                 // unlink-then-rename — FAT rename onto an existing path can fail.
                 char finalPath[64];
                 snprintf(finalPath, sizeof(finalPath), "/sdcard/firmware/%.16s.bin", computedHex);
-                if (unlink(finalPath) != 0 && errno != ENOENT)
+                // Track whether unlink actually removed a stale file. If rename
+                // later fails, knowing we destroyed prior good firmware is the
+                // difference between "no-op retry" and "operator lost a file".
+                int unlinkRc = unlink(finalPath);
+                bool removedPrior = (unlinkRc == 0);
+                if (unlinkRc != 0 && errno != ENOENT)
                 {
-                    // Anything other than "not present" means rename is likely
-                    // to fail too; log the real first error before the rename
-                    // overwrites errno.
+                    // Non-ENOENT failure — log the real first error before the
+                    // rename overwrites errno.
                     ESP_LOGW(TAG, "pre-rename unlink(%s) failed: errno=%d (%s)", finalPath, errno, strerror(errno));
                 }
                 if (rename(kStagingPath, finalPath) == 0)
@@ -463,10 +474,18 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
                 }
                 else
                 {
-                    // Verified bytes are on disk; leave staging.bin in place
-                    // and report IO_ERROR.
+                    int renameErrno = errno;
+                    if (removedPrior)
+                    {
+                        // Worst case: stale firmware was the only valid copy
+                        // and we just deleted it without replacing it.
+                        ESP_LOGE(
+                            TAG,
+                            "FW_TRANSFER_END: rename failed after removing prior %s — operator lost prior firmware",
+                            finalPath);
+                    }
                     ESP_LOGE(TAG, "FW_TRANSFER_END: rename(%s -> %s) failed: errno=%d (%s)", kStagingPath, finalPath,
-                             errno, strerror(errno));
+                             renameErrno, strerror(renameErrno));
                     AstrOs_SerialMsgHandler.sendFwTransferEndAck(msgId, transferIdIn, "IO_ERROR", computedHex);
                 }
             }

--- a/lib/OtaReceiver/src/OtaReceiver.cpp
+++ b/lib/OtaReceiver/src/OtaReceiver.cpp
@@ -6,6 +6,7 @@
 #include <AstrOsStringUtils.hpp>
 #include <esp_log.h>
 
+#include <cerrno>
 #include <cstdio>
 #include <cstring>
 #include <unistd.h>
@@ -415,8 +416,22 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
         // Close before rename so stdio-buffered bytes hit disk; a power loss
         // after END_ACK OK would otherwise truncate the renamed file. The hash
         // was fed from chunk payloads, independent of this flush.
+        // Capture errno at the fclose call site — mbedtls finish/free below
+        // could clobber it before the diagnostic log runs.
         bool fileOpen = (staging_ != nullptr);
-        bool fcloseOk = fileOpen && (fclose(staging_) == 0);
+        bool fcloseOk = false;
+        int fcloseErrno = 0;
+        if (fileOpen)
+        {
+            if (fclose(staging_) == 0)
+            {
+                fcloseOk = true;
+            }
+            else
+            {
+                fcloseErrno = errno;
+            }
+        }
         staging_ = nullptr;
 
         uint8_t digest[32];
@@ -446,7 +461,8 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
             }
             else if (!fcloseOk)
             {
-                ESP_LOGE(TAG, "FW_TRANSFER_END finalize: fclose failed errno=%d (%s)", errno, strerror(errno));
+                ESP_LOGE(TAG, "FW_TRANSFER_END finalize: fclose failed errno=%d (%s)", fcloseErrno,
+                         strerror(fcloseErrno));
             }
             if (!hashOk)
             {

--- a/lib/OtaReceiver/src/OtaReceiver.cpp
+++ b/lib/OtaReceiver/src/OtaReceiver.cpp
@@ -9,6 +9,7 @@
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
+#include <sys/stat.h>
 #include <unistd.h>
 
 static const char *TAG = "OtaReceiver";
@@ -244,10 +245,22 @@ void OtaReceiver::handleBegin(queue_ota_msg_t &msg)
         AstrOs_SerialMsgHandler.sendFwTransferBeginAck(msgId, transferIdIn, "io_error");
         return;
     }
-    if (*freeBytes < msg.begin.totalSize)
+
+    // A prior HASH_MISMATCH (or finalize IO_ERROR) leaves staging.bin on disk
+    // for forensics. The fopen("wb") below truncates it before any new bytes
+    // land, so its current clusters return to the free pool — count them as
+    // available so we don't falsely reject a same-size re-upload as sd_full.
+    uint64_t reclaimableStaging = 0;
+    struct stat existingStaging;
+    if (stat(kStagingPath, &existingStaging) == 0 && S_ISREG(existingStaging.st_mode))
     {
-        ESP_LOGW(TAG, "FW_TRANSFER_BEGIN: sd_full (free=%llu need=%u)", (unsigned long long)*freeBytes,
-                 (unsigned)msg.begin.totalSize);
+        reclaimableStaging = static_cast<uint64_t>(existingStaging.st_size);
+    }
+    uint64_t availableBytes = *freeBytes + reclaimableStaging;
+    if (availableBytes < msg.begin.totalSize)
+    {
+        ESP_LOGW(TAG, "FW_TRANSFER_BEGIN: sd_full (free=%llu reclaim=%llu need=%u)", (unsigned long long)*freeBytes,
+                 (unsigned long long)reclaimableStaging, (unsigned)msg.begin.totalSize);
         bulk_.reset();
         AstrOs_SerialMsgHandler.sendFwTransferBeginAck(msgId, transferIdIn, "sd_full");
         return;
@@ -584,9 +597,15 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
         transferIdStr_.clear();
         bulk_.reset();
         watchdogStop();
-        // Keep staging.bin so HASH_MISMATCH preserves the artifact; the OK
-        // path's rename has already moved it out of the way.
-        resetCryptoAndFile(/*keepStaging=*/true);
+        // Discard unverified bytes. The OK status branch already nulled
+        // staging_ after fclose, so the forensic-preserve cases
+        // (HASH_MISMATCH, post-verify rename failure, finalize IO_ERROR)
+        // skip the unlink inside resetCryptoAndFile and leave staging.bin
+        // intact for inspection. Only the non-OK teardown reasons
+        // (SENDER_TOTAL_MISMATCH, RECEIVER_SHORT_COUNT) still hold an open
+        // staging_ here — those are the "other aborts" the PR description
+        // promises to discard, alongside the watchdog path.
+        resetCryptoAndFile(/*keepStaging=*/false);
     }
 }
 

--- a/lib/OtaReceiver/src/OtaReceiver.cpp
+++ b/lib/OtaReceiver/src/OtaReceiver.cpp
@@ -1,5 +1,6 @@
 #include <OtaReceiver.hpp>
 
+#include <AstrOsPathUtils.hpp>
 #include <AstrOsSerialMsgHandler.hpp>
 #include <AstrOsStorageManager.hpp>
 #include <AstrOsStringUtils.hpp>
@@ -450,11 +451,18 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
         else
         {
             const char *expectedHex = msg.end.finalSha256Hex;
-            if (strcmp(computedHex, expectedHex) == 0)
+            char finalPath[AstrOsPathUtils::FIRMWARE_PATH_BUF_LEN];
+            bool pathOk = AstrOsPathUtils::contentAddressedFirmwarePath(computedHex, finalPath, sizeof(finalPath));
+            if (!pathOk)
+            {
+                // Computed hex came from mbedtls_sha256_finish on 32 bytes, so
+                // it's always 64 chars — this branch should be unreachable.
+                ESP_LOGE(TAG, "contentAddressedFirmwarePath failed for computed=%s — replying IO_ERROR", computedHex);
+                AstrOs_SerialMsgHandler.sendFwTransferEndAck(msgId, transferIdIn, "IO_ERROR", computedHex);
+            }
+            else if (strcmp(computedHex, expectedHex) == 0)
             {
                 // unlink-then-rename — FAT rename onto an existing path can fail.
-                char finalPath[64];
-                snprintf(finalPath, sizeof(finalPath), "/sdcard/firmware/%.16s.bin", computedHex);
                 // Track whether unlink actually removed a stale file. If rename
                 // later fails, knowing we destroyed prior good firmware is the
                 // difference between "no-op retry" and "operator lost a file".

--- a/lib/OtaReceiver/src/OtaReceiver.cpp
+++ b/lib/OtaReceiver/src/OtaReceiver.cpp
@@ -15,7 +15,7 @@ static const char *TAG = "OtaReceiver";
 
 namespace
 {
-    constexpr const char *kStagingPath = "/sdcard/firmware/staging.bin";
+    constexpr const char *kStagingPath = AstrOsPathUtils::FIRMWARE_STAGING_PATH;
 } // namespace
 
 OtaReceiver AstrOs_OtaReceiver;

--- a/lib/OtaReceiver/src/OtaReceiver.cpp
+++ b/lib/OtaReceiver/src/OtaReceiver.cpp
@@ -123,10 +123,11 @@ void OtaReceiver::resetCryptoAndFile(bool keepStaging)
     {
         if (fclose(staging_) != 0)
         {
-            // Buffered bytes may not have reached disk; a preserved file
-            // could be short.
-            ESP_LOGE(TAG, "fclose(staging_) failed: errno=%d (%s) — preserved file may be truncated", errno,
-                     strerror(errno));
+            // Capture errno before strerror or any other libc call can clobber it.
+            // Buffered bytes may not have reached disk; a preserved file could be short.
+            const int closeErrno = errno;
+            ESP_LOGE(TAG, "fclose(staging_) failed: errno=%d (%s) — preserved file may be truncated", closeErrno,
+                     strerror(closeErrno));
         }
         staging_ = nullptr;
         if (!keepStaging)

--- a/lib/OtaReceiver/src/OtaReceiver.cpp
+++ b/lib/OtaReceiver/src/OtaReceiver.cpp
@@ -13,19 +13,6 @@ static const char *TAG = "OtaReceiver";
 
 namespace
 {
-    // Lowercase-hex encoding of `len` bytes from `in` into `out`. `out` must
-    // hold at least 2*len + 1 chars; this writes the NUL.
-    void toHexLower(const uint8_t *in, size_t len, char *out)
-    {
-        static const char kHex[] = "0123456789abcdef";
-        for (size_t i = 0; i < len; ++i)
-        {
-            out[2 * i] = kHex[(in[i] >> 4) & 0x0F];
-            out[2 * i + 1] = kHex[in[i] & 0x0F];
-        }
-        out[2 * len] = '\0';
-    }
-
     constexpr const char *kStagingPath = "/sdcard/firmware/staging.bin";
 } // namespace
 
@@ -133,7 +120,15 @@ void OtaReceiver::resetCryptoAndFile(bool keepStaging)
 {
     if (staging_ != nullptr)
     {
-        fclose(staging_);
+        if (fclose(staging_) != 0)
+        {
+            // On keepStaging=true (HASH_MISMATCH, dtor, server-bug teardown), a
+            // failed fclose can leave buffered bytes off-disk, so the
+            // "preserved" file an operator opens later may be short. Surfacing
+            // this turns a silent corruption into a grepable LOGE.
+            ESP_LOGE(TAG, "fclose(staging_) failed: errno=%d (%s) — preserved file may be truncated", errno,
+                     strerror(errno));
+        }
         staging_ = nullptr;
         if (!keepStaging)
         {
@@ -189,9 +184,7 @@ void OtaReceiver::handleWatchdogFire()
     ESP_LOGW(TAG, "OTA watchdog fired: transferId=%s idle >%llums — aborting transfer", transferIdStr_.c_str(),
              kWatchdogIdleUs / 1000ULL);
     bulk_.reset();
-    // Unverified partial bytes — no END means no hash check, so discarding
-    // staging.bin is correct here (different policy from HASH_MISMATCH, which
-    // preserves for forensics).
+    // No END means no hash check; discard the unverified bytes.
     resetCryptoAndFile(/*keepStaging=*/false);
     active_ = false;
     transferIdStr_.clear();
@@ -206,7 +199,6 @@ void OtaReceiver::handleBegin(queue_ota_msg_t &msg)
 
     if (active_)
     {
-        // Don't touch staging_/shaCtx_ — they belong to the in-flight transfer.
         ESP_LOGW(TAG, "FW_TRANSFER_BEGIN while transfer %s active; replying busy", transferIdStr_.c_str());
         AstrOs_SerialMsgHandler.sendFwTransferBeginAck(msgId, transferIdIn, "busy");
         return;
@@ -235,9 +227,7 @@ void OtaReceiver::handleBegin(queue_ota_msg_t &msg)
         return;
     }
 
-    // SD-staging gate. Order matters: ensureSdFirmwareDir, then free-space
-    // pre-check, then open. Any failure must NOT mutate active_/transferIdStr_
-    // so a rejected BEGIN leaves the receiver exactly as it was.
+    // Rejected BEGIN must leave active_/transferIdStr_ untouched.
     if (!AstrOs_Storage.ensureSdFirmwareDir())
     {
         ESP_LOGE(TAG, "FW_TRANSFER_BEGIN: ensureSdFirmwareDir failed — replying io_error");
@@ -246,18 +236,25 @@ void OtaReceiver::handleBegin(queue_ota_msg_t &msg)
         return;
     }
 
-    uint64_t freeBytes = AstrOs_Storage.freeSpaceSdBytes();
-    if (freeBytes < msg.begin.totalSize)
+    auto freeBytes = AstrOs_Storage.freeSpaceSdBytes();
+    if (!freeBytes.has_value())
     {
-        ESP_LOGW(TAG, "FW_TRANSFER_BEGIN: sd_full (free=%llu need=%u)", (unsigned long long)freeBytes,
+        // Probe failure is an I/O fault; sd_full would mislead the operator.
+        ESP_LOGE(TAG, "FW_TRANSFER_BEGIN: freeSpaceSdBytes probe failed — replying io_error");
+        bulk_.reset();
+        AstrOs_SerialMsgHandler.sendFwTransferBeginAck(msgId, transferIdIn, "io_error");
+        return;
+    }
+    if (*freeBytes < msg.begin.totalSize)
+    {
+        ESP_LOGW(TAG, "FW_TRANSFER_BEGIN: sd_full (free=%llu need=%u)", (unsigned long long)*freeBytes,
                  (unsigned)msg.begin.totalSize);
         bulk_.reset();
         AstrOs_SerialMsgHandler.sendFwTransferBeginAck(msgId, transferIdIn, "sd_full");
         return;
     }
 
-    // "wb" truncates — a HASH_MISMATCH leftover from the prior transfer is
-    // replaced cleanly here without a separate "previous-transfer cleanup" step.
+    // "wb" truncates — cleans up any HASH_MISMATCH leftover from a prior transfer.
     staging_ = fopen(kStagingPath, "wb");
     if (staging_ == nullptr)
     {
@@ -315,14 +312,11 @@ void OtaReceiver::handleChunk(queue_ota_msg_t &msg)
 
     if (cr.decision == AstrOsBulkTransport::Decision::ACK)
     {
-        // Persist before ACK'ing. A short fwrite (full disk, fs error) means
-        // the byte stream we'd be ACK'ing is incomplete, so we NAK with
-        // FLASH_FULL and tear the transfer down — the server's next BEGIN
-        // truncates staging.bin and starts over.
+        // Persist before ACK — a short fwrite means the bytes we'd be
+        // acknowledging aren't on disk.
         if (staging_ == nullptr || !shaActive_)
         {
-            // Defensive: should be impossible if handleBegin succeeded. Treat
-            // as terminal so the next BEGIN can recover.
+            // Defensive — should be unreachable if BEGIN succeeded.
             ESP_LOGE(TAG, "handleChunk ACK but staging/sha not initialized — aborting transfer");
             AstrOs_SerialMsgHandler.sendFwChunkNak(transferIdIn, cr.highestContiguousSeq, cr.nextExpectedSeq,
                                                    "FLASH_FULL");
@@ -349,8 +343,8 @@ void OtaReceiver::handleChunk(queue_ota_msg_t &msg)
         }
         if (mbedtls_sha256_update(&shaCtx_, cr.payload, cr.payloadLen) != 0)
         {
-            // Hash failure is rare but unrecoverable — END would compare a
-            // corrupt digest and reply HASH_MISMATCH anyway. Fail fast.
+            // Update failure corrupts the digest; abort now rather than
+            // reporting HASH_MISMATCH at END.
             ESP_LOGE(TAG, "mbedtls_sha256_update failed — aborting transfer");
             AstrOs_SerialMsgHandler.sendFwChunkNak(transferIdIn, cr.highestContiguousSeq, cr.nextExpectedSeq,
                                                    "FLASH_FULL");
@@ -421,9 +415,10 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
 
     if (er.status == AstrOsBulkTransport::EndResult::Status::OK)
     {
-        // Drain stdio buffers before finishing the hash. Without this, bytes
-        // queued inside the FILE* would never reach disk and a power-loss
-        // immediately after END_ACK OK could leave the renamed file short.
+        // Close before rename so any stdio-buffered bytes hit disk first; a
+        // power loss after END_ACK OK would otherwise leave the renamed file
+        // short. The hash itself was computed from cr.payload in handleChunk,
+        // so it is independent of this flush.
         bool closeOk = (staging_ != nullptr) && (fclose(staging_) == 0);
         staging_ = nullptr;
 
@@ -445,19 +440,21 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
         else
         {
             char computedHex[SHA256_HEX_LEN + 1];
-            toHexLower(digest, sizeof(digest), computedHex);
+            AstrOsStringUtils::toHexLower(digest, sizeof(digest), computedHex);
 
             const char *expectedHex = msg.end.finalSha256Hex;
             if (strcmp(computedHex, expectedHex) == 0)
             {
-                // Content-addressed final name: 16-hex-char prefix is enough
-                // to disambiguate firmware images in practice and keeps the
-                // path short. unlink-then-rename tolerates same-firmware
-                // re-uploads (POSIX rename onto an existing path can fail on
-                // FAT).
+                // unlink-then-rename — FAT rename onto an existing path can fail.
                 char finalPath[64];
                 snprintf(finalPath, sizeof(finalPath), "/sdcard/firmware/%.16s.bin", computedHex);
-                unlink(finalPath);
+                if (unlink(finalPath) != 0 && errno != ENOENT)
+                {
+                    // Anything other than "not present" means rename is likely
+                    // to fail too; log the real first error before the rename
+                    // overwrites errno.
+                    ESP_LOGW(TAG, "pre-rename unlink(%s) failed: errno=%d (%s)", finalPath, errno, strerror(errno));
+                }
                 if (rename(kStagingPath, finalPath) == 0)
                 {
                     ESP_LOGI(TAG, "FW_TRANSFER_END OK: transferId=%s totalChunks=%u path=%s sha=%s",
@@ -466,9 +463,8 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
                 }
                 else
                 {
-                    // Verified bytes are on disk but couldn't be moved into
-                    // place. Leave staging.bin so a follow-up phase can still
-                    // consume them; signal the failure honestly.
+                    // Verified bytes are on disk; leave staging.bin in place
+                    // and report IO_ERROR.
                     ESP_LOGE(TAG, "FW_TRANSFER_END: rename(%s -> %s) failed: errno=%d (%s)", kStagingPath, finalPath,
                              errno, strerror(errno));
                     AstrOs_SerialMsgHandler.sendFwTransferEndAck(msgId, transferIdIn, "IO_ERROR", computedHex);
@@ -479,7 +475,7 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
                 ESP_LOGW(TAG,
                          "FW_TRANSFER_END HASH_MISMATCH: transferId=%s computed=%s expected=%s — staging.bin preserved",
                          transferIdIn.c_str(), computedHex, expectedHex);
-                // Forensic preservation per design — do NOT unlink staging.bin.
+                // Preserve staging.bin for post-mortem inspection.
                 AstrOs_SerialMsgHandler.sendFwTransferEndAck(msgId, transferIdIn, "HASH_MISMATCH", computedHex);
             }
         }
@@ -534,14 +530,8 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
         transferIdStr_.clear();
         bulk_.reset();
         watchdogStop();
-        // HASH_MISMATCH preserves staging.bin (handled inline above by not
-        // unlinking and leaving staging_ closed). Every other teardown path —
-        // RECEIVER_SHORT_COUNT, finalize-failure IO_ERROR, OK rename success
-        // — has already closed the FILE* but the helper is idempotent and
-        // also covers the case where the OK branch above didn't run (e.g.,
-        // server-state bugs reaching the IO_ERROR branch with staging_ still
-        // open). keepStaging=true is the conservative choice: forensic
-        // inspection beats silent deletion.
+        // Idempotent — preserve staging.bin for forensics; the OK path
+        // already renamed it away.
         resetCryptoAndFile(/*keepStaging=*/true);
     }
 }

--- a/lib/OtaReceiver/src/OtaReceiver.cpp
+++ b/lib/OtaReceiver/src/OtaReceiver.cpp
@@ -1,10 +1,33 @@
 #include <OtaReceiver.hpp>
 
 #include <AstrOsSerialMsgHandler.hpp>
+#include <AstrOsStorageManager.hpp>
 #include <AstrOsStringUtils.hpp>
 #include <esp_log.h>
 
+#include <cstdio>
+#include <cstring>
+#include <unistd.h>
+
 static const char *TAG = "OtaReceiver";
+
+namespace
+{
+    // Lowercase-hex encoding of `len` bytes from `in` into `out`. `out` must
+    // hold at least 2*len + 1 chars; this writes the NUL.
+    void toHexLower(const uint8_t *in, size_t len, char *out)
+    {
+        static const char kHex[] = "0123456789abcdef";
+        for (size_t i = 0; i < len; ++i)
+        {
+            out[2 * i] = kHex[(in[i] >> 4) & 0x0F];
+            out[2 * i + 1] = kHex[in[i] & 0x0F];
+        }
+        out[2 * len] = '\0';
+    }
+
+    constexpr const char *kStagingPath = "/sdcard/firmware/staging.bin";
+} // namespace
 
 OtaReceiver AstrOs_OtaReceiver;
 
@@ -20,6 +43,9 @@ OtaReceiver::~OtaReceiver()
         esp_timer_delete(watchdog_);
         watchdog_ = nullptr;
     }
+    // Shutdown is not a transfer outcome — preserve any in-flight staging.bin
+    // for the next boot rather than deleting it.
+    resetCryptoAndFile(/*keepStaging=*/true);
 }
 
 void OtaReceiver::Init(QueueHandle_t otaQueue)
@@ -103,6 +129,26 @@ void OtaReceiver::watchdogStop()
     esp_timer_stop(watchdog_);
 }
 
+void OtaReceiver::resetCryptoAndFile(bool keepStaging)
+{
+    if (staging_ != nullptr)
+    {
+        fclose(staging_);
+        staging_ = nullptr;
+        if (!keepStaging)
+        {
+            // unlink may fail if the file was already renamed (END OK path);
+            // ignore — the goal is to leave the path absent.
+            unlink(kStagingPath);
+        }
+    }
+    if (shaActive_)
+    {
+        mbedtls_sha256_free(&shaCtx_);
+        shaActive_ = false;
+    }
+}
+
 void OtaReceiver::process(queue_ota_msg_t &msg)
 {
     switch (msg.kind)
@@ -143,6 +189,10 @@ void OtaReceiver::handleWatchdogFire()
     ESP_LOGW(TAG, "OTA watchdog fired: transferId=%s idle >%llums — aborting transfer", transferIdStr_.c_str(),
              kWatchdogIdleUs / 1000ULL);
     bulk_.reset();
+    // Unverified partial bytes — no END means no hash check, so discarding
+    // staging.bin is correct here (different policy from HASH_MISMATCH, which
+    // preserves for forensics).
+    resetCryptoAndFile(/*keepStaging=*/false);
     active_ = false;
     transferIdStr_.clear();
     // No server notification — chunk_streamer has its own timeout. The
@@ -156,6 +206,7 @@ void OtaReceiver::handleBegin(queue_ota_msg_t &msg)
 
     if (active_)
     {
+        // Don't touch staging_/shaCtx_ — they belong to the in-flight transfer.
         ESP_LOGW(TAG, "FW_TRANSFER_BEGIN while transfer %s active; replying busy", transferIdStr_.c_str());
         AstrOs_SerialMsgHandler.sendFwTransferBeginAck(msgId, transferIdIn, "busy");
         return;
@@ -183,6 +234,52 @@ void OtaReceiver::handleBegin(queue_ota_msg_t &msg)
         AstrOs_SerialMsgHandler.sendFwTransferBeginAck(msgId, transferIdIn, "io_error");
         return;
     }
+
+    // SD-staging gate. Order matters: ensureSdFirmwareDir, then free-space
+    // pre-check, then open. Any failure must NOT mutate active_/transferIdStr_
+    // so a rejected BEGIN leaves the receiver exactly as it was.
+    if (!AstrOs_Storage.ensureSdFirmwareDir())
+    {
+        ESP_LOGE(TAG, "FW_TRANSFER_BEGIN: ensureSdFirmwareDir failed — replying io_error");
+        bulk_.reset();
+        AstrOs_SerialMsgHandler.sendFwTransferBeginAck(msgId, transferIdIn, "io_error");
+        return;
+    }
+
+    uint64_t freeBytes = AstrOs_Storage.freeSpaceSdBytes();
+    if (freeBytes < msg.begin.totalSize)
+    {
+        ESP_LOGW(TAG, "FW_TRANSFER_BEGIN: sd_full (free=%llu need=%u)", (unsigned long long)freeBytes,
+                 (unsigned)msg.begin.totalSize);
+        bulk_.reset();
+        AstrOs_SerialMsgHandler.sendFwTransferBeginAck(msgId, transferIdIn, "sd_full");
+        return;
+    }
+
+    // "wb" truncates — a HASH_MISMATCH leftover from the prior transfer is
+    // replaced cleanly here without a separate "previous-transfer cleanup" step.
+    staging_ = fopen(kStagingPath, "wb");
+    if (staging_ == nullptr)
+    {
+        ESP_LOGE(TAG, "FW_TRANSFER_BEGIN: fopen(%s) failed: errno=%d (%s)", kStagingPath, errno, strerror(errno));
+        bulk_.reset();
+        AstrOs_SerialMsgHandler.sendFwTransferBeginAck(msgId, transferIdIn, "io_error");
+        return;
+    }
+
+    mbedtls_sha256_init(&shaCtx_);
+    if (mbedtls_sha256_starts(&shaCtx_, /*is224=*/0) != 0)
+    {
+        ESP_LOGE(TAG, "FW_TRANSFER_BEGIN: mbedtls_sha256_starts failed");
+        mbedtls_sha256_free(&shaCtx_);
+        fclose(staging_);
+        staging_ = nullptr;
+        unlink(kStagingPath);
+        bulk_.reset();
+        AstrOs_SerialMsgHandler.sendFwTransferBeginAck(msgId, transferIdIn, "io_error");
+        return;
+    }
+    shaActive_ = true;
 
     active_ = true;
     transferIdStr_ = transferIdIn;
@@ -218,6 +315,52 @@ void OtaReceiver::handleChunk(queue_ota_msg_t &msg)
 
     if (cr.decision == AstrOsBulkTransport::Decision::ACK)
     {
+        // Persist before ACK'ing. A short fwrite (full disk, fs error) means
+        // the byte stream we'd be ACK'ing is incomplete, so we NAK with
+        // FLASH_FULL and tear the transfer down — the server's next BEGIN
+        // truncates staging.bin and starts over.
+        if (staging_ == nullptr || !shaActive_)
+        {
+            // Defensive: should be impossible if handleBegin succeeded. Treat
+            // as terminal so the next BEGIN can recover.
+            ESP_LOGE(TAG, "handleChunk ACK but staging/sha not initialized — aborting transfer");
+            AstrOs_SerialMsgHandler.sendFwChunkNak(transferIdIn, cr.highestContiguousSeq, cr.nextExpectedSeq,
+                                                   "FLASH_FULL");
+            resetCryptoAndFile(/*keepStaging=*/false);
+            bulk_.reset();
+            active_ = false;
+            transferIdStr_.clear();
+            watchdogStop();
+            return;
+        }
+        size_t wrote = fwrite(cr.payload, 1, cr.payloadLen, staging_);
+        if (wrote != cr.payloadLen)
+        {
+            ESP_LOGE(TAG, "fwrite short: wrote=%zu of %u (errno=%d %s) — aborting transfer", wrote,
+                     (unsigned)cr.payloadLen, errno, strerror(errno));
+            AstrOs_SerialMsgHandler.sendFwChunkNak(transferIdIn, cr.highestContiguousSeq, cr.nextExpectedSeq,
+                                                   "FLASH_FULL");
+            resetCryptoAndFile(/*keepStaging=*/false);
+            bulk_.reset();
+            active_ = false;
+            transferIdStr_.clear();
+            watchdogStop();
+            return;
+        }
+        if (mbedtls_sha256_update(&shaCtx_, cr.payload, cr.payloadLen) != 0)
+        {
+            // Hash failure is rare but unrecoverable — END would compare a
+            // corrupt digest and reply HASH_MISMATCH anyway. Fail fast.
+            ESP_LOGE(TAG, "mbedtls_sha256_update failed — aborting transfer");
+            AstrOs_SerialMsgHandler.sendFwChunkNak(transferIdIn, cr.highestContiguousSeq, cr.nextExpectedSeq,
+                                                   "FLASH_FULL");
+            resetCryptoAndFile(/*keepStaging=*/false);
+            bulk_.reset();
+            active_ = false;
+            transferIdStr_.clear();
+            watchdogStop();
+            return;
+        }
         AstrOs_SerialMsgHandler.sendFwChunkAck(transferIdIn, cr.highestContiguousSeq, cr.nextExpectedSeq,
                                                cr.windowRemaining);
     }
@@ -278,10 +421,68 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
 
     if (er.status == AstrOsBulkTransport::EndResult::Status::OK)
     {
-        // No local hash yet — echo the server's hash so its compare succeeds.
-        ESP_LOGI(TAG, "FW_TRANSFER_END OK: transferId=%s totalChunks=%u", transferIdIn.c_str(),
-                 (unsigned)msg.end.totalChunks);
-        AstrOs_SerialMsgHandler.sendFwTransferEndAck(msgId, transferIdIn, "OK", finalShaIn);
+        // Drain stdio buffers before finishing the hash. Without this, bytes
+        // queued inside the FILE* would never reach disk and a power-loss
+        // immediately after END_ACK OK could leave the renamed file short.
+        bool closeOk = (staging_ != nullptr) && (fclose(staging_) == 0);
+        staging_ = nullptr;
+
+        uint8_t digest[32];
+        bool hashOk = shaActive_ && (mbedtls_sha256_finish(&shaCtx_, digest) == 0);
+        if (shaActive_)
+        {
+            mbedtls_sha256_free(&shaCtx_);
+            shaActive_ = false;
+        }
+
+        if (!closeOk || !hashOk)
+        {
+            ESP_LOGE(TAG, "FW_TRANSFER_END finalize failed (closeOk=%d hashOk=%d) — replying IO_ERROR", (int)closeOk,
+                     (int)hashOk);
+            // Keep staging.bin so a follow-up can inspect what was written.
+            AstrOs_SerialMsgHandler.sendFwTransferEndAck(msgId, transferIdIn, "IO_ERROR", "");
+        }
+        else
+        {
+            char computedHex[SHA256_HEX_LEN + 1];
+            toHexLower(digest, sizeof(digest), computedHex);
+
+            const char *expectedHex = msg.end.finalSha256Hex;
+            if (strcmp(computedHex, expectedHex) == 0)
+            {
+                // Content-addressed final name: 16-hex-char prefix is enough
+                // to disambiguate firmware images in practice and keeps the
+                // path short. unlink-then-rename tolerates same-firmware
+                // re-uploads (POSIX rename onto an existing path can fail on
+                // FAT).
+                char finalPath[64];
+                snprintf(finalPath, sizeof(finalPath), "/sdcard/firmware/%.16s.bin", computedHex);
+                unlink(finalPath);
+                if (rename(kStagingPath, finalPath) == 0)
+                {
+                    ESP_LOGI(TAG, "FW_TRANSFER_END OK: transferId=%s totalChunks=%u path=%s sha=%s",
+                             transferIdIn.c_str(), (unsigned)msg.end.totalChunks, finalPath, computedHex);
+                    AstrOs_SerialMsgHandler.sendFwTransferEndAck(msgId, transferIdIn, "OK", computedHex);
+                }
+                else
+                {
+                    // Verified bytes are on disk but couldn't be moved into
+                    // place. Leave staging.bin so a follow-up phase can still
+                    // consume them; signal the failure honestly.
+                    ESP_LOGE(TAG, "FW_TRANSFER_END: rename(%s -> %s) failed: errno=%d (%s)", kStagingPath, finalPath,
+                             errno, strerror(errno));
+                    AstrOs_SerialMsgHandler.sendFwTransferEndAck(msgId, transferIdIn, "IO_ERROR", computedHex);
+                }
+            }
+            else
+            {
+                ESP_LOGW(TAG,
+                         "FW_TRANSFER_END HASH_MISMATCH: transferId=%s computed=%s expected=%s — staging.bin preserved",
+                         transferIdIn.c_str(), computedHex, expectedHex);
+                // Forensic preservation per design — do NOT unlink staging.bin.
+                AstrOs_SerialMsgHandler.sendFwTransferEndAck(msgId, transferIdIn, "HASH_MISMATCH", computedHex);
+            }
+        }
     }
     else
     {
@@ -333,6 +534,15 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
         transferIdStr_.clear();
         bulk_.reset();
         watchdogStop();
+        // HASH_MISMATCH preserves staging.bin (handled inline above by not
+        // unlinking and leaving staging_ closed). Every other teardown path —
+        // RECEIVER_SHORT_COUNT, finalize-failure IO_ERROR, OK rename success
+        // — has already closed the FILE* but the helper is idempotent and
+        // also covers the case where the OK branch above didn't run (e.g.,
+        // server-state bugs reaching the IO_ERROR branch with staging_ still
+        // open). keepStaging=true is the conservative choice: forensic
+        // inspection beats silent deletion.
+        resetCryptoAndFile(/*keepStaging=*/true);
     }
 }
 

--- a/lib_native/AstrOsUtility/include/AstrOsPathUtils.hpp
+++ b/lib_native/AstrOsUtility/include/AstrOsPathUtils.hpp
@@ -28,8 +28,8 @@ namespace AstrOsPathUtils
     //
     // Each verified firmware blob on SD is named after the first 16 hex chars
     // of its SHA-256 digest, under /sdcard/firmware/. The 16-char prefix has
-    // ~1 in 2^64 collision odds and keeps the resulting path well inside FAT
-    // 8.3 long-filename limits.
+    // ~1 in 2^64 collision odds and keeps the resulting path well within FAT
+    // filename/path length limits.
 
     // Number of hex characters from the digest used to name the file.
     constexpr std::size_t FIRMWARE_HASH_PREFIX_LEN = 16;

--- a/lib_native/AstrOsUtility/include/AstrOsPathUtils.hpp
+++ b/lib_native/AstrOsUtility/include/AstrOsPathUtils.hpp
@@ -23,4 +23,32 @@ namespace AstrOsPathUtils
     //
     // On success `reasonOut` is cleared.
     bool isPathSafe(const std::string &path, std::string &reasonOut);
+
+    // Content-addressed firmware path construction.
+    //
+    // Each verified firmware blob on SD is named after the first 16 hex chars
+    // of its SHA-256 digest, under /sdcard/firmware/. The 16-char prefix has
+    // ~1 in 2^64 collision odds and keeps the resulting path well inside FAT
+    // 8.3 long-filename limits.
+
+    // Number of hex characters from the digest used to name the file.
+    constexpr std::size_t FIRMWARE_HASH_PREFIX_LEN = 16;
+
+    // Directory under which all verified firmware blobs are stored.
+    constexpr const char *FIRMWARE_DIR = "/sdcard/firmware/";
+
+    // Minimum out-buffer size for contentAddressedFirmwarePath including NUL:
+    // strlen("/sdcard/firmware/") + FIRMWARE_HASH_PREFIX_LEN + strlen(".bin")
+    //   = 17 + 16 + 4 + 1 = 38.
+    constexpr std::size_t FIRMWARE_PATH_BUF_LEN = 38;
+
+    // Builds "/sdcard/firmware/<first-16-of-hashHex>.bin" into `out`.
+    // Returns true on success. Returns false if:
+    //   - `hashHex` is null or has fewer than FIRMWARE_HASH_PREFIX_LEN chars
+    //     before its terminating NUL
+    //   - `out` is null
+    //   - `outLen` is less than FIRMWARE_PATH_BUF_LEN
+    // On any failure where `out` and `outLen` are valid, `out[0]` is set to
+    // NUL so callers can treat the buffer as a safe empty C-string.
+    bool contentAddressedFirmwarePath(const char *hashHex, char *out, std::size_t outLen);
 } // namespace AstrOsPathUtils

--- a/lib_native/AstrOsUtility/include/AstrOsPathUtils.hpp
+++ b/lib_native/AstrOsUtility/include/AstrOsPathUtils.hpp
@@ -34,17 +34,16 @@ namespace AstrOsPathUtils
     // Number of hex characters from the digest used to name the file.
     constexpr std::size_t FIRMWARE_HASH_PREFIX_LEN = 16;
 
-// Single source of truth for the on-disk firmware tree. Defined as a macro
-// (not a constexpr) so the constants below can concatenate it with literal
-// adjacency — C++17 has no way to constexpr-join two const char*.
-#define ASTROS_FIRMWARE_DIR_LITERAL "/sdcard/firmware/"
+    // Firmware tree root — keep these literals in sync. Both must share the
+    // /sdcard/firmware/ prefix; the build won't catch drift between them, so
+    // any change to one requires the matching change to the other.
 
     // Directory under which all verified firmware blobs are stored.
-    constexpr const char *FIRMWARE_DIR = ASTROS_FIRMWARE_DIR_LITERAL;
+    constexpr const char *FIRMWARE_DIR = "/sdcard/firmware/";
 
     // In-progress OTA write target. Renamed to the content-addressed final
     // name on successful END+verify.
-    constexpr const char *FIRMWARE_STAGING_PATH = ASTROS_FIRMWARE_DIR_LITERAL "staging.bin";
+    constexpr const char *FIRMWARE_STAGING_PATH = "/sdcard/firmware/staging.bin";
 
     // Minimum out-buffer size for contentAddressedFirmwarePath including NUL:
     // strlen("/sdcard/firmware/") + FIRMWARE_HASH_PREFIX_LEN + strlen(".bin")

--- a/lib_native/AstrOsUtility/include/AstrOsPathUtils.hpp
+++ b/lib_native/AstrOsUtility/include/AstrOsPathUtils.hpp
@@ -45,10 +45,11 @@ namespace AstrOsPathUtils
     // name on successful END+verify.
     constexpr const char *FIRMWARE_STAGING_PATH = "/sdcard/firmware/staging.bin";
 
-    // Minimum out-buffer size for contentAddressedFirmwarePath including NUL:
-    // strlen("/sdcard/firmware/") + FIRMWARE_HASH_PREFIX_LEN + strlen(".bin")
-    //   = 17 + 16 + 4 + 1 = 38.
-    constexpr std::size_t FIRMWARE_PATH_BUF_LEN = 38;
+    // Minimum out-buffer size for contentAddressedFirmwarePath including NUL.
+    // Derived so any change to FIRMWARE_DIR or FIRMWARE_HASH_PREFIX_LEN is
+    // picked up automatically. sizeof(".bin") is 5 (4 chars + NUL).
+    constexpr std::size_t FIRMWARE_PATH_BUF_LEN =
+        std::char_traits<char>::length(FIRMWARE_DIR) + FIRMWARE_HASH_PREFIX_LEN + sizeof(".bin");
 
     // Builds "/sdcard/firmware/<first-16-of-hashHex>.bin" into `out`.
     // Returns true on success. Returns false if:

--- a/lib_native/AstrOsUtility/include/AstrOsPathUtils.hpp
+++ b/lib_native/AstrOsUtility/include/AstrOsPathUtils.hpp
@@ -34,8 +34,17 @@ namespace AstrOsPathUtils
     // Number of hex characters from the digest used to name the file.
     constexpr std::size_t FIRMWARE_HASH_PREFIX_LEN = 16;
 
+// Single source of truth for the on-disk firmware tree. Defined as a macro
+// (not a constexpr) so the constants below can concatenate it with literal
+// adjacency — C++17 has no way to constexpr-join two const char*.
+#define ASTROS_FIRMWARE_DIR_LITERAL "/sdcard/firmware/"
+
     // Directory under which all verified firmware blobs are stored.
-    constexpr const char *FIRMWARE_DIR = "/sdcard/firmware/";
+    constexpr const char *FIRMWARE_DIR = ASTROS_FIRMWARE_DIR_LITERAL;
+
+    // In-progress OTA write target. Renamed to the content-addressed final
+    // name on successful END+verify.
+    constexpr const char *FIRMWARE_STAGING_PATH = ASTROS_FIRMWARE_DIR_LITERAL "staging.bin";
 
     // Minimum out-buffer size for contentAddressedFirmwarePath including NUL:
     // strlen("/sdcard/firmware/") + FIRMWARE_HASH_PREFIX_LEN + strlen(".bin")

--- a/lib_native/AstrOsUtility/src/AstrOsPathUtils.cpp
+++ b/lib_native/AstrOsUtility/src/AstrOsPathUtils.cpp
@@ -1,9 +1,39 @@
 #include "AstrOsPathUtils.hpp"
 
+#include <cstdio>
 #include <string>
 
 namespace AstrOsPathUtils
 {
+    bool contentAddressedFirmwarePath(const char *hashHex, char *out, std::size_t outLen)
+    {
+        if (out != nullptr && outLen > 0)
+        {
+            out[0] = '\0';
+        }
+        if (out == nullptr || outLen < FIRMWARE_PATH_BUF_LEN || hashHex == nullptr)
+        {
+            return false;
+        }
+        // Need at least FIRMWARE_HASH_PREFIX_LEN chars before the NUL — a
+        // shorter input would let snprintf's "%.16s" silently truncate to
+        // whatever it found, producing names that don't reflect the digest.
+        for (std::size_t i = 0; i < FIRMWARE_HASH_PREFIX_LEN; ++i)
+        {
+            if (hashHex[i] == '\0')
+            {
+                return false;
+            }
+        }
+        int written = std::snprintf(out, outLen, "%s%.16s.bin", FIRMWARE_DIR, hashHex);
+        if (written <= 0 || static_cast<std::size_t>(written) >= outLen)
+        {
+            out[0] = '\0';
+            return false;
+        }
+        return true;
+    }
+
     bool isPathSafe(const std::string &path, std::string &reasonOut)
     {
         reasonOut.clear();

--- a/lib_native/AstrOsUtility/src/AstrOsPathUtils.cpp
+++ b/lib_native/AstrOsUtility/src/AstrOsPathUtils.cpp
@@ -16,8 +16,9 @@ namespace AstrOsPathUtils
             return false;
         }
         // Need at least FIRMWARE_HASH_PREFIX_LEN chars before the NUL — a
-        // shorter input would let snprintf's "%.16s" silently truncate to
-        // whatever it found, producing names that don't reflect the digest.
+        // shorter input would let snprintf's precision-clipped "%.*s" silently
+        // truncate to whatever it found, producing names that don't reflect
+        // the digest.
         for (std::size_t i = 0; i < FIRMWARE_HASH_PREFIX_LEN; ++i)
         {
             if (hashHex[i] == '\0')
@@ -25,7 +26,8 @@ namespace AstrOsPathUtils
                 return false;
             }
         }
-        int written = std::snprintf(out, outLen, "%s%.16s.bin", FIRMWARE_DIR, hashHex);
+        int written =
+            std::snprintf(out, outLen, "%s%.*s.bin", FIRMWARE_DIR, static_cast<int>(FIRMWARE_HASH_PREFIX_LEN), hashHex);
         if (written <= 0 || static_cast<std::size_t>(written) >= outLen)
         {
             out[0] = '\0';

--- a/lib_native/AstrOsUtility/src/AstrOsStringUtils.hpp
+++ b/lib_native/AstrOsUtility/src/AstrOsStringUtils.hpp
@@ -180,6 +180,10 @@ public:
     /// @brief Lowercase-hex encode `len` bytes from `in` into `out`. Writes
     ///        exactly `2*len + 1` chars including the trailing NUL; caller
     ///        owns the buffer and is responsible for sizing it.
+    /// @pre   `out != nullptr` (always — even `len == 0` writes a NUL).
+    /// @pre   `in != nullptr` when `len > 0` (`in` may be null only if `len == 0`).
+    ///        No defensive checks; violating these is undefined behavior. This
+    ///        is an internal utility — validate at the boundary, not here.
     static void toHexLower(const uint8_t *in, size_t len, char *out)
     {
         static const char kHex[] = "0123456789abcdef";

--- a/lib_native/AstrOsUtility/src/AstrOsStringUtils.hpp
+++ b/lib_native/AstrOsUtility/src/AstrOsStringUtils.hpp
@@ -177,6 +177,20 @@ public:
         return static_cast<uint8_t>(ul);
     }
 
+    /// @brief Lowercase-hex encode `len` bytes from `in` into `out`. Writes
+    ///        exactly `2*len + 1` chars including the trailing NUL; caller
+    ///        owns the buffer and is responsible for sizing it.
+    static void toHexLower(const uint8_t *in, size_t len, char *out)
+    {
+        static const char kHex[] = "0123456789abcdef";
+        for (size_t i = 0; i < len; ++i)
+        {
+            out[2 * i] = kHex[(in[i] >> 4) & 0x0F];
+            out[2 * i + 1] = kHex[in[i] & 0x0F];
+        }
+        out[2 * len] = '\0';
+    }
+
     template <typename... Args> static std::string stringFormat(const std::string &format, Args &&...args)
     {
         int size = std::snprintf(nullptr, 0, format.c_str(), std::forward<Args>(args)...);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -159,7 +159,7 @@ static void loadGpioConfig();
 static void initTimers(void);
 static void pollingTimerCallback(void *arg);
 static void maintenanceTimerCallback(void *arg);
-static void servoMoveTimerCallback(void *arg);
+static void servoShutdownTimerCallback(void *arg);
 
 // espnow call backs
 bool cachePeer(espnow_peer_t peer);
@@ -396,7 +396,7 @@ static void initTimers(void)
                                                 .skip_unhandled_events = true};
 
     // May need to make this a GPT timer?
-    const esp_timer_create_args_t sTimerArgs = {.callback = &servoMoveTimerCallback,
+    const esp_timer_create_args_t sTimerArgs = {.callback = &servoShutdownTimerCallback,
                                                 .arg = NULL,
                                                 .dispatch_method = ESP_TIMER_TASK,
                                                 .name = "servoMove",
@@ -714,13 +714,11 @@ void animationDispatchTask(void *arg)
     }
 }
 
-static void servoMoveTimerCallback(void *arg)
+// Periodically check if servos should be shut down to extend servo life.
+// currently there hasn't been a demand for servos to hold tension. May need
+// to add an option for that in the future
+static void servoShutdownTimerCallback(void *arg)
 {
-    // get time at start of loop
-    // auto loopStart = esp_timer_get_time();
-
-    // ServoMod.MoveServos();
-
     // Snapshot module handles under the mutex, then release it before calling
     // CheckServos(): CheckServos can enqueue UART commands via sendQueueMsg,
     // which spins on a per-module mutex. Holding maestroModulesMutex across
@@ -739,7 +737,7 @@ static void servoMoveTimerCallback(void *arg)
     }
     else
     {
-        ESP_LOGW(TAG, "servoMoveTimerCallback: maestroModulesMutex timeout — skipping cycle");
+        ESP_LOGW(TAG, "servoShutdownTimerCallback: maestroModulesMutex timeout — skipping cycle");
     }
 
     for (auto &maestroMod : snapshot)
@@ -747,13 +745,6 @@ static void servoMoveTimerCallback(void *arg)
         maestroMod->CheckServos(300);
     }
 
-    // get time at end of loop
-    // auto loopEnd = esp_timer_get_time();
-
-    // start loop  so it will trigger 500 ms from the start of the loop
-    // int ms = SERVO_MOVE_INTERVAL - std::round((loopEnd - loopStart) / 1000);
-    // auto timeToNextMove = std::clamp(ms, 100, SERVO_MOVE_INTERVAL);
-    // ESP_ERROR_CHECK(esp_timer_start_once(servoMoveTimer, timeToNextMove * 1000));
     ESP_ERROR_CHECK(esp_timer_start_once(servoMoveTimer, 300 * 1000));
 }
 
@@ -1626,12 +1617,6 @@ static void loadMaestroConfigs()
     auto maestroConfigs = AstrOs_Storage.loadMaestroConfigs();
     ESP_LOGI(TAG, "Loaded Maestro modules from file: %d", maestroConfigs.size());
 
-    // Phase 1: structural map mutation under maestroModulesMutex only. We
-    // record pending UpdateConfig calls against existing modules instead of
-    // applying them inline — UpdateConfig() spin-waits on each module's own
-    // mutex, and LoadConfig() does NVS reads + HomeServos() UART traffic.
-    // Running either under the map mutex would stall servoQueueTask and trip
-    // the 100ms timeout in servoMoveTimerCallback repeatedly.
     struct PendingUpdate
     {
         std::shared_ptr<MaestroModule> module;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,7 +93,7 @@ static esp_timer_handle_t pollingTimer;
 static bool polling = false;
 
 static esp_timer_handle_t maintenanceTimer;
-static esp_timer_handle_t servoMoveTimer;
+static esp_timer_handle_t servoShutdownTimer;
 
 // Silent-error counters — incremented from cross-task contexts (Wi-Fi driver task
 // for espnowRecvCallback, astrosRxTask on core 0). Read from maintenanceTimerCallback
@@ -399,7 +399,7 @@ static void initTimers(void)
     const esp_timer_create_args_t sTimerArgs = {.callback = &servoShutdownTimerCallback,
                                                 .arg = NULL,
                                                 .dispatch_method = ESP_TIMER_TASK,
-                                                .name = "servoMove",
+                                                .name = "servoShutdown",
                                                 .skip_unhandled_events = true};
 
     ESP_ERROR_CHECK(esp_timer_create(&pTimerArgs, &pollingTimer));
@@ -410,9 +410,9 @@ static void initTimers(void)
     ESP_ERROR_CHECK(esp_timer_start_periodic(maintenanceTimer, 10 * 1000 * 1000));
     ESP_LOGI("init_timer", "Started maintenance timer");
 
-    ESP_ERROR_CHECK(esp_timer_create(&sTimerArgs, &servoMoveTimer));
-    ESP_ERROR_CHECK(esp_timer_start_once(servoMoveTimer, 300 * 1000));
-    ESP_LOGI("init_timer", "Started servo move timer");
+    ESP_ERROR_CHECK(esp_timer_create(&sTimerArgs, &servoShutdownTimer));
+    ESP_ERROR_CHECK(esp_timer_start_once(servoShutdownTimer, 300 * 1000));
+    ESP_LOGI("init_timer", "Started servo shutdown timer");
 }
 
 static void pollingTimerCallback(void *arg)
@@ -745,7 +745,7 @@ static void servoShutdownTimerCallback(void *arg)
         maestroMod->CheckServos(300);
     }
 
-    ESP_ERROR_CHECK(esp_timer_start_once(servoMoveTimer, 300 * 1000));
+    ESP_ERROR_CHECK(esp_timer_start_once(servoShutdownTimer, 300 * 1000));
 }
 
 #pragma endregion

--- a/test/test_native/astros_path_utils_tests.cpp
+++ b/test/test_native/astros_path_utils_tests.cpp
@@ -1,6 +1,7 @@
 #include <AstrOsPathUtils.hpp>
 #include <gtest/gtest.h>
 
+#include <cstring>
 #include <string>
 
 using AstrOsPathUtils::isPathSafe;
@@ -84,4 +85,105 @@ TEST(PathUtils, EmptyTakesPrecedenceOverOtherChecks)
     std::string reason = "stale";
     EXPECT_FALSE(isPathSafe("", reason));
     EXPECT_EQ(reason, "empty path rejected");
+}
+
+// --- contentAddressedFirmwarePath ---
+
+using AstrOsPathUtils::contentAddressedFirmwarePath;
+using AstrOsPathUtils::FIRMWARE_HASH_PREFIX_LEN;
+using AstrOsPathUtils::FIRMWARE_PATH_BUF_LEN;
+
+TEST(ContentAddressedFirmwarePath, BuildsExpectedPathForFullSha256)
+{
+    // SHA-256("") happens to be a convenient 64-char vector to feed in.
+    const char *hex = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    char out[FIRMWARE_PATH_BUF_LEN] = {0};
+    EXPECT_TRUE(contentAddressedFirmwarePath(hex, out, sizeof(out)));
+    EXPECT_STREQ("/sdcard/firmware/e3b0c44298fc1c14.bin", out);
+}
+
+TEST(ContentAddressedFirmwarePath, UsesExactlyFirst16CharsOfHash)
+{
+    // Construct a hash where chars 0..15 differ from 16..31 to prove the
+    // truncation point is exactly at 16 and not "wherever NUL falls".
+    const char *hex = "0123456789abcdef"
+                      "ffffffffffffffff"
+                      "ffffffffffffffff"
+                      "ffffffffffffffff";
+    char out[FIRMWARE_PATH_BUF_LEN] = {0};
+    EXPECT_TRUE(contentAddressedFirmwarePath(hex, out, sizeof(out)));
+    EXPECT_STREQ("/sdcard/firmware/0123456789abcdef.bin", out);
+}
+
+TEST(ContentAddressedFirmwarePath, AcceptsExactly16CharHash)
+{
+    // No bytes available beyond the truncation point — the helper must still
+    // succeed because it only reads FIRMWARE_HASH_PREFIX_LEN chars.
+    const char *hex = "aaaabbbbccccdddd";
+    ASSERT_EQ(FIRMWARE_HASH_PREFIX_LEN, strlen(hex));
+    char out[FIRMWARE_PATH_BUF_LEN] = {0};
+    EXPECT_TRUE(contentAddressedFirmwarePath(hex, out, sizeof(out)));
+    EXPECT_STREQ("/sdcard/firmware/aaaabbbbccccdddd.bin", out);
+}
+
+TEST(ContentAddressedFirmwarePath, RejectsShortHash)
+{
+    // 15-char hash should be rejected — the "%.16s" silent-truncation
+    // behavior in the original inline snprintf is exactly what extracting
+    // this helper exists to prevent.
+    const char *hex = "aaaabbbbccccdd";
+    ASSERT_LT(strlen(hex), FIRMWARE_HASH_PREFIX_LEN);
+    char out[FIRMWARE_PATH_BUF_LEN] = {'X'};
+    EXPECT_FALSE(contentAddressedFirmwarePath(hex, out, sizeof(out)));
+    EXPECT_EQ('\0', out[0]);
+}
+
+TEST(ContentAddressedFirmwarePath, RejectsEmptyHash)
+{
+    char out[FIRMWARE_PATH_BUF_LEN] = {'X'};
+    EXPECT_FALSE(contentAddressedFirmwarePath("", out, sizeof(out)));
+    EXPECT_EQ('\0', out[0]);
+}
+
+TEST(ContentAddressedFirmwarePath, RejectsNullHash)
+{
+    char out[FIRMWARE_PATH_BUF_LEN] = {'X'};
+    EXPECT_FALSE(contentAddressedFirmwarePath(nullptr, out, sizeof(out)));
+    EXPECT_EQ('\0', out[0]);
+}
+
+TEST(ContentAddressedFirmwarePath, RejectsNullOut)
+{
+    EXPECT_FALSE(contentAddressedFirmwarePath("0123456789abcdef", nullptr, 64));
+}
+
+TEST(ContentAddressedFirmwarePath, RejectsUndersizedBuffer)
+{
+    // One byte short of the required buffer size — must reject and NUL the
+    // output so the caller can't silently consume a truncated path.
+    char out[FIRMWARE_PATH_BUF_LEN - 1] = {'X'};
+    EXPECT_FALSE(contentAddressedFirmwarePath("0123456789abcdef", out, sizeof(out)));
+    EXPECT_EQ('\0', out[0]);
+}
+
+TEST(ContentAddressedFirmwarePath, IsDeterministic)
+{
+    // Same input always produces the same path — the property mesh
+    // forwarders will rely on for filename-based dedup.
+    const char *hex = "feedfacecafebeef0011223344556677";
+    char a[FIRMWARE_PATH_BUF_LEN] = {0};
+    char b[FIRMWARE_PATH_BUF_LEN] = {0};
+    EXPECT_TRUE(contentAddressedFirmwarePath(hex, a, sizeof(a)));
+    EXPECT_TRUE(contentAddressedFirmwarePath(hex, b, sizeof(b)));
+    EXPECT_STREQ(a, b);
+}
+
+TEST(ContentAddressedFirmwarePath, OutputIsNulTerminatedOnSuccess)
+{
+    const char *hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    char out[FIRMWARE_PATH_BUF_LEN] = {0};
+    ASSERT_TRUE(contentAddressedFirmwarePath(hex, out, sizeof(out)));
+    // strlen relies on the trailing NUL — if we lost it we'd run past
+    // the buffer.
+    EXPECT_EQ(strlen("/sdcard/firmware/") + 16 + 4, strlen(out));
 }

--- a/test/test_native/astros_path_utils_tests.cpp
+++ b/test/test_native/astros_path_utils_tests.cpp
@@ -166,10 +166,21 @@ TEST(ContentAddressedFirmwarePath, RejectsUndersizedBuffer)
     EXPECT_EQ('\0', out[0]);
 }
 
+TEST(ContentAddressedFirmwarePath, ZeroLengthBufferDoesNotWriteOut)
+{
+    // outLen=0 with non-null out is a degenerate but legal call. The helper
+    // must reject without touching the buffer — a stray "out[0] = '\\0'"
+    // would be a 1-byte OOB write. The canary lets us prove the buffer
+    // wasn't touched.
+    char canary[2] = {'X', 'Y'};
+    EXPECT_FALSE(contentAddressedFirmwarePath("0123456789abcdef", canary, 0));
+    EXPECT_EQ('X', canary[0]);
+    EXPECT_EQ('Y', canary[1]);
+}
+
 TEST(ContentAddressedFirmwarePath, IsDeterministic)
 {
-    // Same input always produces the same path — the property mesh
-    // forwarders will rely on for filename-based dedup.
+    // Same input must produce the same path.
     const char *hex = "feedfacecafebeef0011223344556677";
     char a[FIRMWARE_PATH_BUF_LEN] = {0};
     char b[FIRMWARE_PATH_BUF_LEN] = {0};

--- a/test/test_native/astros_path_utils_tests.cpp
+++ b/test/test_native/astros_path_utils_tests.cpp
@@ -117,8 +117,6 @@ TEST(ContentAddressedFirmwarePath, UsesExactlyFirst16CharsOfHash)
 
 TEST(ContentAddressedFirmwarePath, AcceptsExactly16CharHash)
 {
-    // No bytes available beyond the truncation point — the helper must still
-    // succeed because it only reads FIRMWARE_HASH_PREFIX_LEN chars.
     const char *hex = "aaaabbbbccccdddd";
     ASSERT_EQ(FIRMWARE_HASH_PREFIX_LEN, strlen(hex));
     char out[FIRMWARE_PATH_BUF_LEN] = {0};
@@ -128,9 +126,7 @@ TEST(ContentAddressedFirmwarePath, AcceptsExactly16CharHash)
 
 TEST(ContentAddressedFirmwarePath, RejectsShortHash)
 {
-    // 15-char hash should be rejected — the "%.16s" silent-truncation
-    // behavior in the original inline snprintf is exactly what extracting
-    // this helper exists to prevent.
+    // Locks down the 16-char minimum that prevents silent %.16s truncation.
     const char *hex = "aaaabbbbccccdd";
     ASSERT_LT(strlen(hex), FIRMWARE_HASH_PREFIX_LEN);
     char out[FIRMWARE_PATH_BUF_LEN] = {'X'};
@@ -159,8 +155,7 @@ TEST(ContentAddressedFirmwarePath, RejectsNullOut)
 
 TEST(ContentAddressedFirmwarePath, RejectsUndersizedBuffer)
 {
-    // One byte short of the required buffer size — must reject and NUL the
-    // output so the caller can't silently consume a truncated path.
+    // NUL on out[0] prevents the caller from consuming a truncated path.
     char out[FIRMWARE_PATH_BUF_LEN - 1] = {'X'};
     EXPECT_FALSE(contentAddressedFirmwarePath("0123456789abcdef", out, sizeof(out)));
     EXPECT_EQ('\0', out[0]);
@@ -168,10 +163,8 @@ TEST(ContentAddressedFirmwarePath, RejectsUndersizedBuffer)
 
 TEST(ContentAddressedFirmwarePath, ZeroLengthBufferDoesNotWriteOut)
 {
-    // outLen=0 with non-null out is a degenerate but legal call. The helper
-    // must reject without touching the buffer — a stray "out[0] = '\\0'"
-    // would be a 1-byte OOB write. The canary lets us prove the buffer
-    // wasn't touched.
+    // Reject must not touch the buffer — a stray out[0]='\0' would be a
+    // 1-byte OOB write.
     char canary[2] = {'X', 'Y'};
     EXPECT_FALSE(contentAddressedFirmwarePath("0123456789abcdef", canary, 0));
     EXPECT_EQ('X', canary[0]);

--- a/test/test_native/astros_string_utils_tests.cpp
+++ b/test/test_native/astros_string_utils_tests.cpp
@@ -58,7 +58,7 @@ TEST(StringUtils, ToHexLower_SingleByteAllNibbles)
         AstrOsStringUtils::toHexLower(&in, 1, out);
 
         char expected[3];
-        snprintf(expected, sizeof(expected), "%02x", in);
+        std::snprintf(expected, sizeof(expected), "%02x", in);
         EXPECT_STREQ(expected, out) << "byte=" << b;
     }
 }

--- a/test/test_native/astros_string_utils_tests.cpp
+++ b/test/test_native/astros_string_utils_tests.cpp
@@ -3,6 +3,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstring>
+
 #define UNIT_SEPARATOR (char)0x1F
 
 TEST(StringUtils, SplitString)
@@ -36,6 +38,68 @@ TEST(StringUtils, DISABLED_GetMessageAt)
     auto message = AstrOsStringUtils::getMessageValueAt(value.data, value.size, UNIT_SEPARATOR, 1);
 
     EXPECT_STREQ("test", message.c_str());
+}
+
+TEST(StringUtils, ToHexLower_EmptyInput)
+{
+    char out[1] = {'X'};
+    AstrOsStringUtils::toHexLower(nullptr, 0, out);
+    EXPECT_EQ('\0', out[0]);
+}
+
+TEST(StringUtils, ToHexLower_SingleByteAllNibbles)
+{
+    // Verify every nibble value maps to the correct lowercase hex char.
+    for (uint16_t b = 0; b < 256; ++b)
+    {
+        uint8_t in = static_cast<uint8_t>(b);
+        char out[3] = {0};
+        AstrOsStringUtils::toHexLower(&in, 1, out);
+
+        char expected[3];
+        snprintf(expected, sizeof(expected), "%02x", in);
+        EXPECT_STREQ(expected, out) << "byte=" << b;
+    }
+}
+
+TEST(StringUtils, ToHexLower_AllZeroSha256Width)
+{
+    uint8_t digest[32] = {0};
+    char out[65] = {0};
+    AstrOsStringUtils::toHexLower(digest, sizeof(digest), out);
+    EXPECT_STREQ("0000000000000000000000000000000000000000000000000000000000000000", out);
+    EXPECT_EQ('\0', out[64]);
+}
+
+TEST(StringUtils, ToHexLower_AllFFSha256Width)
+{
+    uint8_t digest[32];
+    std::memset(digest, 0xFF, sizeof(digest));
+    char out[65] = {0};
+    AstrOsStringUtils::toHexLower(digest, sizeof(digest), out);
+    EXPECT_STREQ("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", out);
+    EXPECT_EQ('\0', out[64]);
+}
+
+TEST(StringUtils, ToHexLower_OutputIsLowercase)
+{
+    // 0xAB must encode as "ab", not "AB" — the server's compare is a literal
+    // strcmp, so case matters end-to-end.
+    uint8_t b = 0xAB;
+    char out[3] = {0};
+    AstrOsStringUtils::toHexLower(&b, 1, out);
+    EXPECT_STREQ("ab", out);
+}
+
+TEST(StringUtils, ToHexLower_KnownVectorSha256OfEmptyString)
+{
+    // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    const uint8_t digest[32] = {0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4,
+                                0xc8, 0x99, 0x6f, 0xb9, 0x24, 0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b,
+                                0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55};
+    char out[65] = {0};
+    AstrOsStringUtils::toHexLower(digest, sizeof(digest), out);
+    EXPECT_STREQ("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", out);
 }
 
 TEST(StringUtils, splitStringOnLineEnd)

--- a/test/test_native/astros_string_utils_tests.cpp
+++ b/test/test_native/astros_string_utils_tests.cpp
@@ -3,6 +3,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstdio>
 #include <cstring>
 
 #define UNIT_SEPARATOR (char)0x1F


### PR DESCRIPTION
# OTA Phase 4 — SD writer + streaming SHA-256

Replaces the Phase 3 `/dev/null` sink with the real SD-card staging path:
every chunk the `BulkReceiver` ACKs is `fwrite`'d to
`/sdcard/firmware/staging.bin` and fed into a streaming `mbedtls_sha256`
context. On END, the locally computed digest is compared against the
server's expected hash; on match, staging.bin is renamed to its
content-addressed final name `/sdcard/firmware/<sha[0..16)>.bin` so it
survives reboot and can be consumed by the future mesh-forwarder phase.
HASH_MISMATCH preserves staging.bin for forensic inspection; watchdog
and other aborts discard it.

The branch sits 8 commits ahead of `develop` (12 files,
+968 / −6). One feat commit plus four iterative review-driven cleanup
rounds.

## What ships

### `lib/OtaReceiver` (MIXED) — staging + streaming SHA-256

- `OtaReceiver` gains two long-lived members for the duration of one
  transfer: `FILE *staging_` and `mbedtls_sha256_context shaCtx_`
  (plus a `shaActive_` flag tracking the SHA lifecycle).
- `handleBegin` adds a gated SD setup sequence:
  `ensureSdFirmwareDir` → free-space pre-check → `fopen("wb")` →
  `mbedtls_sha256_starts`. Every early return leaves
  `active_`/`transferIdStr_` untouched so a rejected BEGIN cannot
  corrupt an in-flight transfer's state.
- `handleChunk` ACK branch `fwrite`s the payload and updates the SHA
  context before sending `FW_CHUNK_ACK`. Short writes and SHA failures
  emit `FW_CHUNK_NAK reason=FLASH_FULL` and tear down the transfer.
- `handleEnd` OK branch closes the staging file (durability before
  rename), finalizes the SHA, compares to the server's expected hex,
  and renames staging.bin to its content-addressed final name on
  match. HASH_MISMATCH replies with the computed hex and leaves
  staging.bin in place. Three distinct failure-mode LOGEs distinguish
  null-handle / fclose-errno / SHA-finish failure.
- `handleWatchdogFire` and other abort paths route through one shared
  `resetCryptoAndFile(bool keepStaging)` helper so every exit closes
  the file and releases the SHA context exactly once. Idempotent —
  the destructor calls it with `keepStaging=true` defensively even
  though `AstrOs_OtaReceiver` is a process-lifetime singleton.
- END_ACK now carries the **locally computed** hash, not the server's
  echoed value — closes the cross-repo loop the protocol contract
  always intended. The server compares its own digest against the
  master's, so a silent bit-flip during transmission shows up as a
  mismatch regardless of what either side thinks happened.

### `lib/AstrOsStorageManager` — two thin helpers

- `freeSpaceSdBytes() -> std::optional<uint64_t>` wraps `f_getfree`
  on the existing mounted FATFS card. Returns `nullopt` on probe
  failure so callers can distinguish "card is really full" from "I/O
  fault during the probe" — sd_full would mislead the operator into
  trying to free space they already have.
- `ensureSdFirmwareDir()` is idempotent `mkdir("/sdcard/firmware",
  0775)` treating `EEXIST` as success.

### `lib_native/AstrOsUtility` — two PURE extractions

- `AstrOsStringUtils::toHexLower(in, len, out)` — lowercase-hex
  encode `2*len` chars + NUL. Lifted out of an `OtaReceiver` anonymous-
  namespace helper so the property that turns a digest into the
  server's compare target gets native-test coverage. A single nibble-
  shift bug here would brick every OTA, hence the dedicated tests.
- `AstrOsPathUtils::contentAddressedFirmwarePath(hashHex, out, outLen)`
  — builds `/sdcard/firmware/<first-16-of-hashHex>.bin` into `out`
  with a strict 16-char minimum on the hash. Replaces an inline
  `snprintf("%.16s.bin", ...)` whose silent truncation behavior was
  exactly the kind of regression the helper exists to prevent.
  Exposes `FIRMWARE_HASH_PREFIX_LEN`, `FIRMWARE_DIR`, and
  `FIRMWARE_PATH_BUF_LEN` (= 38) constants for callers.

## Test plan

### Native unit tests — 343 cases, all passing

The branch adds **17 new native test cases** in two existing PURE-lib
test files:

| Coverage area | File | Cases |
|---|---|---|
| `toHexLower` (empty, full nibble sweep, all-zero/0xFF digest, known SHA-256 vector, lowercase property) | `astros_string_utils_tests.cpp` | 6 |
| `contentAddressedFirmwarePath` (happy path, exact-16, short, empty, null inputs, undersized buffer, zero-length buffer, determinism, NUL termination, truncation point) | `astros_path_utils_tests.cpp` | 11 |

Existing `bulk_transport_tests.cpp` (32 cases) and
`ota_queue_message_tests.cpp` (13 cases) continue to cover the Phase
2/3 state machine and queue-message lifecycle Phase 4 builds on.

Run with `pio test -e test`.

### Build matrix

Both `metro_s3` (ESP32-S3, 16 MB) and `lolin_d32_pro` (ESP32, 8 MB)
build green. Flash usage stays ~18% on metro_s3, ~58% on lolin_d32_pro
— net +13 KB from the new mbedtls/sha256 code path. No RAM
regressions; new on-stack `mbedtls_sha256_context` (~108 B) +
`digest[32]` + `computedHex[65]` + `finalPath[38]` fit inside the
otaReceiverTask 4 KB stack with no HWM warning.

### Manual QA

- [ ] `.docs/qa/ota-master-serial-receive.md` — extended with the
      Phase 4 happy path (pop SD, verify on-disk SHA-256 matches the
      host's `sha256sum`) plus three new negative cases:
  - **Path 6** — Watchdog discards staging.bin on stuck transfer.
  - **Path 7** — Same-firmware re-upload is idempotent (the
    `unlink`-before-`rename` choice gets exercised).
  - **Path 8** — HASH_MISMATCH preserves staging.bin (the only path
    that intentionally keeps unverified bytes on disk; this is the
    test that locks the forensic-preserve contract).

QA plans live under `.docs/qa/` with Preconditions / Steps / Expected /
Pass-Fail per CLAUDE.md rigor.

## Review history

This branch was reviewed three times using the multi-agent PR toolkit
(`/pr-review-toolkit:review-pr`). All findings landed across four
follow-up commits.

**Round 1** flagged 3 silent-failure criticals + 1 misleading comment
+ 2 high-value coverage gaps. Addressed in `12b9c49` and `d31c408`:

- SF-1: `freeSpaceSdBytes` returning `0` on probe failure conflated
  with "really full" → switched to `std::optional<uint64_t>`, handler
  replies `io_error` on probe failure.
- SF-2: `fclose` return swallowed in `resetCryptoAndFile` → logs LOGE
  so a HASH_MISMATCH-preserved file that comes back short is
  grepable.
- SF-3: pre-rename `unlink` swallowed non-ENOENT failures → logs
  before rename overwrites errno.
- Comment: misleading "drain stdio buffers for the hash" → rewritten
  to reflect actual reason (close before rename for durability; the
  hash was computed from `cr.payload` in handleChunk, not from the
  file).
- Coverage-1: `toHexLower` extracted from OtaReceiver to
  `AstrOsStringUtils` (PURE) with 6 native tests.
- Coverage-2: HASH_MISMATCH QA case (path 8) pulled forward from
  Phase 5 — the only path that exercises the forensic-preserve
  contract.

**Round 2** caught one new medium-severity finding plus a small
follow-up. Addressed in `fccc5ca`:

- SF-4 (new): `unlink(finalPath)` before `rename` could destroy a
  previously valid firmware blob if rename then failed. Now tracks
  `removedPrior` and logs an explicit "operator lost prior firmware"
  LOGE on that failure mode.
- C-1: END_ACK with `IO_ERROR` carried `""` for the computed hex when
  fclose failed but SHA succeeded. Reordered finalize so a fclose-only
  failure still reports the valid digest of bytes we actually
  processed.
- Comment: watchdog-discard comment lost a useful HASH_MISMATCH
  cross-reference in round 1's trim — restored.

**Round 3** flagged one defensive-test gap, one comment-rot risk, one
diagnostic-clarity improvement. Addressed in `65751b6` and `8e96c81`:

- Extract: inline `snprintf("/sdcard/firmware/%.16s.bin", ...)`
  promoted to `AstrOsPathUtils::contentAddressedFirmwarePath` with
  10+ tests covering boundary cases (hash < 16, exactly 16, > 16,
  null, undersized buffer, determinism, NUL termination).
- Defensive test: `outLen=0` with non-null `out` now has an explicit
  test asserting no write occurs (canary byte preserved).
- Comment: `IsDeterministic` test's speculative reference to "future
  mesh forwarders" → trimmed to the property under test.
- Diagnostic: END finalize LOGE split into three distinct messages
  (null staging handle / fclose errno / SHA-finish error) so an
  operator chasing the LOGE sees the actual failure mode.

Round 3 also confirmed remaining inline pure logic in `handleDeployBegin`
(RS-delimited orderList parsing) — flagged for a future refactor but
out of Phase 4 scope.

## Files changed

- **Core implementation:**
  `lib/OtaReceiver/include/OtaReceiver.hpp`,
  `lib/OtaReceiver/src/OtaReceiver.cpp`, `lib/OtaReceiver/README`.
- **Storage helpers:**
  `lib/AstrOsStorageManager/include/AstrOsStorageManager.hpp`,
  `lib/AstrOsStorageManager/src/AstOsStorageManager.cpp`.
- **PURE-lib extractions:**
  `lib_native/AstrOsUtility/src/AstrOsStringUtils.hpp`,
  `lib_native/AstrOsUtility/include/AstrOsPathUtils.hpp`,
  `lib_native/AstrOsUtility/src/AstrOsPathUtils.cpp`.
- **Tests:**
  `test/test_native/astros_string_utils_tests.cpp` (+6 cases),
  `test/test_native/astros_path_utils_tests.cpp` (+11 cases).
- **Plans + QA:**
  `.docs/plans/20260517-0756-firmware-ota-phase4-sd-writer-sha256.md`,
  `.docs/qa/ota-master-serial-receive.md` (Phase 4 section + 3 new
  negative paths).

## Risk + backward compatibility

- **Wire format unchanged.** The END_ACK status codes (`OK`,
  `HASH_MISMATCH`, `IO_ERROR`) and the protocol's `computedHex` field
  were already in the contract; Phase 4 just stops echoing the
  server's hash and starts emitting the locally computed one.
- **On-disk layout is new** but isolated under `/sdcard/firmware/`.
  Existing `/sdcard/scripts/`, `/sdcard/gpio/`, `/sdcard/maestro/`
  trees are untouched.
- **HASH_MISMATCH explicitly preserves staging.bin** so a future
  refactor that adds a "cleanup on failure" path must be careful to
  exclude the mismatch case — covered by QA path 8 which is now the
  single source of truth for that contract.
- **Free-space pre-check** rejects BEGIN if `freeBytes < totalSize`.
  Server retries after operator cleanup; no on-disk side effects from
  the rejection.
- **`std::optional<uint64_t>`** is the project's first use in
  `AstrOsStorageManager`'s public API. C++20 (`-std=gnu++2a`) is
  pinned in `platformio.ini` so this is safe across both boards.

## How to test locally

```bash
# Native unit tests (includes new toHexLower + contentAddressedFirmwarePath cases)
pio test -e test

# Build both boards
pio run -e metro_s3
pio run -e lolin_d32_pro

# Generate a test firmware image for QA
./scripts/build_ota_test.sh

# Flash + monitor
pio run -e metro_s3 -t upload
pio device monitor -e metro_s3
```

Then drive the upload from `AstrOs.Server`'s Firmware view and follow
`.docs/qa/ota-master-serial-receive.md` Phase 4 section. After
END_ACK OK, pull the SD card and confirm
`/sdcard/firmware/<sha-prefix>.bin` matches the host's
`sha256sum <input.bin>` byte-for-byte.

## Out of scope (deferred to Phase 5)

- **Wall-clock max-transfer deadline** (5-min `esp_timer` backstop).
  The Phase 3 idle watchdog covers the dominant failure mode; the
  deadline backstop will be measured-then-decided.
- **`FW_BACKPRESSURE PAUSE/RESUME` flow.** Only build if Phase 4 bench
  measurements show the master falling behind. SD-write throughput
  ought to clear the ~11.5 KB/s wire bandwidth comfortably.
- **Full negative-path QA matrix** — `sd_full` via pre-filled card,
  mid-transfer CRC injection, server-side hash-injection bench
  toggle. The HASH_MISMATCH case landed in Phase 4 because it locks
  the forensic-preserve contract; the rest are non-load-bearing.
- **Probe-failure QA case** for `freeSpaceSdBytes() == nullopt`.
  Awkward to bench (eject SD mid-BEGIN); leave for a hardware-fault
  injection harness later.
- **Cleanup/eviction of stale `<sha-prefix>.bin` files.** Owned by
  the future mesh-forwarder phase that first consumes them.
- **Mesh deploy to padawans + `esp_ota_*` calls.** Cross-repo
  sub-project (b) phase 2 — distinct from this master-side work.
