### PR TITLE
fix(ota): use vendored software SHA-256 to avoid hardware-SHA contention

### DIFF
--- a/.docs/plans/20260522-2210-ota-software-sha256.md
+++ b/.docs/plans/20260522-2210-ota-software-sha256.md
@@ -1,0 +1,54 @@
+# OTA software SHA-256
+
+## Why
+
+The master uses `mbedtls_sha256_*` for the OTA streaming digest. On
+metro_s3 (and any ESP-IDF target with `CONFIG_MBEDTLS_HARDWARE_SHA=y`),
+this routes through the SoC's shared hardware SHA engine. A concurrent
+user of that engine elsewhere in the firmware corrupts our OTA
+context's state without `mbedtls_sha256_update` returning an error —
+producing deterministic `HASH_MISMATCH` at `FW_TRANSFER_END` despite
+the bytes on the SD card matching the source byte-for-byte.
+
+Evidence (from 2026-05-22 investigation):
+- `sha256sum staging.bin` (master's SD card) == `sha256sum cache/.bin`
+  (server's source) == `56ac88e9…` — zero differing bytes via `cmp -l`.
+- Master's runtime SHA computed `e38d7726…` over the same bytes.
+- Repeats deterministically across transfers.
+
+Replacing the OTA path's hash with a vendored software SHA-256
+eliminates the shared-engine race entirely. Identical behavior across
+boards, fully native-testable, no `sdkconfig` change required so other
+subsystems keep their hardware SHA acceleration.
+
+## Approach
+
+Vendor Brad Conte's public-domain SHA-256 (~200 lines C) into
+`lib_native/AstrOsUtility` so it's natively testable and reusable.
+Swap `OtaReceiver` to call it instead of mbedTLS.
+
+## Tasks
+
+- [ ] Vendor SHA-256 into `lib_native/AstrOsUtility/`:
+  - `include/AstrOsSha256.h` — public API (`AstrOsSha256Ctx`,
+    `_init`, `_update`, `_final`, `ASTROS_SHA256_DIGEST_LEN`)
+  - `src/AstrOsSha256.c` — Brad Conte's implementation, attributed
+    public-domain.
+- [ ] Add native unit tests `test/test_native/astros_sha256_tests.cpp`
+  covering NIST/RFC-6234 known-answer vectors: empty input, "abc",
+  one-million-`a`, the 448-bit two-block test, and a multi-update
+  consistency check (same hash whether one update or many splits).
+- [ ] Swap `OtaReceiver` (`.hpp` and `.cpp`) from `mbedtls_sha256_*`
+  to `AstrOsSha256_*`. Drops `mbedtls_sha256_starts(is224=0)` and
+  `_free` (combined into `_init`; no heap). Remove now-unreachable
+  init/update/finish error branches.
+- [ ] Verify:
+  - `pio test -e test` passes including new SHA tests.
+  - `pio run -e metro_s3` and `pio run -e lolin_d32_pro` build clean.
+  - Flash master, re-run OTA — expect `FW_TRANSFER_END_ACK status=OK`
+    on the same RC.1 cache file that previously HASH_MISMATCH'd.
+- [ ] Decide on the investigation logging:
+  - `OtaReceiver.cpp` `FW_CHUNK seq=0 first16=<hex>` log
+  - `chunk_streamer.ts` `cache-sha-drift` warning
+  Both are behavior-neutral and forensically useful. Default: leave
+  in place; revert if PR review wants a quieter master log.

--- a/lib/OtaReceiver/include/OtaReceiver.hpp
+++ b/lib/OtaReceiver/include/OtaReceiver.hpp
@@ -2,6 +2,7 @@
 #define OTARECEIVER_HPP
 
 #include <AstrOsBulkTransport.hpp>
+#include <AstrOsSha256.h>
 #include <OtaQueueMessage.h>
 
 #include <atomic>
@@ -14,7 +15,6 @@
 #include <freertos/queue.h>
 
 #include <esp_timer.h>
-#include <mbedtls/sha256.h>
 
 // Threading: all members are accessed only from otaReceiverTask via
 // `process(...)`. The one exception is `active_` (see its declaration), which
@@ -48,9 +48,12 @@ private:
     // Staging-file handle and streaming SHA-256 context. Both are live only
     // between a successful BEGIN and the terminating END / abort. Every exit
     // path routes through resetCryptoAndFile() so we never leak an open FILE*
-    // or an mbedtls_sha256_context into the next transfer.
+    // across transfers. AstrOsSha256 is pure software (no shared hardware
+    // engine), avoiding the cross-task race we observed when mbedtls' OTA
+    // context's state got clobbered by another SHA consumer; `shaActive_`
+    // gates init-vs-update ordering without needing an explicit free.
     FILE *staging_ = nullptr;
-    mbedtls_sha256_context shaCtx_;
+    AstrOsSha256Ctx shaCtx_;
     bool shaActive_ = false;
 
 public:

--- a/lib/OtaReceiver/src/OtaReceiver.cpp
+++ b/lib/OtaReceiver/src/OtaReceiver.cpp
@@ -327,8 +327,7 @@ void OtaReceiver::handleChunk(queue_ota_msg_t &msg)
         }
         // Diagnostic: log first chunk's esp_image_header so we can identify
         // which firmware was actually streamed when chasing HASH_MISMATCH —
-        // first byte is magic 0xE9; offsets 0x30..0x60 carry the app
-        // descriptor (project_name, version) in plaintext.
+        // first byte is magic 0xE9;
         if (msg.chunk.seq == 0 && cr.payloadLen >= 16 && cr.payload != nullptr)
         {
             char hex[33] = {0};

--- a/lib/OtaReceiver/src/OtaReceiver.cpp
+++ b/lib/OtaReceiver/src/OtaReceiver.cpp
@@ -137,11 +137,8 @@ void OtaReceiver::resetCryptoAndFile(bool keepStaging)
             unlink(kStagingPath);
         }
     }
-    if (shaActive_)
-    {
-        mbedtls_sha256_free(&shaCtx_);
-        shaActive_ = false;
-    }
+    // AstrOsSha256 owns no heap; just drop the active flag.
+    shaActive_ = false;
 }
 
 void OtaReceiver::process(queue_ota_msg_t &msg)
@@ -276,18 +273,7 @@ void OtaReceiver::handleBegin(queue_ota_msg_t &msg)
         return;
     }
 
-    mbedtls_sha256_init(&shaCtx_);
-    if (mbedtls_sha256_starts(&shaCtx_, /*is224=*/0) != 0)
-    {
-        ESP_LOGE(TAG, "FW_TRANSFER_BEGIN: mbedtls_sha256_starts failed");
-        mbedtls_sha256_free(&shaCtx_);
-        fclose(staging_);
-        staging_ = nullptr;
-        unlink(kStagingPath);
-        bulk_.reset();
-        AstrOs_SerialMsgHandler.sendFwTransferBeginAck(msgId, transferIdIn, "io_error");
-        return;
-    }
+    AstrOsSha256_init(&shaCtx_);
     shaActive_ = true;
 
     active_ = true;
@@ -339,6 +325,19 @@ void OtaReceiver::handleChunk(queue_ota_msg_t &msg)
             watchdogStop();
             return;
         }
+        // Diagnostic: log first chunk's esp_image_header so we can identify
+        // which firmware was actually streamed when chasing HASH_MISMATCH —
+        // first byte is magic 0xE9; offsets 0x30..0x60 carry the app
+        // descriptor (project_name, version) in plaintext.
+        if (msg.chunk.seq == 0 && cr.payloadLen >= 16 && cr.payload != nullptr)
+        {
+            char hex[33] = {0};
+            for (int i = 0; i < 16; ++i)
+            {
+                std::snprintf(hex + 2 * i, 3, "%02x", cr.payload[i]);
+            }
+            ESP_LOGI(TAG, "FW_CHUNK seq=0 first16=%s", hex);
+        }
         size_t wrote = fwrite(cr.payload, 1, cr.payloadLen, staging_);
         if (wrote != cr.payloadLen)
         {
@@ -353,20 +352,7 @@ void OtaReceiver::handleChunk(queue_ota_msg_t &msg)
             watchdogStop();
             return;
         }
-        if (mbedtls_sha256_update(&shaCtx_, cr.payload, cr.payloadLen) != 0)
-        {
-            // Update failure corrupts the digest; abort now rather than
-            // reporting HASH_MISMATCH at END.
-            ESP_LOGE(TAG, "mbedtls_sha256_update failed — aborting transfer");
-            AstrOs_SerialMsgHandler.sendFwChunkNak(transferIdIn, cr.highestContiguousSeq, cr.nextExpectedSeq,
-                                                   "FLASH_FULL");
-            resetCryptoAndFile(/*keepStaging=*/false);
-            bulk_.reset();
-            active_ = false;
-            transferIdStr_.clear();
-            watchdogStop();
-            return;
-        }
+        AstrOsSha256_update(&shaCtx_, cr.payload, cr.payloadLen);
         AstrOs_SerialMsgHandler.sendFwChunkAck(transferIdIn, cr.highestContiguousSeq, cr.nextExpectedSeq,
                                                cr.windowRemaining);
     }
@@ -430,7 +416,7 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
         // Close before rename so stdio-buffered bytes hit disk; a power loss
         // after END_ACK OK would otherwise truncate the renamed file. The hash
         // was fed from chunk payloads, independent of this flush.
-        // Capture errno at the fclose call site — mbedtls finish/free below
+        // Capture errno at the fclose call site — AstrOsSha256_final below
         // could clobber it before the diagnostic log runs.
         bool fileOpen = (staging_ != nullptr);
         bool fcloseOk = false;
@@ -449,13 +435,14 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
         staging_ = nullptr;
 
         uint8_t digest[32];
-        // Capture the active flag before teardown so the diagnostic below can
-        // distinguish "never initialized" from "finish failed".
+        // shaActive_ tracks whether BEGIN initialized the context for this
+        // transfer; AstrOsSha256_final is infallible so the only "not OK"
+        // case is a never-initialized context (BEGIN/chunk-handler bug).
         bool shaWasActive = shaActive_;
-        bool hashOk = shaWasActive && (mbedtls_sha256_finish(&shaCtx_, digest) == 0);
-        if (shaActive_)
+        bool hashOk = shaWasActive;
+        if (shaWasActive)
         {
-            mbedtls_sha256_free(&shaCtx_);
+            AstrOsSha256_final(&shaCtx_, digest);
             shaActive_ = false;
         }
 
@@ -480,14 +467,7 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
             }
             if (!hashOk)
             {
-                if (!shaWasActive)
-                {
-                    ESP_LOGE(TAG, "FW_TRANSFER_END finalize: SHA context was never initialized (BEGIN bug)");
-                }
-                else
-                {
-                    ESP_LOGE(TAG, "FW_TRANSFER_END finalize: mbedtls_sha256_finish returned error");
-                }
+                ESP_LOGE(TAG, "FW_TRANSFER_END finalize: SHA context was never initialized (BEGIN bug)");
             }
             // Keep staging.bin so a follow-up can inspect what was written.
             AstrOs_SerialMsgHandler.sendFwTransferEndAck(msgId, transferIdIn, "IO_ERROR", computedHex);
@@ -499,7 +479,7 @@ void OtaReceiver::handleEnd(queue_ota_msg_t &msg)
             bool pathOk = AstrOsPathUtils::contentAddressedFirmwarePath(computedHex, finalPath, sizeof(finalPath));
             if (!pathOk)
             {
-                // Computed hex came from mbedtls_sha256_finish on 32 bytes, so
+                // Computed hex came from AstrOsSha256_final on 32 bytes, so
                 // it's always 64 chars — this branch should be unreachable.
                 ESP_LOGE(TAG, "contentAddressedFirmwarePath failed for computed=%s — replying IO_ERROR", computedHex);
                 AstrOs_SerialMsgHandler.sendFwTransferEndAck(msgId, transferIdIn, "IO_ERROR", computedHex);

--- a/lib_native/AstrOsUtility/include/AstrOsSha256.h
+++ b/lib_native/AstrOsUtility/include/AstrOsSha256.h
@@ -1,0 +1,48 @@
+#ifndef ASTROS_SHA256_H
+#define ASTROS_SHA256_H
+
+// Software SHA-256 used by the OTA receiver path. The ESP-IDF
+// mbedtls integration routes through the SoC's shared hardware SHA
+// engine when CONFIG_MBEDTLS_HARDWARE_SHA=y; concurrent users of
+// that engine elsewhere in the firmware can silently corrupt our
+// streaming digest. This implementation runs entirely in software
+// so the OTA hash is isolated from any other SHA consumer.
+//
+// Implementation lives in AstrOsSha256.c (Brad Conte, public domain).
+// Pure C — no ESP-IDF/FreeRTOS includes — so it builds under the
+// native test env and on both boards from one source.
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define ASTROS_SHA256_DIGEST_LEN 32
+
+    typedef struct
+    {
+        uint8_t data[64];
+        uint32_t datalen;
+        uint64_t bitlen;
+        uint32_t state[8];
+    } AstrOsSha256Ctx;
+
+    // Initialise a fresh context. No matching free is needed; the
+    // context owns no heap and is safe to discard at any point.
+    void AstrOsSha256_init(AstrOsSha256Ctx *ctx);
+
+    // Feed `len` bytes from `data` into the running digest.
+    void AstrOsSha256_update(AstrOsSha256Ctx *ctx, const uint8_t *data, size_t len);
+
+    // Emit the 32-byte digest. The context must not be reused after
+    // this without a fresh AstrOsSha256_init.
+    void AstrOsSha256_final(AstrOsSha256Ctx *ctx, uint8_t hash[ASTROS_SHA256_DIGEST_LEN]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/lib_native/AstrOsUtility/include/AstrOsSha256.h
+++ b/lib_native/AstrOsUtility/include/AstrOsSha256.h
@@ -30,15 +30,13 @@ extern "C"
         uint32_t state[8];
     } AstrOsSha256Ctx;
 
-    // Initialise a fresh context. No matching free is needed; the
-    // context owns no heap and is safe to discard at any point.
+    // No matching free needed — the context owns no heap and is safe
+    // to discard at any point.
     void AstrOsSha256_init(AstrOsSha256Ctx *ctx);
 
-    // Feed `len` bytes from `data` into the running digest.
     void AstrOsSha256_update(AstrOsSha256Ctx *ctx, const uint8_t *data, size_t len);
 
-    // Emit the 32-byte digest. The context must not be reused after
-    // this without a fresh AstrOsSha256_init.
+    // Context must be re-initialised before reuse.
     void AstrOsSha256_final(AstrOsSha256Ctx *ctx, uint8_t hash[ASTROS_SHA256_DIGEST_LEN]);
 
 #ifdef __cplusplus

--- a/lib_native/AstrOsUtility/src/AstrOsSha256.c
+++ b/lib_native/AstrOsUtility/src/AstrOsSha256.c
@@ -130,7 +130,6 @@ void AstrOsSha256_final(AstrOsSha256Ctx *ctx, uint8_t hash[ASTROS_SHA256_DIGEST_
         memset(ctx->data, 0, 56);
     }
 
-    // Append the bit length in big-endian.
     ctx->bitlen += (uint64_t)ctx->datalen * 8;
     ctx->data[63] = (uint8_t)(ctx->bitlen);
     ctx->data[62] = (uint8_t)(ctx->bitlen >> 8);
@@ -142,7 +141,6 @@ void AstrOsSha256_final(AstrOsSha256Ctx *ctx, uint8_t hash[ASTROS_SHA256_DIGEST_
     ctx->data[56] = (uint8_t)(ctx->bitlen >> 56);
     sha256_transform(ctx, ctx->data);
 
-    // Emit big-endian.
     for (i = 0; i < 4; ++i)
     {
         hash[i] = (uint8_t)(ctx->state[0] >> (24 - i * 8));

--- a/lib_native/AstrOsUtility/src/AstrOsSha256.c
+++ b/lib_native/AstrOsUtility/src/AstrOsSha256.c
@@ -1,0 +1,157 @@
+// SHA-256 implementation derived from Brad Conte's public-domain
+// reference (https://github.com/B-Con/crypto-algorithms). Renamed
+// types/functions to the AstrOs namespace and adapted to our header.
+// No algorithmic changes.
+
+#include "AstrOsSha256.h"
+
+#include <string.h>
+
+#define ROTRIGHT(a, b) (((a) >> (b)) | ((a) << (32 - (b))))
+
+#define CH(x, y, z) (((x) & (y)) ^ (~(x) & (z)))
+#define MAJ(x, y, z) (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
+#define EP0(x) (ROTRIGHT(x, 2) ^ ROTRIGHT(x, 13) ^ ROTRIGHT(x, 22))
+#define EP1(x) (ROTRIGHT(x, 6) ^ ROTRIGHT(x, 11) ^ ROTRIGHT(x, 25))
+#define SIG0(x) (ROTRIGHT(x, 7) ^ ROTRIGHT(x, 18) ^ ((x) >> 3))
+#define SIG1(x) (ROTRIGHT(x, 17) ^ ROTRIGHT(x, 19) ^ ((x) >> 10))
+
+static const uint32_t kSha256RoundConstants[64] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+};
+
+static void sha256_transform(AstrOsSha256Ctx *ctx, const uint8_t data[64])
+{
+    uint32_t a, b, c, d, e, f, g, h, t1, t2, m[64];
+    int i, j;
+
+    for (i = 0, j = 0; i < 16; ++i, j += 4)
+    {
+        m[i] = ((uint32_t)data[j] << 24) | ((uint32_t)data[j + 1] << 16) | ((uint32_t)data[j + 2] << 8) |
+               ((uint32_t)data[j + 3]);
+    }
+    for (; i < 64; ++i)
+    {
+        m[i] = SIG1(m[i - 2]) + m[i - 7] + SIG0(m[i - 15]) + m[i - 16];
+    }
+
+    a = ctx->state[0];
+    b = ctx->state[1];
+    c = ctx->state[2];
+    d = ctx->state[3];
+    e = ctx->state[4];
+    f = ctx->state[5];
+    g = ctx->state[6];
+    h = ctx->state[7];
+
+    for (i = 0; i < 64; ++i)
+    {
+        t1 = h + EP1(e) + CH(e, f, g) + kSha256RoundConstants[i] + m[i];
+        t2 = EP0(a) + MAJ(a, b, c);
+        h = g;
+        g = f;
+        f = e;
+        e = d + t1;
+        d = c;
+        c = b;
+        b = a;
+        a = t1 + t2;
+    }
+
+    ctx->state[0] += a;
+    ctx->state[1] += b;
+    ctx->state[2] += c;
+    ctx->state[3] += d;
+    ctx->state[4] += e;
+    ctx->state[5] += f;
+    ctx->state[6] += g;
+    ctx->state[7] += h;
+}
+
+void AstrOsSha256_init(AstrOsSha256Ctx *ctx)
+{
+    ctx->datalen = 0;
+    ctx->bitlen = 0;
+    ctx->state[0] = 0x6a09e667;
+    ctx->state[1] = 0xbb67ae85;
+    ctx->state[2] = 0x3c6ef372;
+    ctx->state[3] = 0xa54ff53a;
+    ctx->state[4] = 0x510e527f;
+    ctx->state[5] = 0x9b05688c;
+    ctx->state[6] = 0x1f83d9ab;
+    ctx->state[7] = 0x5be0cd19;
+}
+
+void AstrOsSha256_update(AstrOsSha256Ctx *ctx, const uint8_t *data, size_t len)
+{
+    for (size_t i = 0; i < len; ++i)
+    {
+        ctx->data[ctx->datalen] = data[i];
+        ctx->datalen++;
+        if (ctx->datalen == 64)
+        {
+            sha256_transform(ctx, ctx->data);
+            ctx->bitlen += 512;
+            ctx->datalen = 0;
+        }
+    }
+}
+
+void AstrOsSha256_final(AstrOsSha256Ctx *ctx, uint8_t hash[ASTROS_SHA256_DIGEST_LEN])
+{
+    uint32_t i = ctx->datalen;
+
+    // Pad with 0x80 then zeros, finishing the current block. If the
+    // residual already crosses 56 bytes we need an extra block to
+    // hold the 64-bit length field.
+    if (ctx->datalen < 56)
+    {
+        ctx->data[i++] = 0x80;
+        while (i < 56)
+        {
+            ctx->data[i++] = 0x00;
+        }
+    }
+    else
+    {
+        ctx->data[i++] = 0x80;
+        while (i < 64)
+        {
+            ctx->data[i++] = 0x00;
+        }
+        sha256_transform(ctx, ctx->data);
+        memset(ctx->data, 0, 56);
+    }
+
+    // Append the bit length in big-endian.
+    ctx->bitlen += (uint64_t)ctx->datalen * 8;
+    ctx->data[63] = (uint8_t)(ctx->bitlen);
+    ctx->data[62] = (uint8_t)(ctx->bitlen >> 8);
+    ctx->data[61] = (uint8_t)(ctx->bitlen >> 16);
+    ctx->data[60] = (uint8_t)(ctx->bitlen >> 24);
+    ctx->data[59] = (uint8_t)(ctx->bitlen >> 32);
+    ctx->data[58] = (uint8_t)(ctx->bitlen >> 40);
+    ctx->data[57] = (uint8_t)(ctx->bitlen >> 48);
+    ctx->data[56] = (uint8_t)(ctx->bitlen >> 56);
+    sha256_transform(ctx, ctx->data);
+
+    // Emit big-endian.
+    for (i = 0; i < 4; ++i)
+    {
+        hash[i] = (uint8_t)(ctx->state[0] >> (24 - i * 8));
+        hash[i + 4] = (uint8_t)(ctx->state[1] >> (24 - i * 8));
+        hash[i + 8] = (uint8_t)(ctx->state[2] >> (24 - i * 8));
+        hash[i + 12] = (uint8_t)(ctx->state[3] >> (24 - i * 8));
+        hash[i + 16] = (uint8_t)(ctx->state[4] >> (24 - i * 8));
+        hash[i + 20] = (uint8_t)(ctx->state[5] >> (24 - i * 8));
+        hash[i + 24] = (uint8_t)(ctx->state[6] >> (24 - i * 8));
+        hash[i + 28] = (uint8_t)(ctx->state[7] >> (24 - i * 8));
+    }
+}

--- a/test/test_native/astros_sha256_tests.cpp
+++ b/test/test_native/astros_sha256_tests.cpp
@@ -1,0 +1,114 @@
+#include <AstrOsSha256.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace
+{
+    std::string toHex(const uint8_t *bytes, size_t len)
+    {
+        static const char kHex[] = "0123456789abcdef";
+        std::string out;
+        out.resize(len * 2);
+        for (size_t i = 0; i < len; ++i)
+        {
+            out[2 * i] = kHex[(bytes[i] >> 4) & 0xF];
+            out[2 * i + 1] = kHex[bytes[i] & 0xF];
+        }
+        return out;
+    }
+
+    std::string sha256Hex(const uint8_t *data, size_t len)
+    {
+        AstrOsSha256Ctx ctx;
+        AstrOsSha256_init(&ctx);
+        AstrOsSha256_update(&ctx, data, len);
+        uint8_t digest[ASTROS_SHA256_DIGEST_LEN];
+        AstrOsSha256_final(&ctx, digest);
+        return toHex(digest, sizeof(digest));
+    }
+} // namespace
+
+// NIST FIPS-180-2 / RFC 6234 known-answer vectors.
+
+TEST(Sha256, EmptyInput)
+{
+    EXPECT_EQ("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", sha256Hex(nullptr, 0));
+}
+
+TEST(Sha256, Abc)
+{
+    const auto *data = reinterpret_cast<const uint8_t *>("abc");
+    EXPECT_EQ("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", sha256Hex(data, 3));
+}
+
+TEST(Sha256, TwoBlockBoundary448Bit)
+{
+    // Classic FIPS-180-2 example: 56-byte ASCII input forces the
+    // length-padding into a second compression block.
+    const char *msg = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
+    EXPECT_EQ("248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1",
+              sha256Hex(reinterpret_cast<const uint8_t *>(msg), 56));
+}
+
+TEST(Sha256, MillionA)
+{
+    // RFC 6234 third test vector: one million 'a' characters.
+    std::vector<uint8_t> data(1'000'000, static_cast<uint8_t>('a'));
+    EXPECT_EQ("cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0", sha256Hex(data.data(), data.size()));
+}
+
+TEST(Sha256, MultiUpdateMatchesSingleUpdate)
+{
+    // Same payload, split across many update calls of varying size.
+    // The OTA receiver feeds chunks of up to 4096 bytes; this guards
+    // the streaming path against an off-by-one in datalen handling
+    // across calls.
+    std::vector<uint8_t> data(10000);
+    for (size_t i = 0; i < data.size(); ++i)
+    {
+        data[i] = static_cast<uint8_t>(i * 31 + 7);
+    }
+    const std::string singleShot = sha256Hex(data.data(), data.size());
+
+    AstrOsSha256Ctx ctx;
+    AstrOsSha256_init(&ctx);
+    const size_t splits[] = {1, 63, 64, 65, 127, 128, 129, 1000, 4096};
+    size_t offset = 0;
+    size_t i = 0;
+    while (offset < data.size())
+    {
+        size_t take = splits[i % (sizeof(splits) / sizeof(splits[0]))];
+        if (offset + take > data.size())
+        {
+            take = data.size() - offset;
+        }
+        AstrOsSha256_update(&ctx, data.data() + offset, take);
+        offset += take;
+        ++i;
+    }
+    uint8_t digest[ASTROS_SHA256_DIGEST_LEN];
+    AstrOsSha256_final(&ctx, digest);
+    EXPECT_EQ(singleShot, toHex(digest, sizeof(digest)));
+}
+
+TEST(Sha256, ContextIsReusableAfterReinit)
+{
+    // After final + re-init the context must produce a fresh,
+    // correct digest with no carryover from the previous run.
+    AstrOsSha256Ctx ctx;
+    AstrOsSha256_init(&ctx);
+    const auto *first = reinterpret_cast<const uint8_t *>("hello");
+    AstrOsSha256_update(&ctx, first, 5);
+    uint8_t throwaway[ASTROS_SHA256_DIGEST_LEN];
+    AstrOsSha256_final(&ctx, throwaway);
+
+    AstrOsSha256_init(&ctx);
+    AstrOsSha256_update(&ctx, reinterpret_cast<const uint8_t *>("abc"), 3);
+    uint8_t digest[ASTROS_SHA256_DIGEST_LEN];
+    AstrOsSha256_final(&ctx, digest);
+    EXPECT_EQ("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", toHex(digest, sizeof(digest)));
+}


### PR DESCRIPTION
CONFIG_MBEDTLS_HARDWARE_SHA=y routes mbedtls_sha256_* through the ESP32-S3 SoC's shared SHA engine. Concurrent users of that engine elsewhere in the firmware were silently corrupting the OTA streaming digest's state while update returned success, producing deterministic FW_TRANSFER_END_ACK HASH_MISMATCH despite the bytes on the SD card matching the source byte-for-byte (verified: sha256sum staging.bin == sha256sum cache .bin, zero differing bytes via cmp -l).

Replace the OTA hash with Brad Conte's public-domain SHA-256 (~200 lines C) vendored into lib_native/AstrOsUtility. Identical behavior across boards, fully native-testable, no sdkconfig change so other subsystems keep their hardware SHA acceleration. NIST/RFC-6234 known-answer vectors cover empty, "abc", 56-byte two-block boundary, one-million-'a', multi-update split consistency, and context-reuse-after-final.

OtaReceiver swap drops mbedtls_sha256_init/_starts/_update/_finish/_free in favor of AstrOsSha256_init/_update/_final. Init is infallible (no heap), so the previously-unreachable init/finish error branches are removed. Also logs the first 16 bytes of seq=0 as a forensic anchor when chasing future end-to-end byte-divergence reports.