### PR TITLE
Feature/ota mesh forward m2 bulk sender

### DIFF
--- a/.docs/plans/20260523-1023-firmware-ota-mesh-forward-design.md
+++ b/.docs/plans/20260523-1023-firmware-ota-mesh-forward-design.md
@@ -655,6 +655,47 @@ Existing 309+ native tests must continue to pass. M2 adds ~6–8 new
    in their scope before writing code; otherwise a one-line patch can ship
    between M2 and M3 as scaffolding.
 
+8. **M3 must emit `tick()` retransmits before pulling new chunks** (raised by M2
+   PR-toolkit third-pass silent-failure review, 2026-05-23). `BulkSender::tick`
+   appends timed-out seqs to `TickResult::retransmitSeqs[]` but does NOT update
+   `nextSeqToSend_`. If M3's OtaForwarder loop calls `nextChunkToSend()` without
+   first emitting bytes for each entry in `retransmitSeqs[]`, those retransmits
+   silently never go on the wire. M3 must structure the loop as: tick → emit
+   retransmits → drain via nextChunkToSend.
+
+9. **M3 must consult `status()` to disambiguate `tick(count=0, abandon=false)`**
+   (raised by M2 PR-toolkit third-pass silent-failure review). `tick()` returns
+   the same shape for "STREAMING, no timeouts fired" and "non-STREAMING (DONE_OK
+   / ABANDONED / IDLE)". M3 must read `status()` separately to detect terminal
+   states; treating tick alone as the state oracle would leave a buggy forwarder
+   ticking forever on a finished or abandoned transfer.
+
+10. **NAK below the previously-ACKed watermark — protocol contract decision**
+    (raised by M2 PR-toolkit third-pass silent-failure review). A NAK with
+    `nextExpectedSeq=0` after `cumulativeSeq=0` was ACKed today rewinds and
+    re-emits seq 0, which the receiver will then NAK as STALE — burning wire
+    traffic until the timeout-driven abandonment kicks in. M3 should decide:
+    (a) reject such NAKs at the wire layer as protocol violations, OR (b) add
+    a `NakResult::Decision::REWIND_BELOW_WATERMARK` enumerator and force M3 to
+    abort the transfer explicitly.
+
+11. **`newlyConfirmedCount` semantics blend explicit + implicit confirmations**
+    (raised by M2 PR-toolkit third-pass silent-failure review). After a NAK
+    advances `highestConfirmedSeq_` via `impliedCumulative`, a later ACK's
+    `newlyConfirmedCount` includes the implicitly-confirmed seqs in `prev`. M3
+    should treat this field as "slots freed in the sender's in-flight table",
+    not as "wire-level OTA_DATA_ACK frames received from the padawan."
+
+12. **M3 abandonment path must check `TickResult::abandon` independent of
+    `count`** (raised by M2 PR-toolkit third-pass silent-failure review). The
+    abandon path sets `count=0` and exits before processing remaining in-flight
+    slots — any seqs already pushed to `retransmitSeqs[]` in earlier loop
+    iterations are intentionally discarded. M3's tick consumer must check
+    `abandon` first, then iterate retransmitSeqs only if `!abandon`. Treating
+    `count > 0 || abandon` as the "something happened" signal would correctly
+    fire on both paths, but treating `abandon` as orthogonal to count would
+    miss the M3 contract.
+
 ## Related documents
 
 - `.docs/plans/20260514-1941-firmware-ota-esp-master-serial-receive-design.md`

--- a/.docs/plans/20260523-1023-firmware-ota-mesh-forward-design.md
+++ b/.docs/plans/20260523-1023-firmware-ota-mesh-forward-design.md
@@ -696,6 +696,25 @@ Existing 309+ native tests must continue to pass. M2 adds ~6–8 new
     fire on both paths, but treating `abandon` as orthogonal to count would
     miss the M3 contract.
 
+13. **M3 wire-layer must log `OUT_OF_RANGE` distinctly from other rejections**
+    (raised by M2 PR-toolkit fourth-pass silent-failure review, 2026-05-24).
+    `BulkSender::onDataAck`/`onDataNak` reject ahead-of-sender peer input with
+    `Decision::OUT_OF_RANGE`. M3 cannot pre-validate against `highWaterSentSeq_`
+    because it's a private field — but M3's wire-layer log MUST distinguish
+    OUT_OF_RANGE from WRONG_XFER_ID / NOT_STREAMING when emitting forensic
+    detail. Otherwise a "peer ACK ahead of sender" attack would log identically
+    to a benign wrong-xferId mistake.
+
+14. **M3 progress counter must distinguish retransmits from fresh sends**
+    (raised by M2 PR-toolkit fourth-pass silent-failure review). After a NAK
+    rewinds nextSeqToSend_, subsequent `nextChunkToSend()` calls increment
+    nextSeqToSend_ but do NOT bump highWaterSentSeq_ (the `>` guard stops the
+    bump until nextSeqToSend_ regains and exceeds the old peak). M3 progress
+    counters (for FW_PROGRESS emission in M5) must not assume "successful
+    SendResult::send ⇒ new wire bytes for a new seq" — half of those may be
+    retransmits. Track "bytes confirmed by receiver" via highestConfirmedSeq_
+    rather than "bytes pushed to peer" via cumulative SEND count.
+
 ## Related documents
 
 - `.docs/plans/20260514-1941-firmware-ota-esp-master-serial-receive-design.md`

--- a/.docs/plans/20260523-1301-firmware-ota-mesh-forward-m2-bulk-sender.md
+++ b/.docs/plans/20260523-1301-firmware-ota-mesh-forward-m2-bulk-sender.md
@@ -1,0 +1,1495 @@
+# Firmware OTA Mesh-Forward M2 — BulkSender PURE Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a PURE `BulkSender` state machine alongside the existing `BulkReceiver` in `lib_native/AstrOsBulkTransport`, with sliding-window send semantics suitable for the master-side mesh forwarder that M3 will build on top. Zero firmware behavior change.
+
+**Architecture:** New `BulkSender` class lives in the existing PURE lib. Tracks per-seq in-flight state in a fixed-size `std::array<InFlightEntry, MAX_WINDOW_SIZE>` (no heap). Each result type follows the existing `ChunkResult` discipline: `const`-fields + private constructor + static factories, with `[[nodiscard]]` enforced at the type level. Wire-stable enum values pinned via `static_assert` at file scope. The state machine has 5 states (`IDLE → AWAITING_BEGIN_ACK → STREAMING → DONE_OK | ABANDONED`); `AWAITING_END_ACK` is implicit ("STREAMING with all seqs confirmed").
+
+**Tech Stack:** C++17, GoogleTest/GMock (native), PlatformIO `[env:test]` with `-std=gnu++2a`. PURE-lib: only `<cstdint>`, `<array>`, `<type_traits>`, `<cassert>` are needed beyond what `BulkReceiver` already pulls in.
+
+---
+
+## Context for the engineer
+
+Read these first — they're load-bearing and will not be re-explained per task:
+
+- **Design doc**: `.docs/plans/20260523-1023-firmware-ota-mesh-forward-design.md` — sections "Master side — BulkSender (PURE) + OtaForwarder (MIXED)" and "M2 — BulkSender PURE" are the contract.
+- **Existing precedent**: `lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp` and `.cpp`. `BulkReceiver` is the sister class. Mirror its discipline: result-type `const`-fields + private ctor + static factories (`ChunkResult` lines 87-147), `[[nodiscard]]` on every result struct (`BeginResult` line 154, `EndResult` line 181), file-scope `static_assert` pinning enum values (`AstrOsBulkTransport.cpp` lines 12-37 and 46-54), and per-method docstring explaining the invariants and error modes.
+- **Test file**: `test/test_native/bulk_transport_tests.cpp` (717 lines). Read the first 100 lines to see the test patterns: helper functions in anonymous namespaces, `TEST(BulkTransport, DescriptiveCamelCaseName)` style, no parameterized tests, explicit field-by-field expectations.
+- **Frozen wire contract**: `AstrOs.Server/.docs/completed_plans/2026/04/27/20260427-2202-firmware-ota-decomposition.md` section B — window=8 for ESP-NOW, ACK timeout 400 ms, 3 retries.
+- **Native-purity CI guard**: `.github/workflows/pr-validation.yml` enforces `lib_native/AstrOsBulkTransport` purity. M2 must not introduce any ESP-IDF / FreeRTOS / driver header.
+
+## File structure
+
+**Modified:**
+- `lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp` — append `BulkSender` class + 7 new result types (`BeginSenderResult`, `BeginAckResult`, `SendResult`, `AckResult`, `NakResult`, `TickResult`, `EndAckResult`) + `InFlightEntry` struct + `MAX_WINDOW_SIZE` constant. All inside the existing `namespace AstrOsBulkTransport`.
+- `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp` — append `BulkSender` method implementations + file-scope `static_assert` blocks pinning the new enum values.
+- `test/test_native/bulk_transport_tests.cpp` — append new section block "BulkSender" with ~11 tests. Anonymous-namespace helper `drainSends` for happy-path window pumping.
+
+No new files. No `lib/` (MIXED) changes. No `src/main.cpp` changes. No platformio.ini changes.
+
+## Wire-format reference (cross-check against frozen contract)
+
+| Field | Wire byte | Use in BulkSender |
+|---|---|---|
+| `OTA_DATA_ACK.highestContiguousSeq` (u32) | bytes 1-4 | Drives `onDataAck(xferId, cumulativeSeq)` |
+| `OTA_DATA_NAK.nextExpectedSeq` (u32) | bytes 5-8 | Drives `onDataNak(xferId, nextExpectedSeq, reason)` |
+| `OTA_DATA_NAK.reason` (u8) | byte 10 | `NakReason` already defined for BulkReceiver |
+| `OTA_END_ACK.status` (u8) | byte 1 | `OtaEndStatus` from M1 (`OtaWirePayloads.hpp`); drives `onEndAck(xferId, status)` |
+
+The PURE sender doesn't see ESP-NOW frame bytes directly — the MIXED layer in M3 will parse with M1's `parseOta*` free functions and call `BulkSender` methods with the unpacked values.
+
+---
+
+## Task 1: Result-type scaffolding + `BulkSender::begin` + `onBeginAck` + `reset`
+
+Lay the foundation: enum-based state machine, `MAX_WINDOW_SIZE` constant, `BeginSenderResult` and `BeginAckResult` result types with full factory discipline, plus the BEGIN-side state transitions. After this task, the sender can validate parameters and transition `IDLE → AWAITING_BEGIN_ACK → STREAMING`.
+
+**Files:**
+- Modify: `lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp`
+- Modify: `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp`
+- Modify: `test/test_native/bulk_transport_tests.cpp`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/test_native/bulk_transport_tests.cpp`:
+
+```cpp
+//=================================================================================================
+// BulkSender — M2 wire-format-compatible sender state machine.
+//
+// Mirrors BulkReceiver's result-type discipline: const-fields + private
+// constructor + static factories on each result, [[nodiscard]] enforced
+// per-type, file-scope static_assert pinning of wire-stable enum values.
+//=================================================================================================
+
+TEST(BulkTransport, BulkSenderStartsInIdle)
+{
+    AstrOsBulkTransport::BulkSender s;
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::IDLE, s.status());
+}
+
+TEST(BulkTransport, BulkSenderBeginAcceptsValidParams)
+{
+    AstrOsBulkTransport::BulkSender s;
+    auto r = s.begin(/*xferId=*/7, /*totalChunks=*/100, /*chunkSize=*/128,
+                     /*windowSize=*/8, /*ackTimeoutMs=*/400, /*maxRetries=*/3);
+    EXPECT_TRUE(r.valid);
+    EXPECT_EQ(AstrOsBulkTransport::BeginSenderResult::Reason::OK, r.reason);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::AWAITING_BEGIN_ACK, s.status());
+}
+
+TEST(BulkTransport, BulkSenderBeginRejectsZeroTotalChunks)
+{
+    AstrOsBulkTransport::BulkSender s;
+    auto r = s.begin(/*xferId=*/7, /*totalChunks=*/0, /*chunkSize=*/128,
+                     /*windowSize=*/8, /*ackTimeoutMs=*/400, /*maxRetries=*/3);
+    EXPECT_FALSE(r.valid);
+    EXPECT_EQ(AstrOsBulkTransport::BeginSenderResult::Reason::ZERO_TOTAL_CHUNKS, r.reason);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::IDLE, s.status());
+}
+
+TEST(BulkTransport, BulkSenderBeginRejectsZeroChunkSize)
+{
+    AstrOsBulkTransport::BulkSender s;
+    auto r = s.begin(7, 100, 0, 8, 400, 3);
+    EXPECT_FALSE(r.valid);
+    EXPECT_EQ(AstrOsBulkTransport::BeginSenderResult::Reason::ZERO_CHUNK_SIZE, r.reason);
+}
+
+TEST(BulkTransport, BulkSenderBeginRejectsZeroWindowSize)
+{
+    AstrOsBulkTransport::BulkSender s;
+    auto r = s.begin(7, 100, 128, 0, 400, 3);
+    EXPECT_FALSE(r.valid);
+    EXPECT_EQ(AstrOsBulkTransport::BeginSenderResult::Reason::ZERO_WINDOW_SIZE, r.reason);
+}
+
+TEST(BulkTransport, BulkSenderBeginRejectsZeroAckTimeout)
+{
+    AstrOsBulkTransport::BulkSender s;
+    auto r = s.begin(7, 100, 128, 8, 0, 3);
+    EXPECT_FALSE(r.valid);
+    EXPECT_EQ(AstrOsBulkTransport::BeginSenderResult::Reason::ZERO_ACK_TIMEOUT, r.reason);
+}
+
+TEST(BulkTransport, BulkSenderBeginRejectsZeroMaxRetries)
+{
+    AstrOsBulkTransport::BulkSender s;
+    auto r = s.begin(7, 100, 128, 8, 400, 0);
+    EXPECT_FALSE(r.valid);
+    EXPECT_EQ(AstrOsBulkTransport::BeginSenderResult::Reason::ZERO_MAX_RETRIES, r.reason);
+}
+
+TEST(BulkTransport, BulkSenderBeginRejectsWindowTooLarge)
+{
+    AstrOsBulkTransport::BulkSender s;
+    // MAX_WINDOW_SIZE = 16; windowSize = 17 must reject.
+    auto r = s.begin(7, 100, 128, 17, 400, 3);
+    EXPECT_FALSE(r.valid);
+    EXPECT_EQ(AstrOsBulkTransport::BeginSenderResult::Reason::WINDOW_TOO_LARGE, r.reason);
+}
+
+TEST(BulkTransport, BulkSenderOnBeginAckAdvancesToStreaming)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    auto r = s.onBeginAck(/*xferId=*/7);
+    EXPECT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, r.decision);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::STREAMING, s.status());
+}
+
+TEST(BulkTransport, BulkSenderOnBeginAckRejectsWrongXferId)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    auto r = s.onBeginAck(/*xferId=*/99);
+    EXPECT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::WRONG_XFER_ID, r.decision);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::AWAITING_BEGIN_ACK, s.status());
+}
+
+TEST(BulkTransport, BulkSenderOnBeginAckRejectsBeforeBegin)
+{
+    AstrOsBulkTransport::BulkSender s;
+    // No begin() called — status is IDLE.
+    auto r = s.onBeginAck(7);
+    EXPECT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::NOT_AWAITING_BEGIN_ACK, r.decision);
+}
+
+TEST(BulkTransport, BulkSenderResetReturnsToIdle)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BulkSender::Status::AWAITING_BEGIN_ACK, s.status());
+    s.reset();
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::IDLE, s.status());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pio test -e test --filter "*test_native*" 2>&1 | tail -20`
+Expected: compile errors — `BulkSender`, `BeginSenderResult`, `BeginAckResult` are not members of `AstrOsBulkTransport`.
+
+- [ ] **Step 3: Add the new types to the header**
+
+In `lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp`, append the following AFTER the existing `BulkReceiver` class definition but BEFORE the closing `}` of the `namespace AstrOsBulkTransport`:
+
+```cpp
+    // Maximum window size BulkSender supports. Covers both the
+    // ESP-NOW path (window=8 per the frozen contract) and the
+    // serial path (window=16 per the same contract). Bounds the
+    // in-flight table and TickResult retransmit array so the
+    // sender stays heap-free.
+    constexpr uint8_t MAX_WINDOW_SIZE = 16;
+
+    // One row of the BulkSender in-flight table. The sender keeps
+    // up to MAX_WINDOW_SIZE entries; each tracks a single sent-but-
+    // not-yet-acknowledged seq with its latest send-timestamp and
+    // retry count. Public for tests; not part of the wire contract.
+    struct InFlightEntry
+    {
+        uint32_t seq = 0;
+        uint64_t sendTimestampMs = 0;
+        uint8_t retryCount = 0;
+        bool occupied = false;
+    };
+
+    // [[nodiscard]] mirrors BulkReceiver::BeginResult — silently
+    // dropping the return value would leave the caller unable to
+    // distinguish "transfer ready" from "begin rejected, sender
+    // still IDLE", which is the silent-failure mode this attribute
+    // closes.
+    struct [[nodiscard]] BeginSenderResult
+    {
+        enum class Reason : uint8_t
+        {
+            OK = 0,
+            ZERO_TOTAL_CHUNKS = 1,
+            ZERO_CHUNK_SIZE = 2,
+            ZERO_WINDOW_SIZE = 3,
+            ZERO_ACK_TIMEOUT = 4,
+            ZERO_MAX_RETRIES = 5,
+            WINDOW_TOO_LARGE = 6 // windowSize > MAX_WINDOW_SIZE
+        };
+        bool valid = false;
+        Reason reason = Reason::ZERO_TOTAL_CHUNKS;
+
+        static BeginSenderResult ok()
+        {
+            return {true, Reason::OK};
+        }
+        static BeginSenderResult invalid(Reason r)
+        {
+            return {false, r};
+        }
+    };
+
+    struct [[nodiscard]] BeginAckResult
+    {
+        enum class Decision : uint8_t
+        {
+            OK = 0,
+            WRONG_XFER_ID = 1,
+            NOT_AWAITING_BEGIN_ACK = 2
+        };
+        Decision decision = Decision::NOT_AWAITING_BEGIN_ACK;
+
+        static BeginAckResult ok()
+        {
+            return {Decision::OK};
+        }
+        static BeginAckResult wrongXferId()
+        {
+            return {Decision::WRONG_XFER_ID};
+        }
+        static BeginAckResult notAwaiting()
+        {
+            return {Decision::NOT_AWAITING_BEGIN_ACK};
+        }
+    };
+
+    // Sliding-window sender state machine for the firmware OTA path.
+    // Used by the master-side OtaForwarder (M3) to push chunks to a
+    // padawan and react to ACK/NAK responses. PURE — no I/O, no
+    // FreeRTOS, no ESP-IDF. The MIXED caller does the actual byte
+    // emission; this class tracks "what to send next" and "is the
+    // transfer healthy".
+    //
+    // State machine:
+    //   IDLE
+    //     → AWAITING_BEGIN_ACK (via begin())
+    //     → STREAMING (via onBeginAck OK)
+    //         ⮨ self (per-chunk send/ack/nak/tick cycle)
+    //         → DONE_OK (via onEndAck OK)
+    //         → ABANDONED (via onEndAck != OK, OR tick(abandon=true))
+    //
+    // AWAITING_END_ACK is intentionally NOT a distinct state — it's
+    // implicit ("STREAMING with all seqs confirmed and in-flight
+    // table empty"). The MIXED caller checks SendResult::ALL_SENT
+    // to know when it's time to send OTA_END.
+    class BulkSender
+    {
+    public:
+        enum class Status : uint8_t
+        {
+            IDLE = 0,
+            AWAITING_BEGIN_ACK = 1,
+            STREAMING = 2,
+            DONE_OK = 3,
+            ABANDONED = 4
+        };
+
+        [[nodiscard]] BeginSenderResult begin(uint8_t xferId, uint32_t totalChunks, uint16_t chunkSize,
+                                              uint8_t windowSize, uint32_t ackTimeoutMs, uint8_t maxRetries);
+        [[nodiscard]] BeginAckResult onBeginAck(uint8_t xferId);
+        void reset();
+        Status status() const
+        {
+            return status_;
+        }
+
+    private:
+        uint8_t xferId_ = 0;
+        uint32_t totalChunks_ = 0;
+        uint16_t chunkSize_ = 0;
+        uint8_t windowSize_ = 0;
+        uint32_t ackTimeoutMs_ = 0;
+        uint8_t maxRetries_ = 0;
+
+        uint32_t nextSeqToSend_ = 0;
+        uint32_t highestConfirmedSeq_ = 0;
+        bool anyConfirmed_ = false; // disambiguates "seq 0 confirmed" from "nothing confirmed yet"
+
+        std::array<InFlightEntry, MAX_WINDOW_SIZE> inFlight_{};
+
+        Status status_ = Status::IDLE;
+    };
+```
+
+Also add the `<array>` include at the top of the file with the other includes:
+
+```cpp
+#include <array>
+#include <cstddef>
+#include <cstdint>
+```
+
+- [ ] **Step 4: Implement the methods**
+
+In `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp`, append at the end of the `namespace AstrOsBulkTransport` block (BEFORE the closing `}`):
+
+```cpp
+    // BulkSender::Status integer values are API-stable and consumed by
+    // switch statements in M3's OtaForwarder. Pin them so a future
+    // reorder breaks the build, not the dispatch.
+    static_assert(static_cast<uint8_t>(BulkSender::Status::IDLE) == 0);
+    static_assert(static_cast<uint8_t>(BulkSender::Status::AWAITING_BEGIN_ACK) == 1);
+    static_assert(static_cast<uint8_t>(BulkSender::Status::STREAMING) == 2);
+    static_assert(static_cast<uint8_t>(BulkSender::Status::DONE_OK) == 3);
+    static_assert(static_cast<uint8_t>(BulkSender::Status::ABANDONED) == 4);
+
+    static_assert(static_cast<uint8_t>(BeginSenderResult::Reason::OK) == 0);
+    static_assert(static_cast<uint8_t>(BeginSenderResult::Reason::ZERO_TOTAL_CHUNKS) == 1);
+    static_assert(static_cast<uint8_t>(BeginSenderResult::Reason::ZERO_CHUNK_SIZE) == 2);
+    static_assert(static_cast<uint8_t>(BeginSenderResult::Reason::ZERO_WINDOW_SIZE) == 3);
+    static_assert(static_cast<uint8_t>(BeginSenderResult::Reason::ZERO_ACK_TIMEOUT) == 4);
+    static_assert(static_cast<uint8_t>(BeginSenderResult::Reason::ZERO_MAX_RETRIES) == 5);
+    static_assert(static_cast<uint8_t>(BeginSenderResult::Reason::WINDOW_TOO_LARGE) == 6);
+
+    static_assert(static_cast<uint8_t>(BeginAckResult::Decision::OK) == 0);
+    static_assert(static_cast<uint8_t>(BeginAckResult::Decision::WRONG_XFER_ID) == 1);
+    static_assert(static_cast<uint8_t>(BeginAckResult::Decision::NOT_AWAITING_BEGIN_ACK) == 2);
+
+    BeginSenderResult BulkSender::begin(uint8_t xferId, uint32_t totalChunks, uint16_t chunkSize, uint8_t windowSize,
+                                        uint32_t ackTimeoutMs, uint8_t maxRetries)
+    {
+        // Reject protocol-illegal parameters in the order the contract
+        // freezes them. Each rejection leaves the sender in IDLE so a
+        // subsequent corrected begin() works cleanly. Order matters: a
+        // future reorder of these guards would change which Reason a
+        // caller sees for multi-fault input.
+        if (totalChunks == 0)
+        {
+            reset();
+            return BeginSenderResult::invalid(BeginSenderResult::Reason::ZERO_TOTAL_CHUNKS);
+        }
+        if (chunkSize == 0)
+        {
+            reset();
+            return BeginSenderResult::invalid(BeginSenderResult::Reason::ZERO_CHUNK_SIZE);
+        }
+        if (windowSize == 0)
+        {
+            reset();
+            return BeginSenderResult::invalid(BeginSenderResult::Reason::ZERO_WINDOW_SIZE);
+        }
+        if (windowSize > MAX_WINDOW_SIZE)
+        {
+            reset();
+            return BeginSenderResult::invalid(BeginSenderResult::Reason::WINDOW_TOO_LARGE);
+        }
+        if (ackTimeoutMs == 0)
+        {
+            reset();
+            return BeginSenderResult::invalid(BeginSenderResult::Reason::ZERO_ACK_TIMEOUT);
+        }
+        if (maxRetries == 0)
+        {
+            reset();
+            return BeginSenderResult::invalid(BeginSenderResult::Reason::ZERO_MAX_RETRIES);
+        }
+
+        xferId_ = xferId;
+        totalChunks_ = totalChunks;
+        chunkSize_ = chunkSize;
+        windowSize_ = windowSize;
+        ackTimeoutMs_ = ackTimeoutMs;
+        maxRetries_ = maxRetries;
+        nextSeqToSend_ = 0;
+        highestConfirmedSeq_ = 0;
+        anyConfirmed_ = false;
+        for (auto &e : inFlight_)
+        {
+            e = InFlightEntry{};
+        }
+        status_ = Status::AWAITING_BEGIN_ACK;
+        return BeginSenderResult::ok();
+    }
+
+    BeginAckResult BulkSender::onBeginAck(uint8_t xferId)
+    {
+        if (status_ != Status::AWAITING_BEGIN_ACK)
+        {
+            return BeginAckResult::notAwaiting();
+        }
+        if (xferId != xferId_)
+        {
+            return BeginAckResult::wrongXferId();
+        }
+        status_ = Status::STREAMING;
+        return BeginAckResult::ok();
+    }
+
+    void BulkSender::reset()
+    {
+        xferId_ = 0;
+        totalChunks_ = 0;
+        chunkSize_ = 0;
+        windowSize_ = 0;
+        ackTimeoutMs_ = 0;
+        maxRetries_ = 0;
+        nextSeqToSend_ = 0;
+        highestConfirmedSeq_ = 0;
+        anyConfirmed_ = false;
+        for (auto &e : inFlight_)
+        {
+            e = InFlightEntry{};
+        }
+        status_ = Status::IDLE;
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pio test -e test --filter "*test_native*" 2>&1 | tail -20`
+Expected: all 12 new `BulkTransport.BulkSender*` tests PASS.
+
+Full suite: `pio test -e test 2>&1 | tail -5`
+Expected: existing baseline + 12 new tests pass. (Baseline is `pio test -e test`'s pre-M2 count on `develop` after M1 merge.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp \
+        lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp \
+        test/test_native/bulk_transport_tests.cpp
+git commit -m "feat(bulk-transport): add BulkSender begin/onBeginAck/reset + scaffolding"
+```
+
+---
+
+## Task 2: `SendResult` + `nextChunkToSend` + in-flight table claim
+
+Add the send-side primitive. `nextChunkToSend(nowMs)` claims an in-flight slot, records the send timestamp, advances `nextSeqToSend_`, and returns the seq to emit. Returns `WINDOW_FULL` when the in-flight count reaches `windowSize_`, `ALL_SENT` when `nextSeqToSend_ >= totalChunks_`, or `NOT_STREAMING` if state is wrong.
+
+**Files:**
+- Modify: `lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp`
+- Modify: `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp`
+- Modify: `test/test_native/bulk_transport_tests.cpp`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/test_native/bulk_transport_tests.cpp`:
+
+```cpp
+namespace
+{
+    // Helper: drive `nextChunkToSend` in a loop until WINDOW_FULL or ALL_SENT.
+    // Records each emitted seq in `outSeqs`. Returns the final Decision.
+    AstrOsBulkTransport::SendResult::Decision drainSends(AstrOsBulkTransport::BulkSender &s, uint64_t nowMs,
+                                                          std::vector<uint32_t> &outSeqs)
+    {
+        for (;;)
+        {
+            auto r = s.nextChunkToSend(nowMs);
+            if (r.decision == AstrOsBulkTransport::SendResult::Decision::SEND)
+            {
+                outSeqs.push_back(r.seq);
+                continue;
+            }
+            return r.decision;
+        }
+    }
+} // namespace
+
+TEST(BulkTransport, BulkSenderNextChunkRejectedBeforeStreaming)
+{
+    AstrOsBulkTransport::BulkSender s;
+    auto r = s.nextChunkToSend(/*nowMs=*/0);
+    EXPECT_EQ(AstrOsBulkTransport::SendResult::Decision::NOT_STREAMING, r.decision);
+}
+
+TEST(BulkTransport, BulkSenderNextChunkAfterBeginAckEmitsSeqZero)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    auto r = s.nextChunkToSend(/*nowMs=*/1000);
+    EXPECT_EQ(AstrOsBulkTransport::SendResult::Decision::SEND, r.decision);
+    EXPECT_EQ(0u, r.seq);
+}
+
+TEST(BulkTransport, BulkSenderFillsWindowThenStopsWithWindowFull)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, /*totalChunks=*/100, 128, /*windowSize=*/8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    std::vector<uint32_t> sent;
+    auto terminal = drainSends(s, 1000, sent);
+
+    EXPECT_EQ(AstrOsBulkTransport::SendResult::Decision::WINDOW_FULL, terminal);
+    ASSERT_EQ(8u, sent.size());
+    for (uint32_t i = 0; i < 8; i++)
+    {
+        EXPECT_EQ(i, sent[i]);
+    }
+}
+
+TEST(BulkTransport, BulkSenderEmitsAllChunksWhenTotalIsBelowWindow)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, /*totalChunks=*/3, 128, /*windowSize=*/8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    std::vector<uint32_t> sent;
+    auto terminal = drainSends(s, 1000, sent);
+
+    EXPECT_EQ(AstrOsBulkTransport::SendResult::Decision::ALL_SENT, terminal);
+    ASSERT_EQ(3u, sent.size());
+    EXPECT_EQ(0u, sent[0]);
+    EXPECT_EQ(1u, sent[1]);
+    EXPECT_EQ(2u, sent[2]);
+}
+```
+
+Also ensure `#include <vector>` is at the top of the test file (it should already be there from the existing tests; if not, add it).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pio test -e test --filter "*test_native*" 2>&1 | tail -20`
+Expected: compile errors — `SendResult` and `BulkSender::nextChunkToSend` don't exist.
+
+- [ ] **Step 3: Add `SendResult` and the method declaration**
+
+In `lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp`, add the `SendResult` struct AFTER `BeginAckResult` and BEFORE the `BulkSender` class:
+
+```cpp
+    // Result of BulkSender::nextChunkToSend. On SEND, `seq` is the seq
+    // to emit on the wire and the in-flight table now owns a slot for
+    // it. Other Decisions leave the sender state unchanged.
+    //
+    // Const-fields + private constructor mirror ChunkResult's
+    // discipline so a returned result cannot be mutated into an
+    // invalid combination (e.g. WINDOW_FULL with a real seq).
+    struct SendResult
+    {
+        enum class Decision : uint8_t
+        {
+            SEND = 0,          // emit `seq` on the wire
+            WINDOW_FULL = 1,   // in-flight count == windowSize; ACK something first
+            ALL_SENT = 2,      // nextSeqToSend_ == totalChunks_; nothing left to send
+            NOT_STREAMING = 3  // status != STREAMING
+        };
+
+        const Decision decision;
+        const uint32_t seq;
+
+        static SendResult send(uint32_t s)
+        {
+            return SendResult(Decision::SEND, s);
+        }
+        static SendResult windowFull()
+        {
+            return SendResult(Decision::WINDOW_FULL, 0);
+        }
+        static SendResult allSent()
+        {
+            return SendResult(Decision::ALL_SENT, 0);
+        }
+        static SendResult notStreaming()
+        {
+            return SendResult(Decision::NOT_STREAMING, 0);
+        }
+
+    private:
+        SendResult(Decision d, uint32_t s) : decision(d), seq(s)
+        {
+        }
+    };
+```
+
+Add the declaration to the `BulkSender` `public:` section (after `onBeginAck`, before `reset`):
+
+```cpp
+        [[nodiscard]] SendResult nextChunkToSend(uint64_t nowMs);
+```
+
+- [ ] **Step 4: Implement `nextChunkToSend`**
+
+In `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp`, append to the `namespace AstrOsBulkTransport` block:
+
+Add the static_asserts near the other BulkSender ones:
+
+```cpp
+    static_assert(static_cast<uint8_t>(SendResult::Decision::SEND) == 0);
+    static_assert(static_cast<uint8_t>(SendResult::Decision::WINDOW_FULL) == 1);
+    static_assert(static_cast<uint8_t>(SendResult::Decision::ALL_SENT) == 2);
+    static_assert(static_cast<uint8_t>(SendResult::Decision::NOT_STREAMING) == 3);
+
+    // SendResult immutability: every public field must be const so a
+    // factory-produced result can't be mutated into an invalid combo
+    // (WINDOW_FULL with a meaningful seq, etc.). Mirrors ChunkResult's
+    // discipline.
+    static_assert(std::is_const_v<decltype(SendResult::decision)>);
+    static_assert(std::is_const_v<decltype(SendResult::seq)>);
+    static_assert(!std::is_copy_assignable_v<SendResult>);
+    static_assert(std::is_copy_constructible_v<SendResult>);
+```
+
+Add the method implementation:
+
+```cpp
+    SendResult BulkSender::nextChunkToSend(uint64_t nowMs)
+    {
+        if (status_ != Status::STREAMING)
+        {
+            return SendResult::notStreaming();
+        }
+
+        // ALL_SENT check first: if every chunk has been launched into
+        // the in-flight table (or already evicted by ACK), there's
+        // nothing left to claim. The MIXED caller treats ALL_SENT
+        // (plus an empty in-flight table) as the signal to send OTA_END.
+        if (nextSeqToSend_ >= totalChunks_)
+        {
+            return SendResult::allSent();
+        }
+
+        // Count occupied slots. WINDOW_FULL fires when we've already
+        // launched `windowSize_` chunks that haven't been acked yet.
+        // O(MAX_WINDOW_SIZE) linear scan; trivial at 16 entries.
+        uint8_t occupied = 0;
+        for (const auto &e : inFlight_)
+        {
+            if (e.occupied)
+            {
+                occupied++;
+            }
+        }
+        if (occupied >= windowSize_)
+        {
+            return SendResult::windowFull();
+        }
+
+        // Claim the first unoccupied slot. The slot index is internal;
+        // callers identify chunks by seq, not slot.
+        for (auto &e : inFlight_)
+        {
+            if (!e.occupied)
+            {
+                e.seq = nextSeqToSend_;
+                e.sendTimestampMs = nowMs;
+                e.retryCount = 0;
+                e.occupied = true;
+                const uint32_t emittedSeq = nextSeqToSend_;
+                nextSeqToSend_++;
+                return SendResult::send(emittedSeq);
+            }
+        }
+
+        // Unreachable: if `occupied < windowSize_ <= MAX_WINDOW_SIZE`,
+        // at least one slot is free. The early-return above already
+        // returned WINDOW_FULL in the full case.
+        assert(false && "BulkSender::nextChunkToSend: in-flight table full despite occupied < windowSize_");
+        std::abort();
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pio test -e test --filter "*test_native*" 2>&1 | tail -20`
+Expected: 4 new tests PASS.
+
+Full suite: `pio test -e test 2>&1 | tail -5`
+Expected: existing tests + cumulative new tests pass (12 from T1 + 4 from T2 = 16 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp \
+        lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp \
+        test/test_native/bulk_transport_tests.cpp
+git commit -m "feat(bulk-transport): add BulkSender::nextChunkToSend + SendResult"
+```
+
+---
+
+## Task 3: `AckResult` + `NakResult` + `onDataAck` + `onDataNak`
+
+Add cumulative-ACK and NAK handling. `onDataAck` advances `highestConfirmedSeq_` and evicts confirmed in-flight slots. `onDataNak` rewinds `nextSeqToSend_` and evicts seqs >= the NAK's nextExpectedSeq, so the next `nextChunkToSend` call resends from the right point.
+
+**Files:**
+- Modify: `lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp`
+- Modify: `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp`
+- Modify: `test/test_native/bulk_transport_tests.cpp`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/test_native/bulk_transport_tests.cpp`:
+
+```cpp
+TEST(BulkTransport, BulkSenderOnDataAckAdvancesHighestConfirmed)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    std::vector<uint32_t> sent;
+    drainSends(s, 1000, sent);
+    ASSERT_EQ(8u, sent.size()); // window full at 0..7
+
+    // Cumulative ACK up through seq 3: frees slots for 0..3.
+    auto r = s.onDataAck(7, /*cumulativeSeq=*/3);
+    EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::OK, r.decision);
+    EXPECT_EQ(4u, r.newlyConfirmedCount); // seqs 0, 1, 2, 3 newly confirmed
+
+    // Now nextChunkToSend should emit seq 8 (window frees 4 slots).
+    auto sr = s.nextChunkToSend(1100);
+    EXPECT_EQ(AstrOsBulkTransport::SendResult::Decision::SEND, sr.decision);
+    EXPECT_EQ(8u, sr.seq);
+}
+
+TEST(BulkTransport, BulkSenderRejectsStaleAck)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    std::vector<uint32_t> sent;
+    drainSends(s, 1000, sent);
+
+    ASSERT_EQ(AstrOsBulkTransport::AckResult::Decision::OK, s.onDataAck(7, 5).decision);
+    // Stale: cumulativeSeq=3 already covered by the previous ACK at 5.
+    auto r = s.onDataAck(7, 3);
+    EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::STALE, r.decision);
+}
+
+TEST(BulkTransport, BulkSenderOnDataAckRejectsWrongXferId)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+    auto r = s.onDataAck(/*xferId=*/99, 3);
+    EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::WRONG_XFER_ID, r.decision);
+}
+
+TEST(BulkTransport, BulkSenderOnDataAckRejectsBeforeStreaming)
+{
+    AstrOsBulkTransport::BulkSender s;
+    // No begin / onBeginAck — status is IDLE.
+    auto r = s.onDataAck(7, 0);
+    EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::NOT_STREAMING, r.decision);
+}
+
+TEST(BulkTransport, BulkSenderOnDataNakRewindsToNextExpectedSeq)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    std::vector<uint32_t> sent;
+    drainSends(s, 1000, sent);
+    ASSERT_EQ(8u, sent.size()); // sent 0..7
+
+    // Receiver NAKs with nextExpectedSeq=3 — meaning seqs 0..2 are OK,
+    // but seq 3 needs retransmission (and 4..7 will be discarded by
+    // the receiver since they're out of order).
+    auto r = s.onDataNak(7, /*nextExpectedSeq=*/3, AstrOsBulkTransport::NakReason::CRC);
+    EXPECT_EQ(AstrOsBulkTransport::NakResult::Decision::OK, r.decision);
+    EXPECT_EQ(3u, r.nextSeqToResend);
+
+    // The next send should re-emit seq 3 (not 8).
+    auto sr = s.nextChunkToSend(1100);
+    EXPECT_EQ(AstrOsBulkTransport::SendResult::Decision::SEND, sr.decision);
+    EXPECT_EQ(3u, sr.seq);
+}
+
+TEST(BulkTransport, BulkSenderOnDataNakRejectsWrongXferId)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+    auto r = s.onDataNak(/*xferId=*/99, 3, AstrOsBulkTransport::NakReason::CRC);
+    EXPECT_EQ(AstrOsBulkTransport::NakResult::Decision::WRONG_XFER_ID, r.decision);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pio test -e test --filter "*test_native*" 2>&1 | tail -20`
+Expected: compile errors — `AckResult`, `NakResult`, `BulkSender::onDataAck`, `BulkSender::onDataNak` don't exist.
+
+- [ ] **Step 3: Add `AckResult` and `NakResult` to the header**
+
+In `lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp`, add AFTER `SendResult` and BEFORE the `BulkSender` class:
+
+```cpp
+    // Result of BulkSender::onDataAck. On OK, `newlyConfirmedCount` is
+    // the number of in-flight slots freed by this cumulative ACK —
+    // useful when the caller wants to know "did room open up that
+    // wasn't there before?" without diffing internal state.
+    struct AckResult
+    {
+        enum class Decision : uint8_t
+        {
+            OK = 0,
+            WRONG_XFER_ID = 1,
+            NOT_STREAMING = 2,
+            STALE = 3 // cumulativeSeq <= highestConfirmedSeq_ (already covered)
+        };
+
+        const Decision decision;
+        const uint32_t newlyConfirmedCount;
+
+        static AckResult ok(uint32_t n)
+        {
+            return AckResult(Decision::OK, n);
+        }
+        static AckResult wrongXferId()
+        {
+            return AckResult(Decision::WRONG_XFER_ID, 0);
+        }
+        static AckResult notStreaming()
+        {
+            return AckResult(Decision::NOT_STREAMING, 0);
+        }
+        static AckResult stale()
+        {
+            return AckResult(Decision::STALE, 0);
+        }
+
+    private:
+        AckResult(Decision d, uint32_t n) : decision(d), newlyConfirmedCount(n)
+        {
+        }
+    };
+
+    // Result of BulkSender::onDataNak. On OK, `nextSeqToResend` is the
+    // seq that the next `nextChunkToSend` call will emit (mirrors the
+    // wire-level `nextExpectedSeq` field from OTA_DATA_NAK).
+    struct NakResult
+    {
+        enum class Decision : uint8_t
+        {
+            OK = 0,
+            WRONG_XFER_ID = 1,
+            NOT_STREAMING = 2
+        };
+
+        const Decision decision;
+        const uint32_t nextSeqToResend;
+
+        static NakResult ok(uint32_t s)
+        {
+            return NakResult(Decision::OK, s);
+        }
+        static NakResult wrongXferId()
+        {
+            return NakResult(Decision::WRONG_XFER_ID, 0);
+        }
+        static NakResult notStreaming()
+        {
+            return NakResult(Decision::NOT_STREAMING, 0);
+        }
+
+    private:
+        NakResult(Decision d, uint32_t s) : decision(d), nextSeqToResend(s)
+        {
+        }
+    };
+```
+
+Add to the `BulkSender` `public:` section:
+
+```cpp
+        [[nodiscard]] AckResult onDataAck(uint8_t xferId, uint32_t cumulativeSeq);
+        [[nodiscard]] NakResult onDataNak(uint8_t xferId, uint32_t nextExpectedSeq, NakReason reason);
+```
+
+- [ ] **Step 4: Implement the methods**
+
+In `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp`, add the static_asserts:
+
+```cpp
+    static_assert(static_cast<uint8_t>(AckResult::Decision::OK) == 0);
+    static_assert(static_cast<uint8_t>(AckResult::Decision::WRONG_XFER_ID) == 1);
+    static_assert(static_cast<uint8_t>(AckResult::Decision::NOT_STREAMING) == 2);
+    static_assert(static_cast<uint8_t>(AckResult::Decision::STALE) == 3);
+
+    static_assert(static_cast<uint8_t>(NakResult::Decision::OK) == 0);
+    static_assert(static_cast<uint8_t>(NakResult::Decision::WRONG_XFER_ID) == 1);
+    static_assert(static_cast<uint8_t>(NakResult::Decision::NOT_STREAMING) == 2);
+
+    static_assert(std::is_const_v<decltype(AckResult::decision)>);
+    static_assert(std::is_const_v<decltype(AckResult::newlyConfirmedCount)>);
+    static_assert(!std::is_copy_assignable_v<AckResult>);
+
+    static_assert(std::is_const_v<decltype(NakResult::decision)>);
+    static_assert(std::is_const_v<decltype(NakResult::nextSeqToResend)>);
+    static_assert(!std::is_copy_assignable_v<NakResult>);
+```
+
+Add the method implementations:
+
+```cpp
+    AckResult BulkSender::onDataAck(uint8_t xferId, uint32_t cumulativeSeq)
+    {
+        if (status_ != Status::STREAMING)
+        {
+            return AckResult::notStreaming();
+        }
+        if (xferId != xferId_)
+        {
+            return AckResult::wrongXferId();
+        }
+        // Stale check: cumulativeSeq must strictly advance from the
+        // previous high-water mark. The `anyConfirmed_` flag
+        // disambiguates "no ACK yet seen" (any cumulativeSeq is fresh)
+        // from "seq 0 already confirmed" (only cumulativeSeq > 0 is
+        // fresh).
+        if (anyConfirmed_ && cumulativeSeq <= highestConfirmedSeq_)
+        {
+            return AckResult::stale();
+        }
+
+        const uint32_t prev = anyConfirmed_ ? highestConfirmedSeq_ + 1 : 0;
+        highestConfirmedSeq_ = cumulativeSeq;
+        anyConfirmed_ = true;
+
+        // Evict all in-flight slots whose seq <= cumulativeSeq.
+        for (auto &e : inFlight_)
+        {
+            if (e.occupied && e.seq <= cumulativeSeq)
+            {
+                e = InFlightEntry{};
+            }
+        }
+
+        const uint32_t newlyConfirmed = cumulativeSeq + 1 - prev;
+        return AckResult::ok(newlyConfirmed);
+    }
+
+    NakResult BulkSender::onDataNak(uint8_t xferId, uint32_t nextExpectedSeq, NakReason /*reason*/)
+    {
+        if (status_ != Status::STREAMING)
+        {
+            return NakResult::notStreaming();
+        }
+        if (xferId != xferId_)
+        {
+            return NakResult::wrongXferId();
+        }
+
+        // Rewind: future sends start from nextExpectedSeq. Evict all
+        // in-flight slots whose seq >= nextExpectedSeq — they were
+        // either NAK'd directly or discarded by the receiver as out-
+        // of-order. The MIXED layer doesn't need to know which slot
+        // belongs to which seq; it just calls nextChunkToSend in a
+        // loop after a NAK.
+        //
+        // Reason is currently unused by the state machine (the wire
+        // layer logs it in M3); it's in the signature so future
+        // reason-aware retry policies don't break the API.
+        nextSeqToSend_ = nextExpectedSeq;
+        for (auto &e : inFlight_)
+        {
+            if (e.occupied && e.seq >= nextExpectedSeq)
+            {
+                e = InFlightEntry{};
+            }
+        }
+        return NakResult::ok(nextExpectedSeq);
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pio test -e test --filter "*test_native*" 2>&1 | tail -20`
+Expected: 6 new tests PASS.
+
+Full suite: `pio test -e test 2>&1 | tail -5`
+Expected: all tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp \
+        lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp \
+        test/test_native/bulk_transport_tests.cpp
+git commit -m "feat(bulk-transport): add BulkSender onDataAck + onDataNak"
+```
+
+---
+
+## Task 4: `TickResult` + `tick` + retry/abandon
+
+Add timer-driven retransmission. `tick(nowMs)` scans the in-flight table; for each occupied slot whose `sendTimestampMs + ackTimeoutMs_ <= nowMs`, it increments `retryCount` (if not over the cap), resets `sendTimestampMs` to `nowMs`, and appends the seq to `TickResult::retransmitSeqs`. If any slot's `retryCount` would exceed `maxRetries_`, transition to `ABANDONED` and set `TickResult::abandon = true`.
+
+**Files:**
+- Modify: `lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp`
+- Modify: `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp`
+- Modify: `test/test_native/bulk_transport_tests.cpp`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/test_native/bulk_transport_tests.cpp`:
+
+```cpp
+TEST(BulkTransport, BulkSenderTickReturnsNothingWhenNoTimeoutsFired)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, /*ackTimeoutMs=*/400, /*maxRetries=*/3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    std::vector<uint32_t> sent;
+    drainSends(s, /*nowMs=*/1000, sent);
+    ASSERT_EQ(8u, sent.size());
+
+    auto t = s.tick(/*nowMs=*/1100); // only 100 ms passed — under the 400 ms timeout
+    EXPECT_EQ(0, t.count);
+    EXPECT_FALSE(t.abandon);
+}
+
+TEST(BulkTransport, BulkSenderTickRetransmitsTimedOutSeqs)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    std::vector<uint32_t> sent;
+    drainSends(s, 1000, sent);
+
+    auto t = s.tick(/*nowMs=*/1500); // 500 ms passed — past the 400 ms timeout
+    EXPECT_EQ(8, t.count);
+    EXPECT_FALSE(t.abandon);
+    // All 8 in-flight seqs should be flagged for retransmission.
+    for (uint8_t i = 0; i < 8; i++)
+    {
+        EXPECT_EQ(i, t.retransmitSeqs[i]);
+    }
+}
+
+TEST(BulkTransport, BulkSenderTickAbandonsAfterMaxRetries)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, /*ackTimeoutMs=*/400, /*maxRetries=*/2).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    std::vector<uint32_t> sent;
+    drainSends(s, 0, sent);
+
+    // First tick at 500 ms: retryCount 0 → 1 for every seq.
+    auto t1 = s.tick(500);
+    EXPECT_EQ(8, t1.count);
+    EXPECT_FALSE(t1.abandon);
+
+    // Second tick at 1000 ms: retryCount 1 → 2 for every seq.
+    auto t2 = s.tick(1000);
+    EXPECT_EQ(8, t2.count);
+    EXPECT_FALSE(t2.abandon);
+
+    // Third tick at 1500 ms: retryCount would go 2 → 3 (> maxRetries=2).
+    // Abandon, no further retransmissions.
+    auto t3 = s.tick(1500);
+    EXPECT_TRUE(t3.abandon);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::ABANDONED, s.status());
+}
+
+TEST(BulkTransport, BulkSenderTickReturnsZeroOnInactive)
+{
+    AstrOsBulkTransport::BulkSender s;
+    // Never called begin — IDLE.
+    auto t = s.tick(10000);
+    EXPECT_EQ(0, t.count);
+    EXPECT_FALSE(t.abandon);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pio test -e test --filter "*test_native*" 2>&1 | tail -20`
+Expected: compile errors — `TickResult`, `BulkSender::tick` don't exist.
+
+- [ ] **Step 3: Add `TickResult` and the method declaration**
+
+In `lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp`, add AFTER `NakResult` and BEFORE the `BulkSender` class:
+
+```cpp
+    // Result of BulkSender::tick. `retransmitSeqs[0..count-1]` are the
+    // seqs whose ackTimeout fired and need re-emission on the wire.
+    // `abandon` is set when any seq's retryCount would exceed
+    // maxRetries — at that point the sender transitions to ABANDONED
+    // and stops issuing further retransmit lists.
+    //
+    // Bounded by MAX_WINDOW_SIZE so this struct stays heap-free. A
+    // single tick can produce at most `windowSize` retransmissions
+    // (the in-flight table is the upper bound).
+    struct TickResult
+    {
+        std::array<uint32_t, MAX_WINDOW_SIZE> retransmitSeqs;
+        uint8_t count = 0;
+        bool abandon = false;
+    };
+```
+
+Add to the `BulkSender` `public:` section:
+
+```cpp
+        [[nodiscard]] TickResult tick(uint64_t nowMs);
+```
+
+Note: `TickResult` does NOT use the const-fields-private-ctor pattern because the fields are written by `tick` directly (count up to count, then return). The other result types are pure observations of an event; `TickResult` is structurally an output buffer. Convention: zero-initialize the array and trust `count`.
+
+- [ ] **Step 4: Implement `tick`**
+
+In `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp`, add the method implementation:
+
+```cpp
+    TickResult BulkSender::tick(uint64_t nowMs)
+    {
+        TickResult result{};
+        if (status_ != Status::STREAMING)
+        {
+            return result;
+        }
+
+        for (auto &e : inFlight_)
+        {
+            if (!e.occupied)
+            {
+                continue;
+            }
+            // Timeout fired iff (nowMs - sendTimestampMs) >= ackTimeoutMs_.
+            // Use subtraction in uint64_t so wrap-around isn't a concern at
+            // typical millisecond scales; if a future caller passes nowMs <
+            // sendTimestampMs (clock went backwards), the underflow wraps
+            // to a huge value and the timeout looks "fired" — acceptable
+            // failure mode (retransmits a slot that wasn't actually timed
+            // out). The MIXED caller is responsible for monotonic time.
+            if (nowMs - e.sendTimestampMs < ackTimeoutMs_)
+            {
+                continue;
+            }
+
+            // Retry count check: if incrementing would exceed maxRetries_,
+            // abandon the whole transfer immediately. The wire-level
+            // contract says "abort this padawan, move to next" — at the
+            // PURE layer we just transition to ABANDONED.
+            if (e.retryCount + 1 > maxRetries_)
+            {
+                status_ = Status::ABANDONED;
+                result.abandon = true;
+                result.count = 0;
+                return result;
+            }
+
+            e.retryCount++;
+            e.sendTimestampMs = nowMs;
+            result.retransmitSeqs[result.count] = e.seq;
+            result.count++;
+        }
+        return result;
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pio test -e test --filter "*test_native*" 2>&1 | tail -20`
+Expected: 4 new tests PASS.
+
+Full suite: `pio test -e test 2>&1 | tail -5`
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp \
+        lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp \
+        test/test_native/bulk_transport_tests.cpp
+git commit -m "feat(bulk-transport): add BulkSender::tick + retry/abandon"
+```
+
+---
+
+## Task 5: `EndAckResult` + `onEndAck` + end-to-end integration test
+
+Add the terminal-state transitions. `onEndAck(xferId, OtaEndStatus)` validates the transfer ID, then transitions to `DONE_OK` if status==OK or `ABANDONED` otherwise. Plus one end-to-end integration test that drives a sender through a full happy-path transfer using all the M2 primitives together.
+
+**Files:**
+- Modify: `lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp`
+- Modify: `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp`
+- Modify: `test/test_native/bulk_transport_tests.cpp`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/test_native/bulk_transport_tests.cpp`:
+
+```cpp
+TEST(BulkTransport, BulkSenderOnEndAckOkTransitionsToDoneOk)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    auto r = s.onEndAck(7, OtaEndStatus::OK);
+    EXPECT_EQ(AstrOsBulkTransport::EndAckResult::Decision::DONE_OK, r.decision);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::DONE_OK, s.status());
+}
+
+TEST(BulkTransport, BulkSenderOnEndAckHashMismatchAbandons)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    auto r = s.onEndAck(7, OtaEndStatus::HASH_MISMATCH);
+    EXPECT_EQ(AstrOsBulkTransport::EndAckResult::Decision::ABANDONED, r.decision);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::ABANDONED, s.status());
+}
+
+TEST(BulkTransport, BulkSenderOnEndAckWriteErrorAbandons)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    auto r = s.onEndAck(7, OtaEndStatus::WRITE_ERROR);
+    EXPECT_EQ(AstrOsBulkTransport::EndAckResult::Decision::ABANDONED, r.decision);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::ABANDONED, s.status());
+}
+
+TEST(BulkTransport, BulkSenderOnEndAckRejectsWrongXferId)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+    auto r = s.onEndAck(/*xferId=*/99, OtaEndStatus::OK);
+    EXPECT_EQ(AstrOsBulkTransport::EndAckResult::Decision::WRONG_XFER_ID, r.decision);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::STREAMING, s.status());
+}
+
+TEST(BulkTransport, BulkSenderEndToEndHappyPath)
+{
+    // Drives the full state machine through a small transfer with the
+    // exact API call pattern M3's OtaForwarder will use.
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(/*xferId=*/42, /*totalChunks=*/4, 128, /*windowSize=*/4, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BulkSender::Status::AWAITING_BEGIN_ACK, s.status());
+
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(42).decision);
+    ASSERT_EQ(AstrOsBulkTransport::BulkSender::Status::STREAMING, s.status());
+
+    // Pump nextChunkToSend until ALL_SENT.
+    std::vector<uint32_t> sent;
+    auto term = drainSends(s, 1000, sent);
+    EXPECT_EQ(AstrOsBulkTransport::SendResult::Decision::WINDOW_FULL, term);
+    ASSERT_EQ(4u, sent.size()); // window=4 fills before reaching ALL_SENT
+
+    // Receiver cumulatively ACKs all 4.
+    auto ackR = s.onDataAck(42, /*cumulativeSeq=*/3);
+    EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::OK, ackR.decision);
+    EXPECT_EQ(4u, ackR.newlyConfirmedCount);
+
+    // Try to send more — should report ALL_SENT (since all 4 chunks were already emitted).
+    auto sendR = s.nextChunkToSend(1100);
+    EXPECT_EQ(AstrOsBulkTransport::SendResult::Decision::ALL_SENT, sendR.decision);
+
+    // Send OTA_END, receiver replies OK.
+    auto endR = s.onEndAck(42, OtaEndStatus::OK);
+    EXPECT_EQ(AstrOsBulkTransport::EndAckResult::Decision::DONE_OK, endR.decision);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::DONE_OK, s.status());
+}
+```
+
+Note: the tests use `OtaEndStatus` from M1 (`OtaWirePayloads.hpp`). That's pulled in transitively via `<AstrOsBulkTransport.hpp>` once we add the include below.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pio test -e test --filter "*test_native*" 2>&1 | tail -20`
+Expected: compile errors — `EndAckResult`, `BulkSender::onEndAck`, `OtaEndStatus` not visible.
+
+- [ ] **Step 3: Add `EndAckResult` and pull in M1's wire payloads**
+
+In `lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp`, add the include at the top (after the existing `<cstdint>` etc.):
+
+```cpp
+#include <OtaWirePayloads.hpp>
+```
+
+This pulls in `OtaEndStatus` from M1's PURE wire-format header. Both libs are in `lib_native/`, so the include resolves cleanly through PlatformIO's `lib_extra_dirs = lib_native` setting.
+
+Add the `EndAckResult` struct AFTER `TickResult` and BEFORE the `BulkSender` class:
+
+```cpp
+    // Result of BulkSender::onEndAck. Terminal transitions only —
+    // after DONE_OK or ABANDONED the sender stays in that state until
+    // reset(). WRONG_XFER_ID and NOT_STREAMING leave state unchanged.
+    struct EndAckResult
+    {
+        enum class Decision : uint8_t
+        {
+            DONE_OK = 0,
+            ABANDONED = 1,
+            WRONG_XFER_ID = 2,
+            NOT_STREAMING = 3
+        };
+
+        const Decision decision;
+
+        static EndAckResult doneOk()
+        {
+            return EndAckResult(Decision::DONE_OK);
+        }
+        static EndAckResult abandoned()
+        {
+            return EndAckResult(Decision::ABANDONED);
+        }
+        static EndAckResult wrongXferId()
+        {
+            return EndAckResult(Decision::WRONG_XFER_ID);
+        }
+        static EndAckResult notStreaming()
+        {
+            return EndAckResult(Decision::NOT_STREAMING);
+        }
+
+    private:
+        explicit EndAckResult(Decision d) : decision(d)
+        {
+        }
+    };
+```
+
+Add to the `BulkSender` `public:` section:
+
+```cpp
+        [[nodiscard]] EndAckResult onEndAck(uint8_t xferId, OtaEndStatus status);
+```
+
+- [ ] **Step 4: Implement `onEndAck`**
+
+In `lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp`, add the static_asserts:
+
+```cpp
+    static_assert(static_cast<uint8_t>(EndAckResult::Decision::DONE_OK) == 0);
+    static_assert(static_cast<uint8_t>(EndAckResult::Decision::ABANDONED) == 1);
+    static_assert(static_cast<uint8_t>(EndAckResult::Decision::WRONG_XFER_ID) == 2);
+    static_assert(static_cast<uint8_t>(EndAckResult::Decision::NOT_STREAMING) == 3);
+
+    static_assert(std::is_const_v<decltype(EndAckResult::decision)>);
+    static_assert(!std::is_copy_assignable_v<EndAckResult>);
+```
+
+Add the method implementation:
+
+```cpp
+    EndAckResult BulkSender::onEndAck(uint8_t xferId, OtaEndStatus status)
+    {
+        if (status_ != Status::STREAMING)
+        {
+            return EndAckResult::notStreaming();
+        }
+        if (xferId != xferId_)
+        {
+            return EndAckResult::wrongXferId();
+        }
+
+        // OK is the only success status; HASH_MISMATCH and WRITE_ERROR
+        // both abandon. The MIXED layer (M3) logs the specific status
+        // for diagnostics; the state machine only cares about
+        // success-vs-abandon.
+        if (status == OtaEndStatus::OK)
+        {
+            status_ = Status::DONE_OK;
+            return EndAckResult::doneOk();
+        }
+        status_ = Status::ABANDONED;
+        return EndAckResult::abandoned();
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pio test -e test --filter "*test_native*" 2>&1 | tail -20`
+Expected: 5 new tests PASS (4 onEndAck cases + 1 end-to-end integration).
+
+Full suite: `pio test -e test 2>&1 | tail -5`
+Expected: all tests pass. M2 adds **31 new tests** total across T1-T5 (12 + 4 + 6 + 4 + 5).
+
+Build both boards to confirm the firmware still compiles:
+
+Run: `pio run -e metro_s3 2>&1 | tail -5`
+Expected: SUCCESS.
+
+Run: `pio run -e lolin_d32_pro 2>&1 | tail -5`
+Expected: SUCCESS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp \
+        lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp \
+        test/test_native/bulk_transport_tests.cpp
+git commit -m "feat(bulk-transport): add BulkSender::onEndAck + end-to-end test"
+```
+
+---
+
+## Task 6: Final verification + PR-ready housekeeping
+
+NO code changes — verification only. Confirms M2 is complete, gates pass, and the branch is ready to push.
+
+**Files:** none
+
+- [ ] **Step 1: Final test suite run**
+
+```bash
+pio test -e test 2>&1 | tail -10
+```
+
+Expected: 100% pass. M2 adds 31 new tests; total should be (M1-baseline) + 31.
+
+- [ ] **Step 2: Both board builds**
+
+```bash
+pio run -e metro_s3 2>&1 | tail -5
+pio run -e lolin_d32_pro 2>&1 | tail -5
+```
+
+Expected: both SUCCESS.
+
+- [ ] **Step 3: clang-format check on the branch**
+
+```bash
+git diff --name-only develop...HEAD | grep -E '\.(hpp|cpp|h)$' \
+  | xargs -I {} /home/jeff/.platformio/penv/bin/clang-format --dry-run --Werror {} 2>&1
+```
+
+Expected: empty output (all changed files clang-format clean). If anything fails, run `clang-format -i <file>` and commit a fixup before continuing.
+
+- [ ] **Step 4: PURE-lib purity sweep**
+
+```bash
+grep -RnE 'esp_|freertos/|driver/|<esp_|<freertos|<driver' \
+    lib_native/AstrOsBulkTransport/include/ \
+    lib_native/AstrOsBulkTransport/src/ \
+    | grep -v ' *//' || echo "PURE OK"
+```
+
+Expected: `PURE OK` — no ESP-IDF / FreeRTOS / driver includes leaked into the PURE tree. (Doc comments mentioning `esp_*` are filtered out by `grep -v ' *//'`.)
+
+- [ ] **Step 5: Branch summary**
+
+```bash
+git log --oneline develop..HEAD
+```
+
+Expected: 5 commits, one per T1-T5, all on `feature/ota-mesh-forward-m2-bulk-sender`.
+
+- [ ] **Step 6: Report PR-ready status**
+
+M2 is feature-complete. Branch carries 5 commits implementing `BulkSender` as a PURE state machine, with 31 new native tests covering happy paths, every rejection path, and the full end-to-end transfer flow. Ready for `git push` and `gh pr create` from the user's authenticated VS Code terminal. **Do NOT push from this session** — that's the user's job per the project's command-execution convention.
+
+---
+
+## Out of scope for M2 (do NOT add)
+
+- Any MIXED-side wiring (`lib/` changes) — M3
+- `OtaForwarder` — M3
+- ESP-NOW binary TX path — M3
+- Pause-polling integration — M3
+- Padawan-side `OtaWriter` — M4
+- `FW_PROGRESS` emission — M5
+- `FW_DEPLOY_BEGIN` orchestration — M5
+
+## Verification gates per the brief
+
+- `pio test -e test` — 100% pass with 31 new BulkSender tests
+- `pio run -e metro_s3` — clean
+- `pio run -e lolin_d32_pro` — clean
+- `clang-format` — clean on changed files
+- Native-purity CI guard (`.github/workflows/pr-validation.yml`) — passes (PURE lib unchanged in classification; no new includes leak)

--- a/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
+++ b/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <OtaWirePayloads.hpp>
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -505,6 +506,42 @@ namespace AstrOsBulkTransport
         bool abandon = false;
     };
 
+    // Result of BulkSender::onEndAck. Terminal transitions only —
+    // after DONE_OK or ABANDONED the sender stays in that state until
+    // reset(). WRONG_XFER_ID and NOT_STREAMING leave state unchanged.
+    struct [[nodiscard]] EndAckResult
+    {
+        enum class Decision : uint8_t
+        {
+            DONE_OK = 0,
+            ABANDONED = 1,
+            WRONG_XFER_ID = 2,
+            NOT_STREAMING = 3
+        };
+
+        const Decision decision;
+
+        static EndAckResult doneOk()
+        {
+            return EndAckResult(Decision::DONE_OK);
+        }
+        static EndAckResult abandoned()
+        {
+            return EndAckResult(Decision::ABANDONED);
+        }
+        static EndAckResult wrongXferId()
+        {
+            return EndAckResult(Decision::WRONG_XFER_ID);
+        }
+        static EndAckResult notStreaming()
+        {
+            return EndAckResult(Decision::NOT_STREAMING);
+        }
+
+    private:
+        explicit EndAckResult(Decision d) : decision(d) {}
+    };
+
     // Sliding-window sender state machine for the firmware OTA path.
     // Used by the master-side OtaForwarder (M3) to push chunks to a
     // padawan and react to ACK/NAK responses. PURE — no I/O, no
@@ -547,6 +584,7 @@ namespace AstrOsBulkTransport
         [[nodiscard]] AckResult onDataAck(uint8_t xferId, uint32_t cumulativeSeq);
         [[nodiscard]] NakResult onDataNak(uint8_t xferId, uint32_t nextExpectedSeq, NakReason reason);
         [[nodiscard]] TickResult tick(uint64_t nowMs);
+        [[nodiscard]] EndAckResult onEndAck(uint8_t xferId, OtaEndStatus status);
         void reset();
         Status status() const
         {

--- a/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
+++ b/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
@@ -416,9 +416,14 @@ namespace AstrOsBulkTransport
     };
 
     // Result of BulkSender::onDataAck. On OK, `newlyConfirmedCount` is
-    // the number of in-flight slots freed by this cumulative ACK —
-    // useful when the caller wants to know "did room open up that
-    // wasn't there before?" without diffing internal state.
+    // the confirmed-watermark delta — the count of seqs newly within
+    // the confirmed range as of this ACK (cumulativeSeq + 1 minus the
+    // prior watermark). Useful as a proxy for "did room open up that
+    // wasn't there before?" for flow control, but NOT equal to the
+    // number of in-flight slots evicted: after a NAK clears inFlight_,
+    // a delayed pre-NAK ACK can arrive and report a positive watermark
+    // delta even though zero (or fewer than reported) in-flight slots
+    // were evicted in this call.
     struct [[nodiscard]] AckResult
     {
         enum class Decision : uint8_t
@@ -427,9 +432,14 @@ namespace AstrOsBulkTransport
             WRONG_XFER_ID = 1,
             NOT_STREAMING = 2,
             STALE = 3,       // cumulativeSeq <= highestConfirmedSeq_ (already covered)
-            OUT_OF_RANGE = 4 // cumulativeSeq >= totalChunks_ (defensive against
-                             // peer-controlled wire input; the seq doesn't exist
-                             // in this transfer, so the ACK is wire-protocol-malformed)
+            OUT_OF_RANGE = 4 // cumulativeSeq is outside the valid range. Two cases,
+                             // both defensive against peer-controlled wire input:
+                             //   - cumulativeSeq >= totalChunks_: the seq doesn't
+                             //     exist in this transfer.
+                             //   - cumulativeSeq >= highWaterSentSeq_: the seq is
+                             //     in the transfer but we've never launched it.
+                             // See onDataAck's bounds-check rationale for the
+                             // failure mode each branch prevents.
         };
 
         const Decision decision;
@@ -470,8 +480,18 @@ namespace AstrOsBulkTransport
             OK = 0,
             WRONG_XFER_ID = 1,
             NOT_STREAMING = 2,
-            OUT_OF_RANGE = 3 // nextExpectedSeq >= totalChunks_ (defensive; receiver
-                             // asking for a seq beyond the transfer is malformed)
+            OUT_OF_RANGE = 3 // nextExpectedSeq is outside the valid range. Two
+                             // cases, both defensive against peer-controlled wire
+                             // input:
+                             //   - nextExpectedSeq >= totalChunks_: the seq is
+                             //     beyond the transfer.
+                             //   - nextExpectedSeq > nextSeqToSend_: the seq is
+                             //     ahead of where we've launched (NAK fast-forward
+                             //     past current send cursor; receiver cannot
+                             //     legitimately know about an unsent seq's gap).
+                             // See onDataNak's bounds-check rationale for the
+                             // asymmetry with onDataAck (NAK uses the current
+                             // cursor, not the high-water mark).
         };
 
         const Decision decision;

--- a/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
+++ b/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 
@@ -298,5 +299,134 @@ namespace AstrOsBulkTransport
         uint16_t chunkSize_ = 0;
         uint8_t windowSize_ = 0;
         bool active_ = false;
+    };
+    // Maximum window size BulkSender supports. Covers both the
+    // ESP-NOW path (window=8 per the frozen contract) and the
+    // serial path (window=16 per the same contract). Bounds the
+    // in-flight table and TickResult retransmit array so the
+    // sender stays heap-free.
+    constexpr uint8_t MAX_WINDOW_SIZE = 16;
+
+    // One row of the BulkSender in-flight table. The sender keeps
+    // up to MAX_WINDOW_SIZE entries; each tracks a single sent-but-
+    // not-yet-acknowledged seq with its latest send-timestamp and
+    // retry count. Public for tests; not part of the wire contract.
+    struct InFlightEntry
+    {
+        uint32_t seq = 0;
+        uint64_t sendTimestampMs = 0;
+        uint8_t retryCount = 0;
+        bool occupied = false;
+    };
+
+    // [[nodiscard]] mirrors BulkReceiver::BeginResult — silently
+    // dropping the return value would leave the caller unable to
+    // distinguish "transfer ready" from "begin rejected, sender
+    // still IDLE", which is the silent-failure mode this attribute
+    // closes.
+    struct [[nodiscard]] BeginSenderResult
+    {
+        enum class Reason : uint8_t
+        {
+            OK = 0,
+            ZERO_TOTAL_CHUNKS = 1,
+            ZERO_CHUNK_SIZE = 2,
+            ZERO_WINDOW_SIZE = 3,
+            ZERO_ACK_TIMEOUT = 4,
+            ZERO_MAX_RETRIES = 5,
+            WINDOW_TOO_LARGE = 6 // windowSize > MAX_WINDOW_SIZE
+        };
+        bool valid = false;
+        Reason reason = Reason::ZERO_TOTAL_CHUNKS;
+
+        static BeginSenderResult ok()
+        {
+            return {true, Reason::OK};
+        }
+        static BeginSenderResult invalid(Reason r)
+        {
+            return {false, r};
+        }
+    };
+
+    struct [[nodiscard]] BeginAckResult
+    {
+        enum class Decision : uint8_t
+        {
+            OK = 0,
+            WRONG_XFER_ID = 1,
+            NOT_AWAITING_BEGIN_ACK = 2
+        };
+        Decision decision = Decision::NOT_AWAITING_BEGIN_ACK;
+
+        static BeginAckResult ok()
+        {
+            return {Decision::OK};
+        }
+        static BeginAckResult wrongXferId()
+        {
+            return {Decision::WRONG_XFER_ID};
+        }
+        static BeginAckResult notAwaiting()
+        {
+            return {Decision::NOT_AWAITING_BEGIN_ACK};
+        }
+    };
+
+    // Sliding-window sender state machine for the firmware OTA path.
+    // Used by the master-side OtaForwarder (M3) to push chunks to a
+    // padawan and react to ACK/NAK responses. PURE — no I/O, no
+    // FreeRTOS, no ESP-IDF. The MIXED caller does the actual byte
+    // emission; this class tracks "what to send next" and "is the
+    // transfer healthy".
+    //
+    // State machine:
+    //   IDLE
+    //     → AWAITING_BEGIN_ACK (via begin())
+    //     → STREAMING (via onBeginAck OK)
+    //         ⮨ self (per-chunk send/ack/nak/tick cycle)
+    //         → DONE_OK (via onEndAck OK)
+    //         → ABANDONED (via onEndAck != OK, OR tick(abandon=true))
+    //
+    // AWAITING_END_ACK is intentionally NOT a distinct state — it's
+    // implicit ("STREAMING with all seqs confirmed and in-flight
+    // table empty"). The MIXED caller checks SendResult::ALL_SENT
+    // to know when it's time to send OTA_END.
+    class BulkSender
+    {
+    public:
+        enum class Status : uint8_t
+        {
+            IDLE = 0,
+            AWAITING_BEGIN_ACK = 1,
+            STREAMING = 2,
+            DONE_OK = 3,
+            ABANDONED = 4
+        };
+
+        [[nodiscard]] BeginSenderResult begin(uint8_t xferId, uint32_t totalChunks, uint16_t chunkSize,
+                                              uint8_t windowSize, uint32_t ackTimeoutMs, uint8_t maxRetries);
+        [[nodiscard]] BeginAckResult onBeginAck(uint8_t xferId);
+        void reset();
+        Status status() const
+        {
+            return status_;
+        }
+
+    private:
+        uint8_t xferId_ = 0;
+        uint32_t totalChunks_ = 0;
+        uint16_t chunkSize_ = 0;
+        uint8_t windowSize_ = 0;
+        uint32_t ackTimeoutMs_ = 0;
+        uint8_t maxRetries_ = 0;
+
+        uint32_t nextSeqToSend_ = 0;
+        uint32_t highestConfirmedSeq_ = 0;
+        bool anyConfirmed_ = false; // disambiguates "seq 0 confirmed" from "nothing confirmed yet"
+
+        std::array<InFlightEntry, MAX_WINDOW_SIZE> inFlight_{};
+
+        Status status_ = Status::IDLE;
     };
 } // namespace AstrOsBulkTransport

--- a/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
+++ b/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
@@ -373,6 +373,47 @@ namespace AstrOsBulkTransport
         }
     };
 
+    // Result of BulkSender::nextChunkToSend. On SEND, `seq` is the seq
+    // to emit on the wire and the in-flight table now owns a slot for
+    // it. Other Decisions leave the sender state unchanged.
+    //
+    // Const-fields + private constructor mirror ChunkResult's
+    // discipline so a returned result cannot be mutated into an
+    // invalid combination (e.g. WINDOW_FULL with a real seq).
+    struct SendResult
+    {
+        enum class Decision : uint8_t
+        {
+            SEND = 0,         // emit `seq` on the wire
+            WINDOW_FULL = 1,  // in-flight count == windowSize; ACK something first
+            ALL_SENT = 2,     // nextSeqToSend_ == totalChunks_; nothing left to send
+            NOT_STREAMING = 3 // status != STREAMING
+        };
+
+        const Decision decision;
+        const uint32_t seq;
+
+        static SendResult send(uint32_t s)
+        {
+            return SendResult(Decision::SEND, s);
+        }
+        static SendResult windowFull()
+        {
+            return SendResult(Decision::WINDOW_FULL, 0);
+        }
+        static SendResult allSent()
+        {
+            return SendResult(Decision::ALL_SENT, 0);
+        }
+        static SendResult notStreaming()
+        {
+            return SendResult(Decision::NOT_STREAMING, 0);
+        }
+
+    private:
+        SendResult(Decision d, uint32_t s) : decision(d), seq(s) {}
+    };
+
     // Sliding-window sender state machine for the firmware OTA path.
     // Used by the master-side OtaForwarder (M3) to push chunks to a
     // padawan and react to ACK/NAK responses. PURE — no I/O, no
@@ -407,6 +448,7 @@ namespace AstrOsBulkTransport
         [[nodiscard]] BeginSenderResult begin(uint8_t xferId, uint32_t totalChunks, uint16_t chunkSize,
                                               uint8_t windowSize, uint32_t ackTimeoutMs, uint8_t maxRetries);
         [[nodiscard]] BeginAckResult onBeginAck(uint8_t xferId);
+        [[nodiscard]] SendResult nextChunkToSend(uint64_t nowMs);
         void reset();
         Status status() const
         {

--- a/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
+++ b/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
@@ -452,6 +452,27 @@ namespace AstrOsBulkTransport
         AckResult(Decision d, uint32_t n) : decision(d), newlyConfirmedCount(n) {}
     };
 
+    // Result of BulkSender::tick. `retransmitSeqs[0..count-1]` are the
+    // seqs whose ackTimeout fired and need re-emission on the wire.
+    // `abandon` is set when any seq's retryCount would exceed
+    // maxRetries — at that point the sender transitions to ABANDONED
+    // and stops issuing further retransmit lists.
+    //
+    // Bounded by MAX_WINDOW_SIZE so this struct stays heap-free. A
+    // single tick can produce at most `windowSize` retransmissions
+    // (the in-flight table is the upper bound).
+    //
+    // Unlike the other result types, TickResult is structurally an
+    // output buffer (caller reads count then iterates retransmitSeqs).
+    // The const-fields + private-ctor pattern doesn't fit — count is
+    // written by tick() as it fills the array, then returned by value.
+    struct TickResult
+    {
+        std::array<uint32_t, MAX_WINDOW_SIZE> retransmitSeqs;
+        uint8_t count = 0;
+        bool abandon = false;
+    };
+
     // Result of BulkSender::onDataNak. On OK, `nextSeqToResend` is the
     // seq that the next `nextChunkToSend` call will emit (mirrors the
     // wire-level `nextExpectedSeq` field from OTA_DATA_NAK).
@@ -525,6 +546,7 @@ namespace AstrOsBulkTransport
         [[nodiscard]] SendResult nextChunkToSend(uint64_t nowMs);
         [[nodiscard]] AckResult onDataAck(uint8_t xferId, uint32_t cumulativeSeq);
         [[nodiscard]] NakResult onDataNak(uint8_t xferId, uint32_t nextExpectedSeq, NakReason reason);
+        [[nodiscard]] TickResult tick(uint64_t nowMs);
         void reset();
         Status status() const
         {

--- a/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
+++ b/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
@@ -380,7 +380,7 @@ namespace AstrOsBulkTransport
     // Const-fields + private constructor mirror ChunkResult's
     // discipline so a returned result cannot be mutated into an
     // invalid combination (e.g. WINDOW_FULL with a real seq).
-    struct SendResult
+    struct [[nodiscard]] SendResult
     {
         enum class Decision : uint8_t
         {
@@ -448,6 +448,10 @@ namespace AstrOsBulkTransport
         [[nodiscard]] BeginSenderResult begin(uint8_t xferId, uint32_t totalChunks, uint16_t chunkSize,
                                               uint8_t windowSize, uint32_t ackTimeoutMs, uint8_t maxRetries);
         [[nodiscard]] BeginAckResult onBeginAck(uint8_t xferId);
+        // Precondition: `nowMs` must be monotonically non-decreasing across
+        // successive calls. M3's MIXED caller drives this from
+        // esp_timer_get_time()/1000. Non-monotonic clocks would corrupt the
+        // tick-driven timeout detection in M2.T4.
         [[nodiscard]] SendResult nextChunkToSend(uint64_t nowMs);
         void reset();
         Status status() const

--- a/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
+++ b/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
@@ -452,27 +452,6 @@ namespace AstrOsBulkTransport
         AckResult(Decision d, uint32_t n) : decision(d), newlyConfirmedCount(n) {}
     };
 
-    // Result of BulkSender::tick. `retransmitSeqs[0..count-1]` are the
-    // seqs whose ackTimeout fired and need re-emission on the wire.
-    // `abandon` is set when any seq's retryCount would exceed
-    // maxRetries — at that point the sender transitions to ABANDONED
-    // and stops issuing further retransmit lists.
-    //
-    // Bounded by MAX_WINDOW_SIZE so this struct stays heap-free. A
-    // single tick can produce at most `windowSize` retransmissions
-    // (the in-flight table is the upper bound).
-    //
-    // Unlike the other result types, TickResult is structurally an
-    // output buffer (caller reads count then iterates retransmitSeqs).
-    // The const-fields + private-ctor pattern doesn't fit — count is
-    // written by tick() as it fills the array, then returned by value.
-    struct TickResult
-    {
-        std::array<uint32_t, MAX_WINDOW_SIZE> retransmitSeqs;
-        uint8_t count = 0;
-        bool abandon = false;
-    };
-
     // Result of BulkSender::onDataNak. On OK, `nextSeqToResend` is the
     // seq that the next `nextChunkToSend` call will emit (mirrors the
     // wire-level `nextExpectedSeq` field from OTA_DATA_NAK).
@@ -503,6 +482,27 @@ namespace AstrOsBulkTransport
 
     private:
         NakResult(Decision d, uint32_t s) : decision(d), nextSeqToResend(s) {}
+    };
+
+    // Result of BulkSender::tick. `retransmitSeqs[0..count-1]` are the
+    // seqs whose ackTimeout fired and need re-emission on the wire.
+    // `abandon` is set when any seq's retryCount would exceed
+    // maxRetries — at that point the sender transitions to ABANDONED
+    // and stops issuing further retransmit lists.
+    //
+    // Bounded by MAX_WINDOW_SIZE so this struct stays heap-free. A
+    // single tick can produce at most `windowSize` retransmissions
+    // (the in-flight table is the upper bound).
+    //
+    // Unlike the other result types, TickResult is structurally an
+    // output buffer (caller reads count then iterates retransmitSeqs).
+    // The const-fields + private-ctor pattern doesn't fit — count is
+    // written by tick() as it fills the array, then returned by value.
+    struct TickResult
+    {
+        std::array<uint32_t, MAX_WINDOW_SIZE> retransmitSeqs;
+        uint8_t count = 0;
+        bool abandon = false;
     };
 
     // Sliding-window sender state machine for the firmware OTA path.

--- a/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
+++ b/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
@@ -414,6 +414,76 @@ namespace AstrOsBulkTransport
         SendResult(Decision d, uint32_t s) : decision(d), seq(s) {}
     };
 
+    // Result of BulkSender::onDataAck. On OK, `newlyConfirmedCount` is
+    // the number of in-flight slots freed by this cumulative ACK —
+    // useful when the caller wants to know "did room open up that
+    // wasn't there before?" without diffing internal state.
+    struct [[nodiscard]] AckResult
+    {
+        enum class Decision : uint8_t
+        {
+            OK = 0,
+            WRONG_XFER_ID = 1,
+            NOT_STREAMING = 2,
+            STALE = 3 // cumulativeSeq <= highestConfirmedSeq_ (already covered)
+        };
+
+        const Decision decision;
+        const uint32_t newlyConfirmedCount;
+
+        static AckResult ok(uint32_t n)
+        {
+            return AckResult(Decision::OK, n);
+        }
+        static AckResult wrongXferId()
+        {
+            return AckResult(Decision::WRONG_XFER_ID, 0);
+        }
+        static AckResult notStreaming()
+        {
+            return AckResult(Decision::NOT_STREAMING, 0);
+        }
+        static AckResult stale()
+        {
+            return AckResult(Decision::STALE, 0);
+        }
+
+    private:
+        AckResult(Decision d, uint32_t n) : decision(d), newlyConfirmedCount(n) {}
+    };
+
+    // Result of BulkSender::onDataNak. On OK, `nextSeqToResend` is the
+    // seq that the next `nextChunkToSend` call will emit (mirrors the
+    // wire-level `nextExpectedSeq` field from OTA_DATA_NAK).
+    struct [[nodiscard]] NakResult
+    {
+        enum class Decision : uint8_t
+        {
+            OK = 0,
+            WRONG_XFER_ID = 1,
+            NOT_STREAMING = 2
+        };
+
+        const Decision decision;
+        const uint32_t nextSeqToResend;
+
+        static NakResult ok(uint32_t s)
+        {
+            return NakResult(Decision::OK, s);
+        }
+        static NakResult wrongXferId()
+        {
+            return NakResult(Decision::WRONG_XFER_ID, 0);
+        }
+        static NakResult notStreaming()
+        {
+            return NakResult(Decision::NOT_STREAMING, 0);
+        }
+
+    private:
+        NakResult(Decision d, uint32_t s) : decision(d), nextSeqToResend(s) {}
+    };
+
     // Sliding-window sender state machine for the firmware OTA path.
     // Used by the master-side OtaForwarder (M3) to push chunks to a
     // padawan and react to ACK/NAK responses. PURE — no I/O, no
@@ -453,6 +523,8 @@ namespace AstrOsBulkTransport
         // esp_timer_get_time()/1000. Non-monotonic clocks would corrupt the
         // tick-driven timeout detection in M2.T4.
         [[nodiscard]] SendResult nextChunkToSend(uint64_t nowMs);
+        [[nodiscard]] AckResult onDataAck(uint8_t xferId, uint32_t cumulativeSeq);
+        [[nodiscard]] NakResult onDataNak(uint8_t xferId, uint32_t nextExpectedSeq, NakReason reason);
         void reset();
         Status status() const
         {

--- a/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
+++ b/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
@@ -620,6 +620,7 @@ namespace AstrOsBulkTransport
         uint8_t maxRetries_ = 0;
 
         uint32_t nextSeqToSend_ = 0;
+        uint32_t highWaterSentSeq_ = 0; // max nextSeqToSend_ ever reached; never rewinds on NAK
         uint32_t highestConfirmedSeq_ = 0;
         bool anyConfirmed_ = false; // disambiguates "seq 0 confirmed" from "nothing confirmed yet"
 

--- a/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
+++ b/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
@@ -499,7 +499,7 @@ namespace AstrOsBulkTransport
     // output buffer (caller reads count then iterates retransmitSeqs).
     // The const-fields + private-ctor pattern doesn't fit — count is
     // written by tick() as it fills the array, then returned by value.
-    struct TickResult
+    struct [[nodiscard]] TickResult
     {
         std::array<uint32_t, MAX_WINDOW_SIZE> retransmitSeqs;
         uint8_t count = 0;

--- a/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
+++ b/lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp
@@ -426,7 +426,10 @@ namespace AstrOsBulkTransport
             OK = 0,
             WRONG_XFER_ID = 1,
             NOT_STREAMING = 2,
-            STALE = 3 // cumulativeSeq <= highestConfirmedSeq_ (already covered)
+            STALE = 3,       // cumulativeSeq <= highestConfirmedSeq_ (already covered)
+            OUT_OF_RANGE = 4 // cumulativeSeq >= totalChunks_ (defensive against
+                             // peer-controlled wire input; the seq doesn't exist
+                             // in this transfer, so the ACK is wire-protocol-malformed)
         };
 
         const Decision decision;
@@ -448,6 +451,10 @@ namespace AstrOsBulkTransport
         {
             return AckResult(Decision::STALE, 0);
         }
+        static AckResult outOfRange()
+        {
+            return AckResult(Decision::OUT_OF_RANGE, 0);
+        }
 
     private:
         AckResult(Decision d, uint32_t n) : decision(d), newlyConfirmedCount(n) {}
@@ -462,7 +469,9 @@ namespace AstrOsBulkTransport
         {
             OK = 0,
             WRONG_XFER_ID = 1,
-            NOT_STREAMING = 2
+            NOT_STREAMING = 2,
+            OUT_OF_RANGE = 3 // nextExpectedSeq >= totalChunks_ (defensive; receiver
+                             // asking for a seq beyond the transfer is malformed)
         };
 
         const Decision decision;
@@ -479,6 +488,10 @@ namespace AstrOsBulkTransport
         static NakResult notStreaming()
         {
             return NakResult(Decision::NOT_STREAMING, 0);
+        }
+        static NakResult outOfRange()
+        {
+            return NakResult(Decision::OUT_OF_RANGE, 0);
         }
 
     private:
@@ -516,7 +529,10 @@ namespace AstrOsBulkTransport
             DONE_OK = 0,
             ABANDONED = 1,
             WRONG_XFER_ID = 2,
-            NOT_STREAMING = 3
+            NOT_STREAMING = 3,
+            PREMATURE = 4 // onEndAck called before the implicit AWAITING_END_ACK
+                          // predicate is satisfied (all chunks sent AND all
+                          // confirmed). Caller error or buggy peer.
         };
 
         const Decision decision;
@@ -536,6 +552,10 @@ namespace AstrOsBulkTransport
         static EndAckResult notStreaming()
         {
             return EndAckResult(Decision::NOT_STREAMING);
+        }
+        static EndAckResult premature()
+        {
+            return EndAckResult(Decision::PREMATURE);
         }
 
     private:

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -385,6 +385,7 @@ namespace AstrOsBulkTransport
         ackTimeoutMs_ = ackTimeoutMs;
         maxRetries_ = maxRetries;
         nextSeqToSend_ = 0;
+        highWaterSentSeq_ = 0;
         highestConfirmedSeq_ = 0;
         anyConfirmed_ = false;
         inFlight_.fill(InFlightEntry{});
@@ -450,6 +451,10 @@ namespace AstrOsBulkTransport
                 e.occupied = true;
                 const uint32_t emittedSeq = nextSeqToSend_;
                 nextSeqToSend_++;
+                if (nextSeqToSend_ > highWaterSentSeq_)
+                {
+                    highWaterSentSeq_ = nextSeqToSend_;
+                }
                 return SendResult::send(emittedSeq);
             }
         }
@@ -471,21 +476,28 @@ namespace AstrOsBulkTransport
         {
             return AckResult::wrongXferId();
         }
-        // Bounds check: cumulativeSeq must reference a real seq in this transfer.
+        // Bounds check: cumulativeSeq must reference a seq we've actually sent.
         // Defends the PURE state machine against peer-controlled wire input;
-        // the M3 wire parser can also gate this, but we don't want to rely on it.
-        //
-        // Without this guard:
-        //   - cumulativeSeq = UINT32_MAX: the newlyConfirmedCount arithmetic
-        //     below (cumulativeSeq + 1 - prev) wraps unsigned, returning a
-        //     falsely-zero count to the MIXED layer.
-        //   - cumulativeSeq in [totalChunks_, UINT32_MAX-1]: highestConfirmedSeq_
-        //     overshoots the transfer range. The PREMATURE guard in onEndAck
-        //     would still catch a subsequent OK transition (allConfirmed check
-        //     would fail since highestConfirmedSeq_ + 1 != totalChunks_), but
-        //     the watermark is left corrupted for any later valid-range ACK to
-        //     be falsely rejected as STALE.
-        if (cumulativeSeq >= totalChunks_)
+        // the M3 wire parser can also gate this, but we don't want to rely on
+        // it. Two bounds:
+        //   - cumulativeSeq >= totalChunks_: the seq doesn't exist in this
+        //     transfer at all. Without this guard, UINT32_MAX would wrap the
+        //     newlyConfirmedCount arithmetic below (cumulativeSeq + 1 - prev)
+        //     to zero; any cumulativeSeq in [totalChunks_, UINT32_MAX-1] would
+        //     corrupt highestConfirmedSeq_ (causing later valid-range ACKs to
+        //     be falsely STALE).
+        //   - cumulativeSeq >= highWaterSentSeq_: the seq exists in the
+        //     transfer but we haven't launched it yet (highWaterSentSeq_ is
+        //     the max nextSeqToSend_ ever reached; it never rewinds on NAK).
+        //     The receiver cannot legitimately ACK what we haven't sent.
+        //     Without this guard, a peer ACK ahead of the sender (e.g.
+        //     cumulativeSeq=15 when highWaterSentSeq_=8) would evict all real
+        //     in-flight slots, advance the watermark past unsent seqs, and
+        //     stall the transfer (later legitimate ACKs for seqs 0..7 would
+        //     be falsely STALE; tick wouldn't time out evicted slots;
+        //     nextChunkToSend would happily emit seqs the receiver thinks
+        //     it's already received).
+        if (cumulativeSeq >= totalChunks_ || cumulativeSeq >= highWaterSentSeq_)
         {
             return AckResult::outOfRange();
         }
@@ -526,11 +538,22 @@ namespace AstrOsBulkTransport
         {
             return NakResult::wrongXferId();
         }
-        // Bounds check: nextExpectedSeq must reference a seq in this transfer.
-        // Defends against peer-controlled wire input that would advance
-        // nextSeqToSend_ past totalChunks_, causing the sender to silently
-        // skip real chunks via the ALL_SENT path on the next nextChunkToSend.
-        if (nextExpectedSeq >= totalChunks_)
+        // Bounds check: nextExpectedSeq must reference a seq we've launched
+        // (or one-past — the degenerate no-op case). Defends against
+        // peer-controlled wire input. Two bounds:
+        //   - nextExpectedSeq >= totalChunks_: the seq doesn't exist in this
+        //     transfer. Without this guard, a peer NAK with nextExpectedSeq
+        //     >= totalChunks_ would advance nextSeqToSend_ past totalChunks_,
+        //     causing the sender to silently skip real chunks via the
+        //     ALL_SENT path on the next nextChunkToSend.
+        //   - nextExpectedSeq > nextSeqToSend_: the seq is within the
+        //     transfer but ahead of where we've launched. NAK semantics are
+        //     "rewind to here" — fast-forwarding is a wire-protocol
+        //     violation that would skip chunks we haven't even sent. Equality
+        //     (nextExpectedSeq == nextSeqToSend_) is the degenerate no-op
+        //     where the receiver asks for what we'd send next anyway —
+        //     accepted to be permissive on the boundary.
+        if (nextExpectedSeq >= totalChunks_ || nextExpectedSeq > nextSeqToSend_)
         {
             return NakResult::outOfRange();
         }
@@ -672,6 +695,7 @@ namespace AstrOsBulkTransport
         ackTimeoutMs_ = 0;
         maxRetries_ = 0;
         nextSeqToSend_ = 0;
+        highWaterSentSeq_ = 0;
         highestConfirmedSeq_ = 0;
         anyConfirmed_ = false;
         inFlight_.fill(InFlightEntry{});

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -553,6 +553,13 @@ namespace AstrOsBulkTransport
         //     (nextExpectedSeq == nextSeqToSend_) is the degenerate no-op
         //     where the receiver asks for what we'd send next anyway —
         //     accepted to be permissive on the boundary.
+        // Note on asymmetry with onDataAck: NAK uses the *current* nextSeqToSend_
+        // (which rewinds), not highWaterSentSeq_. NAK semantics are "rewind to
+        // here, resume from here" — the receiver may legitimately reference any
+        // seq up to where we'll send next, but never beyond it. A stale NAK from
+        // before a rewind referencing a seq > current nextSeqToSend_ is no longer
+        // applicable (the receiver's view of the wire was overtaken by our
+        // rewind + retransmit). Rejecting it is correct.
         if (nextExpectedSeq >= totalChunks_ || nextExpectedSeq > nextSeqToSend_)
         {
             return NakResult::outOfRange();

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -328,6 +328,14 @@ namespace AstrOsBulkTransport
     static_assert(std::is_const_v<decltype(NakResult::nextSeqToResend)>);
     static_assert(!std::is_copy_assignable_v<NakResult>);
 
+    static_assert(static_cast<uint8_t>(EndAckResult::Decision::DONE_OK) == 0);
+    static_assert(static_cast<uint8_t>(EndAckResult::Decision::ABANDONED) == 1);
+    static_assert(static_cast<uint8_t>(EndAckResult::Decision::WRONG_XFER_ID) == 2);
+    static_assert(static_cast<uint8_t>(EndAckResult::Decision::NOT_STREAMING) == 3);
+
+    static_assert(std::is_const_v<decltype(EndAckResult::decision)>);
+    static_assert(!std::is_copy_assignable_v<EndAckResult>);
+
     BeginSenderResult BulkSender::begin(uint8_t xferId, uint32_t totalChunks, uint16_t chunkSize, uint8_t windowSize,
                                         uint32_t ackTimeoutMs, uint8_t maxRetries)
     {
@@ -580,6 +588,30 @@ namespace AstrOsBulkTransport
             result.count++;
         }
         return result;
+    }
+
+    EndAckResult BulkSender::onEndAck(uint8_t xferId, OtaEndStatus status)
+    {
+        if (status_ != Status::STREAMING)
+        {
+            return EndAckResult::notStreaming();
+        }
+        if (xferId != xferId_)
+        {
+            return EndAckResult::wrongXferId();
+        }
+
+        // OK is the only success status; HASH_MISMATCH and WRITE_ERROR
+        // both abandon. The MIXED layer (M3) logs the specific status
+        // for diagnostics; the state machine only cares about
+        // success-vs-abandon.
+        if (status == OtaEndStatus::OK)
+        {
+            status_ = Status::DONE_OK;
+            return EndAckResult::doneOk();
+        }
+        status_ = Status::ABANDONED;
+        return EndAckResult::abandoned();
     }
 
     void BulkSender::reset()

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -275,4 +275,113 @@ namespace AstrOsBulkTransport
         }
         return false; // unknown reason — conservative: preserve state
     }
+
+    // BulkSender::Status integer values are API-stable and consumed by
+    // switch statements in M3's OtaForwarder. Pin them so a future
+    // reorder breaks the build, not the dispatch.
+    static_assert(static_cast<uint8_t>(BulkSender::Status::IDLE) == 0);
+    static_assert(static_cast<uint8_t>(BulkSender::Status::AWAITING_BEGIN_ACK) == 1);
+    static_assert(static_cast<uint8_t>(BulkSender::Status::STREAMING) == 2);
+    static_assert(static_cast<uint8_t>(BulkSender::Status::DONE_OK) == 3);
+    static_assert(static_cast<uint8_t>(BulkSender::Status::ABANDONED) == 4);
+
+    static_assert(static_cast<uint8_t>(BeginSenderResult::Reason::OK) == 0);
+    static_assert(static_cast<uint8_t>(BeginSenderResult::Reason::ZERO_TOTAL_CHUNKS) == 1);
+    static_assert(static_cast<uint8_t>(BeginSenderResult::Reason::ZERO_CHUNK_SIZE) == 2);
+    static_assert(static_cast<uint8_t>(BeginSenderResult::Reason::ZERO_WINDOW_SIZE) == 3);
+    static_assert(static_cast<uint8_t>(BeginSenderResult::Reason::ZERO_ACK_TIMEOUT) == 4);
+    static_assert(static_cast<uint8_t>(BeginSenderResult::Reason::ZERO_MAX_RETRIES) == 5);
+    static_assert(static_cast<uint8_t>(BeginSenderResult::Reason::WINDOW_TOO_LARGE) == 6);
+
+    static_assert(static_cast<uint8_t>(BeginAckResult::Decision::OK) == 0);
+    static_assert(static_cast<uint8_t>(BeginAckResult::Decision::WRONG_XFER_ID) == 1);
+    static_assert(static_cast<uint8_t>(BeginAckResult::Decision::NOT_AWAITING_BEGIN_ACK) == 2);
+
+    BeginSenderResult BulkSender::begin(uint8_t xferId, uint32_t totalChunks, uint16_t chunkSize, uint8_t windowSize,
+                                        uint32_t ackTimeoutMs, uint8_t maxRetries)
+    {
+        // Reject protocol-illegal parameters in the order the contract
+        // freezes them. Each rejection leaves the sender in IDLE so a
+        // subsequent corrected begin() works cleanly. Order matters: a
+        // future reorder of these guards would change which Reason a
+        // caller sees for multi-fault input.
+        if (totalChunks == 0)
+        {
+            reset();
+            return BeginSenderResult::invalid(BeginSenderResult::Reason::ZERO_TOTAL_CHUNKS);
+        }
+        if (chunkSize == 0)
+        {
+            reset();
+            return BeginSenderResult::invalid(BeginSenderResult::Reason::ZERO_CHUNK_SIZE);
+        }
+        if (windowSize == 0)
+        {
+            reset();
+            return BeginSenderResult::invalid(BeginSenderResult::Reason::ZERO_WINDOW_SIZE);
+        }
+        if (windowSize > MAX_WINDOW_SIZE)
+        {
+            reset();
+            return BeginSenderResult::invalid(BeginSenderResult::Reason::WINDOW_TOO_LARGE);
+        }
+        if (ackTimeoutMs == 0)
+        {
+            reset();
+            return BeginSenderResult::invalid(BeginSenderResult::Reason::ZERO_ACK_TIMEOUT);
+        }
+        if (maxRetries == 0)
+        {
+            reset();
+            return BeginSenderResult::invalid(BeginSenderResult::Reason::ZERO_MAX_RETRIES);
+        }
+
+        xferId_ = xferId;
+        totalChunks_ = totalChunks;
+        chunkSize_ = chunkSize;
+        windowSize_ = windowSize;
+        ackTimeoutMs_ = ackTimeoutMs;
+        maxRetries_ = maxRetries;
+        nextSeqToSend_ = 0;
+        highestConfirmedSeq_ = 0;
+        anyConfirmed_ = false;
+        for (auto &e : inFlight_)
+        {
+            e = InFlightEntry{};
+        }
+        status_ = Status::AWAITING_BEGIN_ACK;
+        return BeginSenderResult::ok();
+    }
+
+    BeginAckResult BulkSender::onBeginAck(uint8_t xferId)
+    {
+        if (status_ != Status::AWAITING_BEGIN_ACK)
+        {
+            return BeginAckResult::notAwaiting();
+        }
+        if (xferId != xferId_)
+        {
+            return BeginAckResult::wrongXferId();
+        }
+        status_ = Status::STREAMING;
+        return BeginAckResult::ok();
+    }
+
+    void BulkSender::reset()
+    {
+        xferId_ = 0;
+        totalChunks_ = 0;
+        chunkSize_ = 0;
+        windowSize_ = 0;
+        ackTimeoutMs_ = 0;
+        maxRetries_ = 0;
+        nextSeqToSend_ = 0;
+        highestConfirmedSeq_ = 0;
+        anyConfirmed_ = false;
+        for (auto &e : inFlight_)
+        {
+            e = InFlightEntry{};
+        }
+        status_ = Status::IDLE;
+    }
 } // namespace AstrOsBulkTransport

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -472,11 +472,19 @@ namespace AstrOsBulkTransport
             return AckResult::wrongXferId();
         }
         // Bounds check: cumulativeSeq must reference a real seq in this transfer.
-        // Defends the PURE state machine against peer-controlled wire input. The
-        // M3 wire parser can also gate this, but we don't want to rely on it.
-        // UINT32_MAX would underflow the newlyConfirmedCount arithmetic below;
-        // cumulativeSeq >= totalChunks_ would let highestConfirmedSeq_ overshoot,
-        // causing false DONE_OK on a subsequent onEndAck(OK).
+        // Defends the PURE state machine against peer-controlled wire input;
+        // the M3 wire parser can also gate this, but we don't want to rely on it.
+        //
+        // Without this guard:
+        //   - cumulativeSeq = UINT32_MAX: the newlyConfirmedCount arithmetic
+        //     below (cumulativeSeq + 1 - prev) wraps unsigned, returning a
+        //     falsely-zero count to the MIXED layer.
+        //   - cumulativeSeq in [totalChunks_, UINT32_MAX-1]: highestConfirmedSeq_
+        //     overshoots the transfer range. The PREMATURE guard in onEndAck
+        //     would still catch a subsequent OK transition (allConfirmed check
+        //     would fail since highestConfirmedSeq_ + 1 != totalChunks_), but
+        //     the watermark is left corrupted for any later valid-range ACK to
+        //     be falsely rejected as STALE.
         if (cumulativeSeq >= totalChunks_)
         {
             return AckResult::outOfRange();

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -311,6 +311,23 @@ namespace AstrOsBulkTransport
     static_assert(!std::is_copy_assignable_v<SendResult>);
     static_assert(std::is_copy_constructible_v<SendResult>);
 
+    static_assert(static_cast<uint8_t>(AckResult::Decision::OK) == 0);
+    static_assert(static_cast<uint8_t>(AckResult::Decision::WRONG_XFER_ID) == 1);
+    static_assert(static_cast<uint8_t>(AckResult::Decision::NOT_STREAMING) == 2);
+    static_assert(static_cast<uint8_t>(AckResult::Decision::STALE) == 3);
+
+    static_assert(static_cast<uint8_t>(NakResult::Decision::OK) == 0);
+    static_assert(static_cast<uint8_t>(NakResult::Decision::WRONG_XFER_ID) == 1);
+    static_assert(static_cast<uint8_t>(NakResult::Decision::NOT_STREAMING) == 2);
+
+    static_assert(std::is_const_v<decltype(AckResult::decision)>);
+    static_assert(std::is_const_v<decltype(AckResult::newlyConfirmedCount)>);
+    static_assert(!std::is_copy_assignable_v<AckResult>);
+
+    static_assert(std::is_const_v<decltype(NakResult::decision)>);
+    static_assert(std::is_const_v<decltype(NakResult::nextSeqToResend)>);
+    static_assert(!std::is_copy_assignable_v<NakResult>);
+
     BeginSenderResult BulkSender::begin(uint8_t xferId, uint32_t totalChunks, uint16_t chunkSize, uint8_t windowSize,
                                         uint32_t ackTimeoutMs, uint8_t maxRetries)
     {
@@ -434,6 +451,75 @@ namespace AstrOsBulkTransport
         // returned WINDOW_FULL in the full case.
         assert(false && "BulkSender::nextChunkToSend: in-flight table full despite occupied < windowSize_");
         std::abort();
+    }
+
+    AckResult BulkSender::onDataAck(uint8_t xferId, uint32_t cumulativeSeq)
+    {
+        if (status_ != Status::STREAMING)
+        {
+            return AckResult::notStreaming();
+        }
+        if (xferId != xferId_)
+        {
+            return AckResult::wrongXferId();
+        }
+        // Stale check: cumulativeSeq must strictly advance from the
+        // previous high-water mark. The `anyConfirmed_` flag
+        // disambiguates "no ACK yet seen" (any cumulativeSeq is fresh)
+        // from "seq 0 already confirmed" (only cumulativeSeq > 0 is
+        // fresh).
+        if (anyConfirmed_ && cumulativeSeq <= highestConfirmedSeq_)
+        {
+            return AckResult::stale();
+        }
+
+        const uint32_t prev = anyConfirmed_ ? highestConfirmedSeq_ + 1 : 0;
+        highestConfirmedSeq_ = cumulativeSeq;
+        anyConfirmed_ = true;
+
+        // Evict all in-flight slots whose seq <= cumulativeSeq.
+        for (auto &e : inFlight_)
+        {
+            if (e.occupied && e.seq <= cumulativeSeq)
+            {
+                e = InFlightEntry{};
+            }
+        }
+
+        const uint32_t newlyConfirmed = cumulativeSeq + 1 - prev;
+        return AckResult::ok(newlyConfirmed);
+    }
+
+    NakResult BulkSender::onDataNak(uint8_t xferId, uint32_t nextExpectedSeq, NakReason /*reason*/)
+    {
+        if (status_ != Status::STREAMING)
+        {
+            return NakResult::notStreaming();
+        }
+        if (xferId != xferId_)
+        {
+            return NakResult::wrongXferId();
+        }
+
+        // Rewind: future sends start from nextExpectedSeq. Evict all
+        // in-flight slots whose seq >= nextExpectedSeq — they were
+        // either NAK'd directly or discarded by the receiver as out-
+        // of-order. The MIXED layer doesn't need to know which slot
+        // belongs to which seq; it just calls nextChunkToSend in a
+        // loop after a NAK.
+        //
+        // Reason is currently unused by the state machine (the wire
+        // layer logs it in M3); it's in the signature so future
+        // reason-aware retry policies don't break the API.
+        nextSeqToSend_ = nextExpectedSeq;
+        for (auto &e : inFlight_)
+        {
+            if (e.occupied && e.seq >= nextExpectedSeq)
+            {
+                e = InFlightEntry{};
+            }
+        }
+        return NakResult::ok(nextExpectedSeq);
     }
 
     void BulkSender::reset()

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -536,6 +536,52 @@ namespace AstrOsBulkTransport
         return NakResult::ok(nextExpectedSeq);
     }
 
+    TickResult BulkSender::tick(uint64_t nowMs)
+    {
+        TickResult result{};
+        if (status_ != Status::STREAMING)
+        {
+            return result;
+        }
+
+        for (auto &e : inFlight_)
+        {
+            if (!e.occupied)
+            {
+                continue;
+            }
+            // Timeout fired iff (nowMs - sendTimestampMs) >= ackTimeoutMs_.
+            // Use subtraction in uint64_t so wrap-around isn't a concern at
+            // typical millisecond scales; if a future caller passes nowMs <
+            // sendTimestampMs (clock went backwards), the underflow wraps
+            // to a huge value and the timeout looks "fired" — acceptable
+            // failure mode (retransmits a slot that wasn't actually timed
+            // out). The MIXED caller is responsible for monotonic time.
+            if (nowMs - e.sendTimestampMs < ackTimeoutMs_)
+            {
+                continue;
+            }
+
+            // Retry count check: if incrementing would exceed maxRetries_,
+            // abandon the whole transfer immediately. The wire-level
+            // contract says "abort this padawan, move to next" — at the
+            // PURE layer we just transition to ABANDONED.
+            if (e.retryCount + 1 > maxRetries_)
+            {
+                status_ = Status::ABANDONED;
+                result.abandon = true;
+                result.count = 0;
+                return result;
+            }
+
+            e.retryCount++;
+            e.sendTimestampMs = nowMs;
+            result.retransmitSeqs[result.count] = e.seq;
+            result.count++;
+        }
+        return result;
+    }
+
     void BulkSender::reset()
     {
         xferId_ = 0;

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -297,6 +297,20 @@ namespace AstrOsBulkTransport
     static_assert(static_cast<uint8_t>(BeginAckResult::Decision::WRONG_XFER_ID) == 1);
     static_assert(static_cast<uint8_t>(BeginAckResult::Decision::NOT_AWAITING_BEGIN_ACK) == 2);
 
+    static_assert(static_cast<uint8_t>(SendResult::Decision::SEND) == 0);
+    static_assert(static_cast<uint8_t>(SendResult::Decision::WINDOW_FULL) == 1);
+    static_assert(static_cast<uint8_t>(SendResult::Decision::ALL_SENT) == 2);
+    static_assert(static_cast<uint8_t>(SendResult::Decision::NOT_STREAMING) == 3);
+
+    // SendResult immutability: every public field must be const so a
+    // factory-produced result can't be mutated into an invalid combo
+    // (WINDOW_FULL with a meaningful seq, etc.). Mirrors ChunkResult's
+    // discipline.
+    static_assert(std::is_const_v<decltype(SendResult::decision)>);
+    static_assert(std::is_const_v<decltype(SendResult::seq)>);
+    static_assert(!std::is_copy_assignable_v<SendResult>);
+    static_assert(std::is_copy_constructible_v<SendResult>);
+
     BeginSenderResult BulkSender::begin(uint8_t xferId, uint32_t totalChunks, uint16_t chunkSize, uint8_t windowSize,
                                         uint32_t ackTimeoutMs, uint8_t maxRetries)
     {
@@ -365,6 +379,61 @@ namespace AstrOsBulkTransport
         }
         status_ = Status::STREAMING;
         return BeginAckResult::ok();
+    }
+
+    SendResult BulkSender::nextChunkToSend(uint64_t nowMs)
+    {
+        if (status_ != Status::STREAMING)
+        {
+            return SendResult::notStreaming();
+        }
+
+        // ALL_SENT check first: if every chunk has been launched into
+        // the in-flight table (or already evicted by ACK), there's
+        // nothing left to claim. The MIXED caller treats ALL_SENT
+        // (plus an empty in-flight table) as the signal to send OTA_END.
+        if (nextSeqToSend_ >= totalChunks_)
+        {
+            return SendResult::allSent();
+        }
+
+        // Count occupied slots. WINDOW_FULL fires when we've already
+        // launched `windowSize_` chunks that haven't been acked yet.
+        // O(MAX_WINDOW_SIZE) linear scan; trivial at 16 entries.
+        uint8_t occupied = 0;
+        for (const auto &e : inFlight_)
+        {
+            if (e.occupied)
+            {
+                occupied++;
+            }
+        }
+        if (occupied >= windowSize_)
+        {
+            return SendResult::windowFull();
+        }
+
+        // Claim the first unoccupied slot. The slot index is internal;
+        // callers identify chunks by seq, not slot.
+        for (auto &e : inFlight_)
+        {
+            if (!e.occupied)
+            {
+                e.seq = nextSeqToSend_;
+                e.sendTimestampMs = nowMs;
+                e.retryCount = 0;
+                e.occupied = true;
+                const uint32_t emittedSeq = nextSeqToSend_;
+                nextSeqToSend_++;
+                return SendResult::send(emittedSeq);
+            }
+        }
+
+        // Unreachable: if `occupied < windowSize_ <= MAX_WINDOW_SIZE`,
+        // at least one slot is free. The early-return above already
+        // returned WINDOW_FULL in the full case.
+        assert(false && "BulkSender::nextChunkToSend: in-flight table full despite occupied < windowSize_");
+        std::abort();
     }
 
     void BulkSender::reset()

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -384,10 +384,7 @@ namespace AstrOsBulkTransport
         nextSeqToSend_ = 0;
         highestConfirmedSeq_ = 0;
         anyConfirmed_ = false;
-        for (auto &e : inFlight_)
-        {
-            e = InFlightEntry{};
-        }
+        inFlight_.fill(InFlightEntry{});
         status_ = Status::AWAITING_BEGIN_ACK;
         return BeginSenderResult::ok();
     }
@@ -541,10 +538,7 @@ namespace AstrOsBulkTransport
         // logs it in M3); it's in the signature so future reason-aware
         // retry policies don't break the API.
         nextSeqToSend_ = nextExpectedSeq;
-        for (auto &e : inFlight_)
-        {
-            e = InFlightEntry{};
-        }
+        inFlight_.fill(InFlightEntry{});
         return NakResult::ok(nextExpectedSeq);
     }
 
@@ -639,10 +633,7 @@ namespace AstrOsBulkTransport
         nextSeqToSend_ = 0;
         highestConfirmedSeq_ = 0;
         anyConfirmed_ = false;
-        for (auto &e : inFlight_)
-        {
-            e = InFlightEntry{};
-        }
+        inFlight_.fill(InFlightEntry{});
         status_ = Status::IDLE;
     }
 } // namespace AstrOsBulkTransport

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -511,9 +511,13 @@ namespace AstrOsBulkTransport
 
         // NAK semantics: nextExpectedSeq carries cumulative-ACK information —
         // the receiver implicitly confirms seqs 0..nextExpectedSeq-1. Advance
-        // highestConfirmedSeq_ accordingly so tick doesn't keep charging
-        // retries against already-accepted seqs (which would eventually
-        // trigger a spurious ABANDONED transition).
+        // highestConfirmedSeq_ so a subsequent OTA_DATA_ACK at or below the
+        // implied cumulative seq is correctly rejected as STALE rather than
+        // being treated as new progress (which would corrupt the
+        // newlyConfirmedCount arithmetic). The protection against tick
+        // charging retries against already-accepted seqs comes from the
+        // unconditional in-flight eviction loop below — not from this
+        // watermark advance.
         //
         // nextExpectedSeq == 0 is the "receiver got nothing" case — no
         // implicit confirmation; leave the watermark untouched.
@@ -601,15 +605,25 @@ namespace AstrOsBulkTransport
             return EndAckResult::wrongXferId();
         }
 
-        // OK is the only success status; HASH_MISMATCH and WRITE_ERROR
-        // both abandon. The MIXED layer (M3) logs the specific status
-        // for diagnostics; the state machine only cares about
-        // success-vs-abandon.
-        if (status == OtaEndStatus::OK)
+        // OK is the only success status; HASH_MISMATCH and WRITE_ERROR both
+        // abandon. The MIXED layer logs the specific status for diagnostics;
+        // the state machine only cares about success-vs-abandon. Switch (not
+        // if-chain) so a future extension of OtaEndStatus produces a -Wswitch
+        // diagnostic at this site rather than silently routing the new
+        // enumerator to ABANDONED.
+        switch (status)
         {
+        case OtaEndStatus::OK:
             status_ = Status::DONE_OK;
             return EndAckResult::doneOk();
+        case OtaEndStatus::HASH_MISMATCH:
+        case OtaEndStatus::WRITE_ERROR:
+            status_ = Status::ABANDONED;
+            return EndAckResult::abandoned();
         }
+        // Fallback: any future enumerator that lands in OtaEndStatus without
+        // an explicit case above is treated as abandon (safe default) but the
+        // -Wswitch diagnostic above will have already flagged the gap.
         status_ = Status::ABANDONED;
         return EndAckResult::abandoned();
     }

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -501,23 +501,37 @@ namespace AstrOsBulkTransport
             return NakResult::wrongXferId();
         }
 
-        // Rewind: future sends start from nextExpectedSeq. Evict all
-        // in-flight slots whose seq >= nextExpectedSeq — they were
-        // either NAK'd directly or discarded by the receiver as out-
-        // of-order. The MIXED layer doesn't need to know which slot
-        // belongs to which seq; it just calls nextChunkToSend in a
-        // loop after a NAK.
+        // NAK semantics: nextExpectedSeq carries cumulative-ACK information —
+        // the receiver implicitly confirms seqs 0..nextExpectedSeq-1. Advance
+        // highestConfirmedSeq_ accordingly so tick doesn't keep charging
+        // retries against already-accepted seqs (which would eventually
+        // trigger a spurious ABANDONED transition).
         //
-        // Reason is currently unused by the state machine (the wire
-        // layer logs it in M3); it's in the signature so future
-        // reason-aware retry policies don't break the API.
+        // nextExpectedSeq == 0 is the "receiver got nothing" case — no
+        // implicit confirmation; leave the watermark untouched.
+        if (nextExpectedSeq > 0)
+        {
+            const uint32_t impliedCumulative = nextExpectedSeq - 1;
+            if (!anyConfirmed_ || impliedCumulative > highestConfirmedSeq_)
+            {
+                highestConfirmedSeq_ = impliedCumulative;
+                anyConfirmed_ = true;
+            }
+        }
+
+        // Rewind: future sends start from nextExpectedSeq. Evict ALL in-flight
+        // slots — those below nextExpectedSeq are now implicitly confirmed
+        // (handled above) and those at or above need retransmission via
+        // subsequent nextChunkToSend calls. The MIXED layer doesn't need to
+        // know which slot belongs to which seq.
+        //
+        // Reason is currently unused by the state machine (the wire layer
+        // logs it in M3); it's in the signature so future reason-aware
+        // retry policies don't break the API.
         nextSeqToSend_ = nextExpectedSeq;
         for (auto &e : inFlight_)
         {
-            if (e.occupied && e.seq >= nextExpectedSeq)
-            {
-                e = InFlightEntry{};
-            }
+            e = InFlightEntry{};
         }
         return NakResult::ok(nextExpectedSeq);
     }

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -513,7 +513,7 @@ namespace AstrOsBulkTransport
         // being treated as new progress (which would corrupt the
         // newlyConfirmedCount arithmetic). The protection against tick
         // charging retries against already-accepted seqs comes from the
-        // unconditional in-flight eviction loop below — not from this
+        // unconditional inFlight_.fill() reset below — not from this
         // watermark advance.
         //
         // nextExpectedSeq == 0 is the "receiver got nothing" case — no

--- a/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
+++ b/lib_native/AstrOsBulkTransport/src/AstrOsBulkTransport.cpp
@@ -315,10 +315,12 @@ namespace AstrOsBulkTransport
     static_assert(static_cast<uint8_t>(AckResult::Decision::WRONG_XFER_ID) == 1);
     static_assert(static_cast<uint8_t>(AckResult::Decision::NOT_STREAMING) == 2);
     static_assert(static_cast<uint8_t>(AckResult::Decision::STALE) == 3);
+    static_assert(static_cast<uint8_t>(AckResult::Decision::OUT_OF_RANGE) == 4);
 
     static_assert(static_cast<uint8_t>(NakResult::Decision::OK) == 0);
     static_assert(static_cast<uint8_t>(NakResult::Decision::WRONG_XFER_ID) == 1);
     static_assert(static_cast<uint8_t>(NakResult::Decision::NOT_STREAMING) == 2);
+    static_assert(static_cast<uint8_t>(NakResult::Decision::OUT_OF_RANGE) == 3);
 
     static_assert(std::is_const_v<decltype(AckResult::decision)>);
     static_assert(std::is_const_v<decltype(AckResult::newlyConfirmedCount)>);
@@ -332,6 +334,7 @@ namespace AstrOsBulkTransport
     static_assert(static_cast<uint8_t>(EndAckResult::Decision::ABANDONED) == 1);
     static_assert(static_cast<uint8_t>(EndAckResult::Decision::WRONG_XFER_ID) == 2);
     static_assert(static_cast<uint8_t>(EndAckResult::Decision::NOT_STREAMING) == 3);
+    static_assert(static_cast<uint8_t>(EndAckResult::Decision::PREMATURE) == 4);
 
     static_assert(std::is_const_v<decltype(EndAckResult::decision)>);
     static_assert(!std::is_copy_assignable_v<EndAckResult>);
@@ -468,6 +471,16 @@ namespace AstrOsBulkTransport
         {
             return AckResult::wrongXferId();
         }
+        // Bounds check: cumulativeSeq must reference a real seq in this transfer.
+        // Defends the PURE state machine against peer-controlled wire input. The
+        // M3 wire parser can also gate this, but we don't want to rely on it.
+        // UINT32_MAX would underflow the newlyConfirmedCount arithmetic below;
+        // cumulativeSeq >= totalChunks_ would let highestConfirmedSeq_ overshoot,
+        // causing false DONE_OK on a subsequent onEndAck(OK).
+        if (cumulativeSeq >= totalChunks_)
+        {
+            return AckResult::outOfRange();
+        }
         // Stale check: cumulativeSeq must strictly advance from the
         // previous high-water mark. The `anyConfirmed_` flag
         // disambiguates "no ACK yet seen" (any cumulativeSeq is fresh)
@@ -504,6 +517,14 @@ namespace AstrOsBulkTransport
         if (xferId != xferId_)
         {
             return NakResult::wrongXferId();
+        }
+        // Bounds check: nextExpectedSeq must reference a seq in this transfer.
+        // Defends against peer-controlled wire input that would advance
+        // nextSeqToSend_ past totalChunks_, causing the sender to silently
+        // skip real chunks via the ALL_SENT path on the next nextChunkToSend.
+        if (nextExpectedSeq >= totalChunks_)
+        {
+            return NakResult::outOfRange();
         }
 
         // NAK semantics: nextExpectedSeq carries cumulative-ACK information —
@@ -597,6 +618,18 @@ namespace AstrOsBulkTransport
         if (xferId != xferId_)
         {
             return EndAckResult::wrongXferId();
+        }
+        // Implicit AWAITING_END_ACK predicate: all chunks must be sent AND all
+        // confirmed before onEndAck is valid. The class doc says AWAITING_END_ACK
+        // "is implicit (STREAMING with all seqs confirmed and in-flight table
+        // empty)" — this guard enforces that implicit state. A misbehaving caller
+        // (sender side) or peer (receiver sending OTA_END_ACK too early) gets
+        // PREMATURE instead of a false DONE_OK on an incomplete transfer.
+        const bool allSent = (nextSeqToSend_ == totalChunks_);
+        const bool allConfirmed = (anyConfirmed_ && highestConfirmedSeq_ + 1 == totalChunks_);
+        if (!allSent || !allConfirmed)
+        {
+            return EndAckResult::premature();
         }
 
         // OK is the only success status; HASH_MISMATCH and WRITE_ERROR both

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -900,3 +900,88 @@ TEST(BulkTransport, BulkSenderEmitsAllChunksWhenTotalIsBelowWindow)
     EXPECT_EQ(1u, sent[1]);
     EXPECT_EQ(2u, sent[2]);
 }
+
+TEST(BulkTransport, BulkSenderOnDataAckAdvancesHighestConfirmed)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    std::vector<uint32_t> sent;
+    drainSends(s, 1000, sent);
+    ASSERT_EQ(8u, sent.size()); // window full at 0..7
+
+    // Cumulative ACK up through seq 3: frees slots for 0..3.
+    auto r = s.onDataAck(7, /*cumulativeSeq=*/3);
+    EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::OK, r.decision);
+    EXPECT_EQ(4u, r.newlyConfirmedCount); // seqs 0, 1, 2, 3 newly confirmed
+
+    // Now nextChunkToSend should emit seq 8 (window frees 4 slots).
+    auto sr = s.nextChunkToSend(1100);
+    EXPECT_EQ(AstrOsBulkTransport::SendResult::Decision::SEND, sr.decision);
+    EXPECT_EQ(8u, sr.seq);
+}
+
+TEST(BulkTransport, BulkSenderRejectsStaleAck)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    std::vector<uint32_t> sent;
+    drainSends(s, 1000, sent);
+
+    ASSERT_EQ(AstrOsBulkTransport::AckResult::Decision::OK, s.onDataAck(7, 5).decision);
+    // Stale: cumulativeSeq=3 already covered by the previous ACK at 5.
+    auto r = s.onDataAck(7, 3);
+    EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::STALE, r.decision);
+}
+
+TEST(BulkTransport, BulkSenderOnDataAckRejectsWrongXferId)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+    auto r = s.onDataAck(/*xferId=*/99, 3);
+    EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::WRONG_XFER_ID, r.decision);
+}
+
+TEST(BulkTransport, BulkSenderOnDataAckRejectsBeforeStreaming)
+{
+    AstrOsBulkTransport::BulkSender s;
+    // No begin / onBeginAck — status is IDLE.
+    auto r = s.onDataAck(7, 0);
+    EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::NOT_STREAMING, r.decision);
+}
+
+TEST(BulkTransport, BulkSenderOnDataNakRewindsToNextExpectedSeq)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    std::vector<uint32_t> sent;
+    drainSends(s, 1000, sent);
+    ASSERT_EQ(8u, sent.size()); // sent 0..7
+
+    // Receiver NAKs with nextExpectedSeq=3 — meaning seqs 0..2 are OK,
+    // but seq 3 needs retransmission (and 4..7 will be discarded by
+    // the receiver since they're out of order).
+    auto r = s.onDataNak(7, /*nextExpectedSeq=*/3, AstrOsBulkTransport::NakReason::CRC);
+    EXPECT_EQ(AstrOsBulkTransport::NakResult::Decision::OK, r.decision);
+    EXPECT_EQ(3u, r.nextSeqToResend);
+
+    // The next send should re-emit seq 3 (not 8).
+    auto sr = s.nextChunkToSend(1100);
+    EXPECT_EQ(AstrOsBulkTransport::SendResult::Decision::SEND, sr.decision);
+    EXPECT_EQ(3u, sr.seq);
+}
+
+TEST(BulkTransport, BulkSenderOnDataNakRejectsWrongXferId)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+    auto r = s.onDataNak(/*xferId=*/99, 3, AstrOsBulkTransport::NakReason::CRC);
+    EXPECT_EQ(AstrOsBulkTransport::NakResult::Decision::WRONG_XFER_ID, r.decision);
+}

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -1035,3 +1035,72 @@ TEST(BulkTransport, BulkSenderOnDataNakWithZeroNextExpectedDoesNotAdvanceConfirm
     auto ackR = s.onDataAck(7, 0);
     EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::OK, ackR.decision);
 }
+
+TEST(BulkTransport, BulkSenderTickReturnsNothingWhenNoTimeoutsFired)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, /*ackTimeoutMs=*/400, /*maxRetries=*/3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    std::vector<uint32_t> sent;
+    drainSends(s, /*nowMs=*/1000, sent);
+    ASSERT_EQ(8u, sent.size());
+
+    auto t = s.tick(/*nowMs=*/1100); // only 100 ms passed — under the 400 ms timeout
+    EXPECT_EQ(0, t.count);
+    EXPECT_FALSE(t.abandon);
+}
+
+TEST(BulkTransport, BulkSenderTickRetransmitsTimedOutSeqs)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    std::vector<uint32_t> sent;
+    drainSends(s, 1000, sent);
+
+    auto t = s.tick(/*nowMs=*/1500); // 500 ms passed — past the 400 ms timeout
+    EXPECT_EQ(8, t.count);
+    EXPECT_FALSE(t.abandon);
+    // All 8 in-flight seqs should be flagged for retransmission.
+    for (uint8_t i = 0; i < 8; i++)
+    {
+        EXPECT_EQ(i, t.retransmitSeqs[i]);
+    }
+}
+
+TEST(BulkTransport, BulkSenderTickAbandonsAfterMaxRetries)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, /*ackTimeoutMs=*/400, /*maxRetries=*/2).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    std::vector<uint32_t> sent;
+    drainSends(s, 0, sent);
+
+    // First tick at 500 ms: retryCount 0 → 1 for every seq.
+    auto t1 = s.tick(500);
+    EXPECT_EQ(8, t1.count);
+    EXPECT_FALSE(t1.abandon);
+
+    // Second tick at 1000 ms: retryCount 1 → 2 for every seq.
+    auto t2 = s.tick(1000);
+    EXPECT_EQ(8, t2.count);
+    EXPECT_FALSE(t2.abandon);
+
+    // Third tick at 1500 ms: retryCount would go 2 → 3 (> maxRetries=2).
+    // Abandon, no further retransmissions.
+    auto t3 = s.tick(1500);
+    EXPECT_TRUE(t3.abandon);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::ABANDONED, s.status());
+}
+
+TEST(BulkTransport, BulkSenderTickReturnsZeroOnInactive)
+{
+    AstrOsBulkTransport::BulkSender s;
+    // Never called begin — IDLE.
+    auto t = s.tick(10000);
+    EXPECT_EQ(0, t.count);
+    EXPECT_FALSE(t.abandon);
+}

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -1093,6 +1093,7 @@ TEST(BulkTransport, BulkSenderTickAbandonsAfterMaxRetries)
     // Abandon, no further retransmissions.
     auto t3 = s.tick(1500);
     EXPECT_TRUE(t3.abandon);
+    EXPECT_EQ(0, t3.count); // abandon path resets count, not a partial retransmit list
     EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::ABANDONED, s.status());
 }
 

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -715,3 +715,113 @@ TEST(BulkTransport, ShouldTeardownOnEndResultNotActivePreservesState)
     EXPECT_FALSE(AstrOsBulkTransport::shouldTeardownOnEndResult(
         AstrOsBulkTransport::EndResult::ioError(AstrOsBulkTransport::EndResult::Reason::NOT_ACTIVE)));
 }
+
+//=================================================================================================
+// BulkSender — M2 wire-format-compatible sender state machine.
+//
+// Mirrors BulkReceiver's result-type discipline: const-fields + private
+// constructor + static factories on each result, [[nodiscard]] enforced
+// per-type, file-scope static_assert pinning of wire-stable enum values.
+//=================================================================================================
+
+TEST(BulkTransport, BulkSenderStartsInIdle)
+{
+    AstrOsBulkTransport::BulkSender s;
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::IDLE, s.status());
+}
+
+TEST(BulkTransport, BulkSenderBeginAcceptsValidParams)
+{
+    AstrOsBulkTransport::BulkSender s;
+    auto r = s.begin(/*xferId=*/7, /*totalChunks=*/100, /*chunkSize=*/128,
+                     /*windowSize=*/8, /*ackTimeoutMs=*/400, /*maxRetries=*/3);
+    EXPECT_TRUE(r.valid);
+    EXPECT_EQ(AstrOsBulkTransport::BeginSenderResult::Reason::OK, r.reason);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::AWAITING_BEGIN_ACK, s.status());
+}
+
+TEST(BulkTransport, BulkSenderBeginRejectsZeroTotalChunks)
+{
+    AstrOsBulkTransport::BulkSender s;
+    auto r = s.begin(/*xferId=*/7, /*totalChunks=*/0, /*chunkSize=*/128,
+                     /*windowSize=*/8, /*ackTimeoutMs=*/400, /*maxRetries=*/3);
+    EXPECT_FALSE(r.valid);
+    EXPECT_EQ(AstrOsBulkTransport::BeginSenderResult::Reason::ZERO_TOTAL_CHUNKS, r.reason);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::IDLE, s.status());
+}
+
+TEST(BulkTransport, BulkSenderBeginRejectsZeroChunkSize)
+{
+    AstrOsBulkTransport::BulkSender s;
+    auto r = s.begin(7, 100, 0, 8, 400, 3);
+    EXPECT_FALSE(r.valid);
+    EXPECT_EQ(AstrOsBulkTransport::BeginSenderResult::Reason::ZERO_CHUNK_SIZE, r.reason);
+}
+
+TEST(BulkTransport, BulkSenderBeginRejectsZeroWindowSize)
+{
+    AstrOsBulkTransport::BulkSender s;
+    auto r = s.begin(7, 100, 128, 0, 400, 3);
+    EXPECT_FALSE(r.valid);
+    EXPECT_EQ(AstrOsBulkTransport::BeginSenderResult::Reason::ZERO_WINDOW_SIZE, r.reason);
+}
+
+TEST(BulkTransport, BulkSenderBeginRejectsZeroAckTimeout)
+{
+    AstrOsBulkTransport::BulkSender s;
+    auto r = s.begin(7, 100, 128, 8, 0, 3);
+    EXPECT_FALSE(r.valid);
+    EXPECT_EQ(AstrOsBulkTransport::BeginSenderResult::Reason::ZERO_ACK_TIMEOUT, r.reason);
+}
+
+TEST(BulkTransport, BulkSenderBeginRejectsZeroMaxRetries)
+{
+    AstrOsBulkTransport::BulkSender s;
+    auto r = s.begin(7, 100, 128, 8, 400, 0);
+    EXPECT_FALSE(r.valid);
+    EXPECT_EQ(AstrOsBulkTransport::BeginSenderResult::Reason::ZERO_MAX_RETRIES, r.reason);
+}
+
+TEST(BulkTransport, BulkSenderBeginRejectsWindowTooLarge)
+{
+    AstrOsBulkTransport::BulkSender s;
+    // MAX_WINDOW_SIZE = 16; windowSize = 17 must reject.
+    auto r = s.begin(7, 100, 128, 17, 400, 3);
+    EXPECT_FALSE(r.valid);
+    EXPECT_EQ(AstrOsBulkTransport::BeginSenderResult::Reason::WINDOW_TOO_LARGE, r.reason);
+}
+
+TEST(BulkTransport, BulkSenderOnBeginAckAdvancesToStreaming)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    auto r = s.onBeginAck(/*xferId=*/7);
+    EXPECT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, r.decision);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::STREAMING, s.status());
+}
+
+TEST(BulkTransport, BulkSenderOnBeginAckRejectsWrongXferId)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    auto r = s.onBeginAck(/*xferId=*/99);
+    EXPECT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::WRONG_XFER_ID, r.decision);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::AWAITING_BEGIN_ACK, s.status());
+}
+
+TEST(BulkTransport, BulkSenderOnBeginAckRejectsBeforeBegin)
+{
+    AstrOsBulkTransport::BulkSender s;
+    // No begin() called — status is IDLE.
+    auto r = s.onBeginAck(7);
+    EXPECT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::NOT_AWAITING_BEGIN_ACK, r.decision);
+}
+
+TEST(BulkTransport, BulkSenderResetReturnsToIdle)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BulkSender::Status::AWAITING_BEGIN_ACK, s.status());
+    s.reset();
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::IDLE, s.status());
+}

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -1110,7 +1110,7 @@ TEST(BulkTransport, BulkSenderTickRetransmitsOnlyPerEntryTimedOutSeqs)
     EXPECT_EQ(3, t.count); // only seqs 1, 2, 3 — NOT seqs 4, 5, 6
     EXPECT_FALSE(t.abandon);
     // Per-seq timestamp drives the decision, not a global timer.
-    // Iteration order is slot-array order; collect into a set for stable comparison.
+    // Iteration order is slot-array order; collect into a sorted vector for stable comparison.
     std::vector<uint32_t> retransmitted(t.retransmitSeqs.begin(), t.retransmitSeqs.begin() + t.count);
     std::sort(retransmitted.begin(), retransmitted.end());
     EXPECT_EQ(1u, retransmitted[0]);

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -1154,33 +1154,51 @@ TEST(BulkTransport, BulkSenderTickReturnsZeroOnInactive)
     EXPECT_FALSE(t.abandon);
 }
 
-TEST(BulkTransport, BulkSenderOnEndAckOkTransitionsToDoneOk)
+TEST(BulkTransport, BulkSenderOnEndAckOkAfterFullDrainTransitionsToDoneOk)
 {
+    // Use a small totalChunks so we can drain + ACK all of them before onEndAck.
+    // The PREMATURE check now requires the implicit AWAITING_END_ACK predicate
+    // (all chunks sent + all confirmed) to be satisfied first.
     AstrOsBulkTransport::BulkSender s;
-    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_TRUE(s.begin(7, /*totalChunks=*/3, 128, /*windowSize=*/8, 400, 3).valid);
     ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    std::vector<uint32_t> sent;
+    auto term = drainSends(s, 1000, sent);
+    ASSERT_EQ(AstrOsBulkTransport::SendResult::Decision::ALL_SENT, term);
+    ASSERT_EQ(3u, sent.size());
+
+    ASSERT_EQ(AstrOsBulkTransport::AckResult::Decision::OK, s.onDataAck(7, /*cumulativeSeq=*/2).decision);
 
     auto r = s.onEndAck(7, OtaEndStatus::OK);
     EXPECT_EQ(AstrOsBulkTransport::EndAckResult::Decision::DONE_OK, r.decision);
     EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::DONE_OK, s.status());
 }
 
-TEST(BulkTransport, BulkSenderOnEndAckHashMismatchAbandons)
+TEST(BulkTransport, BulkSenderOnEndAckHashMismatchAfterFullDrainAbandons)
 {
     AstrOsBulkTransport::BulkSender s;
-    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_TRUE(s.begin(7, /*totalChunks=*/3, 128, /*windowSize=*/8, 400, 3).valid);
     ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    std::vector<uint32_t> sent;
+    drainSends(s, 1000, sent);
+    ASSERT_EQ(AstrOsBulkTransport::AckResult::Decision::OK, s.onDataAck(7, 2).decision);
 
     auto r = s.onEndAck(7, OtaEndStatus::HASH_MISMATCH);
     EXPECT_EQ(AstrOsBulkTransport::EndAckResult::Decision::ABANDONED, r.decision);
     EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::ABANDONED, s.status());
 }
 
-TEST(BulkTransport, BulkSenderOnEndAckWriteErrorAbandons)
+TEST(BulkTransport, BulkSenderOnEndAckWriteErrorAfterFullDrainAbandons)
 {
     AstrOsBulkTransport::BulkSender s;
-    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_TRUE(s.begin(7, /*totalChunks=*/3, 128, /*windowSize=*/8, 400, 3).valid);
     ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    std::vector<uint32_t> sent;
+    drainSends(s, 1000, sent);
+    ASSERT_EQ(AstrOsBulkTransport::AckResult::Decision::OK, s.onDataAck(7, 2).decision);
 
     auto r = s.onEndAck(7, OtaEndStatus::WRITE_ERROR);
     EXPECT_EQ(AstrOsBulkTransport::EndAckResult::Decision::ABANDONED, r.decision);
@@ -1207,6 +1225,81 @@ TEST(BulkTransport, BulkSenderOnEndAckRejectsBeforeStreaming)
     auto r = s.onEndAck(7, OtaEndStatus::OK);
     EXPECT_EQ(AstrOsBulkTransport::EndAckResult::Decision::NOT_STREAMING, r.decision);
     EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::IDLE, s.status());
+}
+
+TEST(BulkTransport, BulkSenderOnDataAckRejectsOutOfRangeCumulativeSeq)
+{
+    // Defensive: cumulativeSeq >= totalChunks_ is a peer-controlled wire
+    // input that would corrupt the watermark and risk a false DONE_OK on
+    // a subsequent onEndAck. PURE layer rejects rather than relying on
+    // the M3 wire parser to validate first.
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, /*totalChunks=*/10, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    // cumulativeSeq=10 is one past the last legal value (seqs are 0..9).
+    auto r = s.onDataAck(7, /*cumulativeSeq=*/10);
+    EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::OUT_OF_RANGE, r.decision);
+
+    // UINT32_MAX is the wire-format upper bound; trips the same guard.
+    auto r2 = s.onDataAck(7, UINT32_MAX);
+    EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::OUT_OF_RANGE, r2.decision);
+}
+
+TEST(BulkTransport, BulkSenderOnDataNakRejectsOutOfRangeNextExpectedSeq)
+{
+    // Defensive: nextExpectedSeq >= totalChunks_ would advance nextSeqToSend_
+    // past the transfer, causing the sender to silently skip chunks via the
+    // ALL_SENT path. PURE layer rejects.
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, /*totalChunks=*/10, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    auto r = s.onDataNak(7, /*nextExpectedSeq=*/10, AstrOsBulkTransport::NakReason::CRC);
+    EXPECT_EQ(AstrOsBulkTransport::NakResult::Decision::OUT_OF_RANGE, r.decision);
+
+    auto r2 = s.onDataNak(7, UINT32_MAX, AstrOsBulkTransport::NakReason::CRC);
+    EXPECT_EQ(AstrOsBulkTransport::NakResult::Decision::OUT_OF_RANGE, r2.decision);
+}
+
+TEST(BulkTransport, BulkSenderOnEndAckRejectsPrematureCall)
+{
+    // The implicit AWAITING_END_ACK predicate requires all chunks sent AND
+    // all confirmed before onEndAck is valid. Calling onEndAck after just
+    // begin + onBeginAck (zero sends, zero ACKs) must return PREMATURE.
+    // windowSize=16 (MAX_WINDOW_SIZE) so all 10 chunks fit without WINDOW_FULL.
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, /*totalChunks=*/10, 128, /*windowSize=*/16, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    // Zero chunks sent; predicate fails.
+    auto r1 = s.onEndAck(7, OtaEndStatus::OK);
+    EXPECT_EQ(AstrOsBulkTransport::EndAckResult::Decision::PREMATURE, r1.decision);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::STREAMING, s.status());
+
+    // Send some but not all; predicate still fails.
+    for (uint32_t i = 0; i < 5; i++)
+    {
+        auto sr = s.nextChunkToSend(1000);
+        ASSERT_EQ(AstrOsBulkTransport::SendResult::Decision::SEND, sr.decision);
+    }
+    auto r2 = s.onEndAck(7, OtaEndStatus::OK);
+    EXPECT_EQ(AstrOsBulkTransport::EndAckResult::Decision::PREMATURE, r2.decision);
+
+    // Send all but ACK only some; predicate still fails (not all confirmed).
+    for (uint32_t i = 5; i < 10; i++)
+    {
+        auto sr = s.nextChunkToSend(1000);
+        ASSERT_EQ(AstrOsBulkTransport::SendResult::Decision::SEND, sr.decision);
+    }
+    ASSERT_EQ(AstrOsBulkTransport::AckResult::Decision::OK, s.onDataAck(7, 4).decision);
+    auto r3 = s.onEndAck(7, OtaEndStatus::OK);
+    EXPECT_EQ(AstrOsBulkTransport::EndAckResult::Decision::PREMATURE, r3.decision);
+
+    // Finally confirm everything — onEndAck now succeeds.
+    ASSERT_EQ(AstrOsBulkTransport::AckResult::Decision::OK, s.onDataAck(7, 9).decision);
+    auto r4 = s.onEndAck(7, OtaEndStatus::OK);
+    EXPECT_EQ(AstrOsBulkTransport::EndAckResult::Decision::DONE_OK, r4.decision);
 }
 
 TEST(BulkTransport, BulkSenderEndToEndHappyPath)

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -719,9 +719,13 @@ TEST(BulkTransport, ShouldTeardownOnEndResultNotActivePreservesState)
 //=================================================================================================
 // BulkSender — M2 wire-format-compatible sender state machine.
 //
-// Mirrors BulkReceiver's result-type discipline: const-fields + private
-// constructor + static factories on each result, [[nodiscard]] enforced
-// per-type, file-scope static_assert pinning of wire-stable enum values.
+// Mirrors the BulkReceiver result-type family: each result struct carries
+// [[nodiscard]] at the type level + file-scope static_assert pinning of
+// integer enum values. BeginSenderResult / BeginAckResult use the simpler
+// BeginResult / EndResult pattern (mutable bool valid + Reason fields,
+// static factories). Later M2 tasks introduce ChunkResult-style
+// const-fields + private-ctor result types (SendResult, AckResult, NakResult,
+// EndAckResult) where the additional invariant enforcement earns its keep.
 //=================================================================================================
 
 TEST(BulkTransport, BulkSenderStartsInIdle)

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -1230,9 +1230,12 @@ TEST(BulkTransport, BulkSenderOnEndAckRejectsBeforeStreaming)
 TEST(BulkTransport, BulkSenderOnDataAckRejectsOutOfRangeCumulativeSeq)
 {
     // Defensive: cumulativeSeq >= totalChunks_ is a peer-controlled wire
-    // input that would corrupt the watermark and risk a false DONE_OK on
-    // a subsequent onEndAck. PURE layer rejects rather than relying on
-    // the M3 wire parser to validate first.
+    // input that would corrupt the highestConfirmedSeq_ watermark (causing
+    // later valid-range ACKs to be falsely rejected as STALE) and, for
+    // UINT32_MAX specifically, would wrap the newlyConfirmedCount return
+    // value to zero. The PREMATURE guard in onEndAck catches the
+    // false-DONE_OK outcome separately; this guard prevents the watermark
+    // corruption that would precede it.
     AstrOsBulkTransport::BulkSender s;
     ASSERT_TRUE(s.begin(7, /*totalChunks=*/10, 128, 8, 400, 3).valid);
     ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
@@ -1244,6 +1247,19 @@ TEST(BulkTransport, BulkSenderOnDataAckRejectsOutOfRangeCumulativeSeq)
     // UINT32_MAX is the wire-format upper bound; trips the same guard.
     auto r2 = s.onDataAck(7, UINT32_MAX);
     EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::OUT_OF_RANGE, r2.decision);
+
+    // Boundary: cumulativeSeq=9 (totalChunks_-1) is the last legal value
+    // and must be accepted. Pins inclusive-vs-exclusive of the upper bound.
+    // windowSize=16 (MAX_WINDOW_SIZE) so all 10 chunks fit without WINDOW_FULL.
+    AstrOsBulkTransport::BulkSender s2;
+    ASSERT_TRUE(s2.begin(7, /*totalChunks=*/10, 128, /*windowSize=*/16, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s2.onBeginAck(7).decision);
+    for (uint32_t i = 0; i < 10; i++)
+    {
+        ASSERT_EQ(AstrOsBulkTransport::SendResult::Decision::SEND, s2.nextChunkToSend(1000).decision);
+    }
+    auto okR = s2.onDataAck(7, /*cumulativeSeq=*/9);
+    EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::OK, okR.decision);
 }
 
 TEST(BulkTransport, BulkSenderOnDataNakRejectsOutOfRangeNextExpectedSeq)
@@ -1260,6 +1276,19 @@ TEST(BulkTransport, BulkSenderOnDataNakRejectsOutOfRangeNextExpectedSeq)
 
     auto r2 = s.onDataNak(7, UINT32_MAX, AstrOsBulkTransport::NakReason::CRC);
     EXPECT_EQ(AstrOsBulkTransport::NakResult::Decision::OUT_OF_RANGE, r2.decision);
+
+    // Boundary: nextExpectedSeq=9 (totalChunks_-1) is the last legal value
+    // (receiver asking for the last seq to be resent) and must be accepted.
+    // windowSize=16 (MAX_WINDOW_SIZE) so all 10 chunks fit without WINDOW_FULL.
+    AstrOsBulkTransport::BulkSender s2;
+    ASSERT_TRUE(s2.begin(7, /*totalChunks=*/10, 128, /*windowSize=*/16, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s2.onBeginAck(7).decision);
+    for (uint32_t i = 0; i < 10; i++)
+    {
+        ASSERT_EQ(AstrOsBulkTransport::SendResult::Decision::SEND, s2.nextChunkToSend(1000).decision);
+    }
+    auto okR = s2.onDataNak(7, /*nextExpectedSeq=*/9, AstrOsBulkTransport::NakReason::CRC);
+    EXPECT_EQ(AstrOsBulkTransport::NakResult::Decision::OK, okR.decision);
 }
 
 TEST(BulkTransport, BulkSenderOnEndAckRejectsPrematureCall)

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -1262,6 +1262,36 @@ TEST(BulkTransport, BulkSenderOnDataAckRejectsOutOfRangeCumulativeSeq)
     EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::OK, okR.decision);
 }
 
+TEST(BulkTransport, BulkSenderOnDataAckRejectsAheadOfSenderCumulativeSeq)
+{
+    // Defensive: cumulativeSeq must be < nextSeqToSend_ (we can't legitimately
+    // receive an ACK for a chunk we haven't even sent). A peer ACK at a seq
+    // within the transfer range but ahead of where we've launched would
+    // corrupt the watermark and evict all real in-flight slots, stalling
+    // the transfer. PURE layer rejects with OUT_OF_RANGE.
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, /*totalChunks=*/100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    // Send 5 chunks. nextSeqToSend_ is now 5.
+    for (uint32_t i = 0; i < 5; i++)
+    {
+        ASSERT_EQ(AstrOsBulkTransport::SendResult::Decision::SEND, s.nextChunkToSend(1000).decision);
+    }
+
+    // cumulativeSeq=5 (== nextSeqToSend_) — we haven't sent seq 5 yet.
+    auto r1 = s.onDataAck(7, /*cumulativeSeq=*/5);
+    EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::OUT_OF_RANGE, r1.decision);
+
+    // cumulativeSeq=15 (well ahead of nextSeqToSend_=5, still < totalChunks_=100).
+    auto r2 = s.onDataAck(7, /*cumulativeSeq=*/15);
+    EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::OUT_OF_RANGE, r2.decision);
+
+    // Sanity: the legitimate boundary cumulativeSeq=4 (last sent) is accepted.
+    auto r3 = s.onDataAck(7, /*cumulativeSeq=*/4);
+    EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::OK, r3.decision);
+}
+
 TEST(BulkTransport, BulkSenderOnDataNakRejectsOutOfRangeNextExpectedSeq)
 {
     // Defensive: nextExpectedSeq >= totalChunks_ would advance nextSeqToSend_
@@ -1289,6 +1319,54 @@ TEST(BulkTransport, BulkSenderOnDataNakRejectsOutOfRangeNextExpectedSeq)
     }
     auto okR = s2.onDataNak(7, /*nextExpectedSeq=*/9, AstrOsBulkTransport::NakReason::CRC);
     EXPECT_EQ(AstrOsBulkTransport::NakResult::Decision::OK, okR.decision);
+}
+
+TEST(BulkTransport, BulkSenderOnDataNakRejectsAheadOfSenderNextExpectedSeq)
+{
+    // Defensive: nextExpectedSeq must be <= nextSeqToSend_ (NAK semantics are
+    // "rewind to here" — a peer NAK fast-forwarding past nextSeqToSend_ would
+    // skip chunks we haven't launched. Equality is the degenerate no-op
+    // (accepted); strict-greater is wire-protocol violation (rejected).
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, /*totalChunks=*/100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    // Send 5 chunks. nextSeqToSend_ is now 5.
+    for (uint32_t i = 0; i < 5; i++)
+    {
+        ASSERT_EQ(AstrOsBulkTransport::SendResult::Decision::SEND, s.nextChunkToSend(1000).decision);
+    }
+
+    // nextExpectedSeq=6 (one past nextSeqToSend_=5; we haven't sent seq 5 yet).
+    auto r1 = s.onDataNak(7, /*nextExpectedSeq=*/6, AstrOsBulkTransport::NakReason::CRC);
+    EXPECT_EQ(AstrOsBulkTransport::NakResult::Decision::OUT_OF_RANGE, r1.decision);
+
+    // nextExpectedSeq=50 (well ahead of nextSeqToSend_=5, still < totalChunks_=100).
+    auto r2 = s.onDataNak(7, /*nextExpectedSeq=*/50, AstrOsBulkTransport::NakReason::CRC);
+    EXPECT_EQ(AstrOsBulkTransport::NakResult::Decision::OUT_OF_RANGE, r2.decision);
+
+    // Sanity: the degenerate boundary nextExpectedSeq=5 (== nextSeqToSend_) is
+    // accepted as a no-op rewind. The legitimate rewind nextExpectedSeq=3
+    // (< nextSeqToSend_) is also accepted.
+    AstrOsBulkTransport::BulkSender s2;
+    ASSERT_TRUE(s2.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s2.onBeginAck(7).decision);
+    for (uint32_t i = 0; i < 5; i++)
+    {
+        ASSERT_EQ(AstrOsBulkTransport::SendResult::Decision::SEND, s2.nextChunkToSend(1000).decision);
+    }
+    auto rNoOp = s2.onDataNak(7, /*nextExpectedSeq=*/5, AstrOsBulkTransport::NakReason::CRC);
+    EXPECT_EQ(AstrOsBulkTransport::NakResult::Decision::OK, rNoOp.decision);
+
+    AstrOsBulkTransport::BulkSender s3;
+    ASSERT_TRUE(s3.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s3.onBeginAck(7).decision);
+    for (uint32_t i = 0; i < 5; i++)
+    {
+        ASSERT_EQ(AstrOsBulkTransport::SendResult::Decision::SEND, s3.nextChunkToSend(1000).decision);
+    }
+    auto rRewind = s3.onDataNak(7, /*nextExpectedSeq=*/3, AstrOsBulkTransport::NakReason::CRC);
+    EXPECT_EQ(AstrOsBulkTransport::NakResult::Decision::OK, rRewind.decision);
 }
 
 TEST(BulkTransport, BulkSenderOnEndAckRejectsPrematureCall)

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -1,6 +1,7 @@
 #include <AstrOsBulkTransport.hpp>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <vector>
@@ -1068,6 +1069,53 @@ TEST(BulkTransport, BulkSenderTickRetransmitsTimedOutSeqs)
     {
         EXPECT_EQ(i, t.retransmitSeqs[i]);
     }
+}
+
+TEST(BulkTransport, BulkSenderTickRetransmitsOnlyPerEntryTimedOutSeqs)
+{
+    // Per-entry timestamp granularity: send 4 chunks at t=1000, ACK one of them,
+    // send 3 more at t=1200 (so in-flight has mixed timestamps from t=1000 and
+    // t=1200). Tick at t=1450 with ackTimeout=400. Only the t=1000 seqs are
+    // past timeout (1450-1000=450 >= 400); t=1200 seqs aren't (1450-1200=250 < 400).
+    //
+    // Catches a regression where tick uses a single global timer instead of
+    // per-entry sendTimestampMs.
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, /*ackTimeoutMs=*/400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    // Send seqs 0..3 at t=1000.
+    std::vector<uint32_t> firstBatch;
+    for (uint32_t i = 0; i < 4; i++)
+    {
+        auto r = s.nextChunkToSend(1000);
+        ASSERT_EQ(AstrOsBulkTransport::SendResult::Decision::SEND, r.decision);
+        firstBatch.push_back(r.seq);
+    }
+    ASSERT_EQ(4u, firstBatch.size());
+
+    // ACK seq 0 — frees one slot. In-flight now {1, 2, 3} at t=1000.
+    ASSERT_EQ(AstrOsBulkTransport::AckResult::Decision::OK, s.onDataAck(7, 0).decision);
+
+    // Send seqs 4..6 at t=1200. In-flight now {1, 2, 3} at t=1000 + {4, 5, 6} at t=1200.
+    for (uint32_t i = 0; i < 3; i++)
+    {
+        auto r = s.nextChunkToSend(1200);
+        ASSERT_EQ(AstrOsBulkTransport::SendResult::Decision::SEND, r.decision);
+    }
+
+    // Tick at t=1450. Slots from t=1000: 450 ms elapsed (>= 400, timed out).
+    //                Slots from t=1200: 250 ms elapsed (< 400, not timed out).
+    auto t = s.tick(1450);
+    EXPECT_EQ(3, t.count); // only seqs 1, 2, 3 — NOT seqs 4, 5, 6
+    EXPECT_FALSE(t.abandon);
+    // Per-seq timestamp drives the decision, not a global timer.
+    // Iteration order is slot-array order; collect into a set for stable comparison.
+    std::vector<uint32_t> retransmitted(t.retransmitSeqs.begin(), t.retransmitSeqs.begin() + t.count);
+    std::sort(retransmitted.begin(), retransmitted.end());
+    EXPECT_EQ(1u, retransmitted[0]);
+    EXPECT_EQ(2u, retransmitted[1]);
+    EXPECT_EQ(3u, retransmitted[2]);
 }
 
 TEST(BulkTransport, BulkSenderTickAbandonsAfterMaxRetries)

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -1149,6 +1149,18 @@ TEST(BulkTransport, BulkSenderOnEndAckRejectsWrongXferId)
     EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::STREAMING, s.status());
 }
 
+TEST(BulkTransport, BulkSenderOnEndAckRejectsBeforeStreaming)
+{
+    // Symmetry with the NOT_STREAMING tests for the other BulkSender
+    // methods. Closes the test-matrix gap so a future refactor that
+    // accidentally drops the status guard from onEndAck is caught.
+    AstrOsBulkTransport::BulkSender s;
+    // Never called begin — status is IDLE.
+    auto r = s.onEndAck(7, OtaEndStatus::OK);
+    EXPECT_EQ(AstrOsBulkTransport::EndAckResult::Decision::NOT_STREAMING, r.decision);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::IDLE, s.status());
+}
+
 TEST(BulkTransport, BulkSenderEndToEndHappyPath)
 {
     // Drives the full state machine through a small transfer with the

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -1264,11 +1264,14 @@ TEST(BulkTransport, BulkSenderOnDataAckRejectsOutOfRangeCumulativeSeq)
 
 TEST(BulkTransport, BulkSenderOnDataAckRejectsAheadOfSenderCumulativeSeq)
 {
-    // Defensive: cumulativeSeq must be < nextSeqToSend_ (we can't legitimately
-    // receive an ACK for a chunk we haven't even sent). A peer ACK at a seq
-    // within the transfer range but ahead of where we've launched would
-    // corrupt the watermark and evict all real in-flight slots, stalling
-    // the transfer. PURE layer rejects with OUT_OF_RANGE.
+    // Defensive: cumulativeSeq must be < highWaterSentSeq_ (we can't legitimately
+    // receive an ACK for a chunk we haven't ever launched). Using the all-time
+    // high-water mark — not the current nextSeqToSend_ — keeps the bound tight
+    // across NAK-driven rewinds (see BulkSenderOnDataAckAcceptsInFlightAckInPostRewindGap
+    // for the rewind case the high-water mechanism was designed for). A peer ACK at
+    // a seq within the transfer range but ahead of where we've ever launched would
+    // corrupt the watermark and evict all real in-flight slots, stalling the
+    // transfer. PURE layer rejects with OUT_OF_RANGE.
     AstrOsBulkTransport::BulkSender s;
     ASSERT_TRUE(s.begin(7, /*totalChunks=*/100, 128, 8, 400, 3).valid);
     ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
@@ -1367,6 +1370,66 @@ TEST(BulkTransport, BulkSenderOnDataNakRejectsAheadOfSenderNextExpectedSeq)
     }
     auto rRewind = s3.onDataNak(7, /*nextExpectedSeq=*/3, AstrOsBulkTransport::NakReason::CRC);
     EXPECT_EQ(AstrOsBulkTransport::NakResult::Decision::OK, rRewind.decision);
+}
+
+TEST(BulkTransport, BulkSenderOnDataAckAcceptsInFlightAckInPostRewindGap)
+{
+    // This is the test the highWaterSentSeq_ mechanism exists for.
+    //
+    // Scenario:
+    //   1. Sender launches seqs 0..7 (nextSeqToSend_=8, highWaterSentSeq_=8).
+    //   2. Receiver NAKs at nextExpectedSeq=0 (e.g. session-wide reset request).
+    //      After processing: nextSeqToSend_=0, highWaterSentSeq_ STAYS 8.
+    //   3. Sender re-emits seqs 0..3 (nextSeqToSend_=4, highWaterSentSeq_ still 8).
+    //   4. A stale in-flight ACK from BEFORE the rewind arrives, claiming
+    //      cumulativeSeq=5 (seq 5 was sent in step 1, before being wiped from
+    //      the in-flight table by the step-2 NAK).
+    //   5. Expected: the ACK is ACCEPTED because 5 < highWaterSentSeq_=8.
+    //      If the bounds check used nextSeqToSend_=4 instead of high-water,
+    //      this would falsely return OUT_OF_RANGE.
+    //
+    // A future refactor that "simplifies" the ACK bound from
+    // `cumulativeSeq >= highWaterSentSeq_` back to `cumulativeSeq >= nextSeqToSend_`
+    // would break this test — that's the regression this guards against.
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, /*totalChunks=*/100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    // Step 1: launch seqs 0..7.
+    for (uint32_t i = 0; i < 8; i++)
+    {
+        ASSERT_EQ(AstrOsBulkTransport::SendResult::Decision::SEND, s.nextChunkToSend(1000).decision);
+    }
+
+    // Step 2: NAK rewind to 0. nextSeqToSend_ drops to 0; highWaterSentSeq_
+    // stays at 8.
+    ASSERT_EQ(AstrOsBulkTransport::NakResult::Decision::OK,
+              s.onDataNak(7, /*nextExpectedSeq=*/0, AstrOsBulkTransport::NakReason::CRC).decision);
+
+    // Step 3: re-emit seqs 0..3. nextSeqToSend_ becomes 4; highWaterSentSeq_
+    // stays at 8 (monotonically non-decreasing).
+    for (uint32_t i = 0; i < 4; i++)
+    {
+        ASSERT_EQ(AstrOsBulkTransport::SendResult::Decision::SEND, s.nextChunkToSend(2000).decision);
+    }
+
+    // Step 4 + 5: stale in-flight ACK for cumulativeSeq=5 (was launched
+    // pre-NAK in step 1). 5 < highWaterSentSeq_=8, so the high-water bound
+    // accepts. The ACK is not stale either (anyConfirmed_=false initially
+    // because the NAK with nextExpectedSeq=0 did NOT advance the confirmed
+    // watermark — see BulkSenderOnDataNakWithZeroNextExpectedDoesNotAdvanceConfirmed).
+    auto r = s.onDataAck(7, /*cumulativeSeq=*/5);
+    EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::OK, r.decision);
+
+    // Boundary sanity: cumulativeSeq=7 (highWaterSentSeq_-1) should also be
+    // OK. cumulativeSeq=8 (== highWaterSentSeq_) would be OUT_OF_RANGE on
+    // a fresh sender, but here the prior ACK at 5 advanced highestConfirmedSeq_,
+    // so 8 still trips the high-water bound (8 >= 8).
+    auto r2 = s.onDataAck(7, /*cumulativeSeq=*/7);
+    EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::OK, r2.decision);
+
+    auto r3 = s.onDataAck(7, /*cumulativeSeq=*/8);
+    EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::OUT_OF_RANGE, r3.decision);
 }
 
 TEST(BulkTransport, BulkSenderOnEndAckRejectsPrematureCall)

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -985,3 +985,53 @@ TEST(BulkTransport, BulkSenderOnDataNakRejectsWrongXferId)
     auto r = s.onDataNak(/*xferId=*/99, 3, AstrOsBulkTransport::NakReason::CRC);
     EXPECT_EQ(AstrOsBulkTransport::NakResult::Decision::WRONG_XFER_ID, r.decision);
 }
+
+TEST(BulkTransport, BulkSenderOnDataNakRejectsBeforeStreaming)
+{
+    // Symmetry with the OnDataAck variant: NAK with status==IDLE returns
+    // NOT_STREAMING. Closes the test-matrix gap (ACK has this test; NAK
+    // didn't until now).
+    AstrOsBulkTransport::BulkSender s;
+    auto r = s.onDataNak(7, 0, AstrOsBulkTransport::NakReason::CRC);
+    EXPECT_EQ(AstrOsBulkTransport::NakResult::Decision::NOT_STREAMING, r.decision);
+}
+
+TEST(BulkTransport, BulkSenderOnDataNakImplicitlyAdvancesConfirmedWatermark)
+{
+    // NAK with nextExpectedSeq=3 implies seqs 0..2 are confirmed. A
+    // subsequent ACK at cumulativeSeq=2 must be rejected as stale — the
+    // implicit confirmation already covered that range. This pins the
+    // cumulative-ACK semantics of NAK so a future regression that drops
+    // the highestConfirmedSeq_ advance gets caught.
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    std::vector<uint32_t> sent;
+    drainSends(s, 1000, sent);
+
+    ASSERT_EQ(AstrOsBulkTransport::NakResult::Decision::OK,
+              s.onDataNak(7, /*nextExpectedSeq=*/3, AstrOsBulkTransport::NakReason::CRC).decision);
+
+    auto staleR = s.onDataAck(7, 2);
+    EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::STALE, staleR.decision);
+}
+
+TEST(BulkTransport, BulkSenderOnDataNakWithZeroNextExpectedDoesNotAdvanceConfirmed)
+{
+    // NAK with nextExpectedSeq=0 means "receiver got nothing" — no implicit
+    // confirmation. Subsequent ACK at cumulativeSeq=0 must NOT be stale;
+    // the NAK didn't confirm anything.
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    std::vector<uint32_t> sent;
+    drainSends(s, 1000, sent);
+
+    ASSERT_EQ(AstrOsBulkTransport::NakResult::Decision::OK,
+              s.onDataNak(7, /*nextExpectedSeq=*/0, AstrOsBulkTransport::NakReason::CRC).decision);
+
+    auto ackR = s.onDataAck(7, 0);
+    EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::OK, ackR.decision);
+}

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -1105,3 +1105,80 @@ TEST(BulkTransport, BulkSenderTickReturnsZeroOnInactive)
     EXPECT_EQ(0, t.count);
     EXPECT_FALSE(t.abandon);
 }
+
+TEST(BulkTransport, BulkSenderOnEndAckOkTransitionsToDoneOk)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    auto r = s.onEndAck(7, OtaEndStatus::OK);
+    EXPECT_EQ(AstrOsBulkTransport::EndAckResult::Decision::DONE_OK, r.decision);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::DONE_OK, s.status());
+}
+
+TEST(BulkTransport, BulkSenderOnEndAckHashMismatchAbandons)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    auto r = s.onEndAck(7, OtaEndStatus::HASH_MISMATCH);
+    EXPECT_EQ(AstrOsBulkTransport::EndAckResult::Decision::ABANDONED, r.decision);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::ABANDONED, s.status());
+}
+
+TEST(BulkTransport, BulkSenderOnEndAckWriteErrorAbandons)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    auto r = s.onEndAck(7, OtaEndStatus::WRITE_ERROR);
+    EXPECT_EQ(AstrOsBulkTransport::EndAckResult::Decision::ABANDONED, r.decision);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::ABANDONED, s.status());
+}
+
+TEST(BulkTransport, BulkSenderOnEndAckRejectsWrongXferId)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+    auto r = s.onEndAck(/*xferId=*/99, OtaEndStatus::OK);
+    EXPECT_EQ(AstrOsBulkTransport::EndAckResult::Decision::WRONG_XFER_ID, r.decision);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::STREAMING, s.status());
+}
+
+TEST(BulkTransport, BulkSenderEndToEndHappyPath)
+{
+    // Drives the full state machine through a small transfer with the
+    // exact API call pattern M3's OtaForwarder will use.
+    // windowSize=8 > totalChunks=4 so all 4 chunks fit in the window
+    // and drainSends returns ALL_SENT after emitting all of them.
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(/*xferId=*/42, /*totalChunks=*/4, 128, /*windowSize=*/8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BulkSender::Status::AWAITING_BEGIN_ACK, s.status());
+
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(42).decision);
+    ASSERT_EQ(AstrOsBulkTransport::BulkSender::Status::STREAMING, s.status());
+
+    // Pump nextChunkToSend — all 4 chunks fit in the window before ALL_SENT.
+    std::vector<uint32_t> sent;
+    auto term = drainSends(s, 1000, sent);
+    EXPECT_EQ(AstrOsBulkTransport::SendResult::Decision::ALL_SENT, term);
+    ASSERT_EQ(4u, sent.size()); // seqs 0..3 emitted
+
+    // Receiver cumulatively ACKs all 4 (seqs 0..3).
+    auto ackR = s.onDataAck(42, /*cumulativeSeq=*/3);
+    EXPECT_EQ(AstrOsBulkTransport::AckResult::Decision::OK, ackR.decision);
+    EXPECT_EQ(4u, ackR.newlyConfirmedCount);
+
+    // nextChunkToSend still reports ALL_SENT — nothing left to emit.
+    auto sendR = s.nextChunkToSend(1100);
+    EXPECT_EQ(AstrOsBulkTransport::SendResult::Decision::ALL_SENT, sendR.decision);
+
+    // Send OTA_END, receiver replies OK.
+    auto endR = s.onEndAck(42, OtaEndStatus::OK);
+    EXPECT_EQ(AstrOsBulkTransport::EndAckResult::Decision::DONE_OK, endR.decision);
+    EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::DONE_OK, s.status());
+}

--- a/test/test_native/bulk_transport_tests.cpp
+++ b/test/test_native/bulk_transport_tests.cpp
@@ -829,3 +829,74 @@ TEST(BulkTransport, BulkSenderResetReturnsToIdle)
     s.reset();
     EXPECT_EQ(AstrOsBulkTransport::BulkSender::Status::IDLE, s.status());
 }
+
+namespace
+{
+    // Helper: drive `nextChunkToSend` in a loop until WINDOW_FULL or ALL_SENT.
+    // Records each emitted seq in `outSeqs`. Returns the final Decision.
+    AstrOsBulkTransport::SendResult::Decision drainSends(AstrOsBulkTransport::BulkSender &s, uint64_t nowMs,
+                                                         std::vector<uint32_t> &outSeqs)
+    {
+        for (;;)
+        {
+            auto r = s.nextChunkToSend(nowMs);
+            if (r.decision == AstrOsBulkTransport::SendResult::Decision::SEND)
+            {
+                outSeqs.push_back(r.seq);
+                continue;
+            }
+            return r.decision;
+        }
+    }
+} // namespace
+
+TEST(BulkTransport, BulkSenderNextChunkRejectedBeforeStreaming)
+{
+    AstrOsBulkTransport::BulkSender s;
+    auto r = s.nextChunkToSend(/*nowMs=*/0);
+    EXPECT_EQ(AstrOsBulkTransport::SendResult::Decision::NOT_STREAMING, r.decision);
+}
+
+TEST(BulkTransport, BulkSenderNextChunkAfterBeginAckEmitsSeqZero)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, 100, 128, 8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    auto r = s.nextChunkToSend(/*nowMs=*/1000);
+    EXPECT_EQ(AstrOsBulkTransport::SendResult::Decision::SEND, r.decision);
+    EXPECT_EQ(0u, r.seq);
+}
+
+TEST(BulkTransport, BulkSenderFillsWindowThenStopsWithWindowFull)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, /*totalChunks=*/100, 128, /*windowSize=*/8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    std::vector<uint32_t> sent;
+    auto terminal = drainSends(s, 1000, sent);
+
+    EXPECT_EQ(AstrOsBulkTransport::SendResult::Decision::WINDOW_FULL, terminal);
+    ASSERT_EQ(8u, sent.size());
+    for (uint32_t i = 0; i < 8; i++)
+    {
+        EXPECT_EQ(i, sent[i]);
+    }
+}
+
+TEST(BulkTransport, BulkSenderEmitsAllChunksWhenTotalIsBelowWindow)
+{
+    AstrOsBulkTransport::BulkSender s;
+    ASSERT_TRUE(s.begin(7, /*totalChunks=*/3, 128, /*windowSize=*/8, 400, 3).valid);
+    ASSERT_EQ(AstrOsBulkTransport::BeginAckResult::Decision::OK, s.onBeginAck(7).decision);
+
+    std::vector<uint32_t> sent;
+    auto terminal = drainSends(s, 1000, sent);
+
+    EXPECT_EQ(AstrOsBulkTransport::SendResult::Decision::ALL_SENT, terminal);
+    ASSERT_EQ(3u, sent.size());
+    EXPECT_EQ(0u, sent[0]);
+    EXPECT_EQ(1u, sent[1]);
+    EXPECT_EQ(2u, sent[2]);
+}


### PR DESCRIPTION
# OTA Mesh Forward M2 — BulkSender PURE State Machine

Second of 5 milestones in PR set 1 of the firmware OTA mesh-forward feature
(`AstrOs.Server/.docs/completed_plans/2026/04/27/20260427-2202-firmware-ota-decomposition.md`
sub-project **(b)** phase 2). Adds a sliding-window sender state machine
alongside the existing `BulkReceiver` in `lib_native/AstrOsBulkTransport`,
with full result-type discipline and defensive validation against
peer-controlled input.

**Zero firmware behavior change.** All changes are in PURE `lib_native/`
code. Sits **21 commits** ahead of `develop` (5 files, **42 new native
tests**, both board builds clean). Hardened across **4 full PR-toolkit
review cycles** plus an external review round that caught header
docstring drift.

## What ships

### `lib_native/AstrOsBulkTransport/include/AstrOsBulkTransport.hpp`

The header gained 7 result types and the `BulkSender` class. All result
types follow the established `BulkReceiver` discipline:

- **5 result types use the `ChunkResult`-style pattern** (const fields +
  private constructor + static factories + struct-level `[[nodiscard]]`):
  - `SendResult` — 4 Decisions: SEND / WINDOW_FULL / ALL_SENT / NOT_STREAMING
  - `AckResult` — 5 Decisions: OK / WRONG_XFER_ID / NOT_STREAMING / STALE /
    **OUT_OF_RANGE** (defensive bounds check against peer-controlled
    `cumulativeSeq >= totalChunks_`)
  - `NakResult` — 4 Decisions: OK / WRONG_XFER_ID / NOT_STREAMING /
    **OUT_OF_RANGE** (defensive bounds check on `nextExpectedSeq`)
  - `EndAckResult` — 5 Decisions: DONE_OK / ABANDONED / WRONG_XFER_ID /
    NOT_STREAMING / **PREMATURE** (enforces the implicit AWAITING_END_ACK
    predicate — "all chunks sent AND all confirmed")
- **2 result types use the `BeginResult`-style pattern** (mutable public
  fields + factories + struct-level `[[nodiscard]]`):
  - `BeginSenderResult` — 7 Reasons covering every `begin` parameter
    validation
  - `BeginAckResult` — 3 Decisions
- **1 output-buffer type**: `TickResult` — `std::array<uint32_t,
  MAX_WINDOW_SIZE>` plus `count` and `abandon` flags, struct-level
  `[[nodiscard]]`. Intentionally simpler than the other result types
  because `tick()` fills the array as it iterates the in-flight table.

Plus:
- `MAX_WINDOW_SIZE = 16` — covers both the ESP-NOW (8) and serial (16)
  window sizes from the frozen contract. Bounds the in-flight table and
  `TickResult::retransmitSeqs[]` so the sender is heap-free.
- `InFlightEntry` POD struct — one row of the in-flight table.

### `BulkSender` class

5-state machine: `IDLE → AWAITING_BEGIN_ACK → STREAMING → DONE_OK |
ABANDONED`. `AWAITING_END_ACK` is intentionally **not** a distinct state —
it's implicit ("STREAMING with all seqs confirmed and in-flight table
empty"). The `PREMATURE` guard on `onEndAck` enforces this implicit
predicate at runtime.

8 public methods, all `[[nodiscard]]` where they return a result type:

| Method | Returns | Purpose |
|---|---|---|
| `begin(xferId, totalChunks, chunkSize, windowSize, ackTimeoutMs, maxRetries)` | `BeginSenderResult` | IDLE → AWAITING_BEGIN_ACK; validates 7 distinct param-rejection reasons |
| `onBeginAck(xferId)` | `BeginAckResult` | AWAITING_BEGIN_ACK → STREAMING |
| `nextChunkToSend(nowMs)` | `SendResult` | Claim an in-flight slot, return seq to emit. WINDOW_FULL / ALL_SENT terminal conditions |
| `onDataAck(xferId, cumulativeSeq)` | `AckResult` | Cumulative-ACK semantics: advances `highestConfirmedSeq_`, evicts confirmed in-flight slots, returns `newlyConfirmedCount` for caller flow control |
| `onDataNak(xferId, nextExpectedSeq, reason)` | `NakResult` | Implicitly confirms seqs below `nextExpectedSeq` (cumulative semantics); rewinds `nextSeqToSend_`; evicts all in-flight |
| `tick(nowMs)` | `TickResult` | Returns list of timed-out seqs needing retransmission. Transitions to ABANDONED when any seq's retry count would exceed `maxRetries_` |
| `onEndAck(xferId, OtaEndStatus)` | `EndAckResult` | STREAMING → DONE_OK on OK; → ABANDONED on HASH_MISMATCH / WRITE_ERROR; PREMATURE if implicit AWAITING_END_ACK predicate not satisfied |
| `reset()` | `void` | Returns sender to IDLE |
| `status() const` | `Status` | Read-only state observation |

Plus 30+ file-scope `static_assert` declarations pinning every enum
integer value — refactor-resistant against silent renumbering of
wire-stable or dispatch-stable values.

### Private state (12 fields total)

`BulkSender` maintains 4 monotone counters plus the in-flight table:

| Field | Invariant | Lifetime |
|---|---|---|
| `nextSeqToSend_` | Cursor for next emission | Advances on send; **rewinds on NAK** to `nextExpectedSeq` |
| `highWaterSentSeq_` | Upper bound on "ever launched" | Advances on send; **never rewinds** (added in defensive-validation cycle) |
| `highestConfirmedSeq_` | Upper bound on peer-confirmed | Advances on ACK / implicit NAK; never rewinds |
| `anyConfirmed_` | "Anything confirmed?" (disambiguates seq 0) | Latches true; never resets within transfer |
| `inFlight_` | `std::array<InFlightEntry, 16>` | Slot-based; cleared on NAK / evicted on ACK |

The asymmetry between `nextSeqToSend_` and `highWaterSentSeq_` is
load-bearing: ACK bounds use the high-water mark (so post-rewind stale
ACKs are correctly accepted), NAK bounds use the current cursor (so
fast-forward NAKs from before a rewind are correctly rejected).

### Test coverage (NEW: 42 tests appended to `test/test_native/bulk_transport_tests.cpp`)

Organized into 7 logical suites, building on the existing `BulkReceiver`
test patterns:

| Suite | Tests | Covers |
|---|---|---|
| `BulkSender` begin/state | 12 | Initial IDLE state, begin's 7 rejection reasons, AWAITING_BEGIN_ACK transitions, reset |
| `BulkSender` nextChunkToSend | 4 | Pre-streaming reject, first-chunk emission, fill-window-then-WINDOW_FULL, below-window-ALL_SENT |
| `BulkSender` onDataAck/onDataNak | 9 | Cumulative ACK advances, stale rejection, wrong-xferId, pre-streaming, NAK rewind, NAK wrong-xferId, NAK cumulative-confirm semantics (3 tests added in review-driven cycle) |
| `BulkSender` tick | 5 | No-timeout-fired, partial-timeout (mixed timestamps), all-timed-out, abandon-after-max-retries, inactive |
| `BulkSender` onEndAck | 6 | OK→DONE_OK, HASH_MISMATCH→ABANDONED, WRITE_ERROR→ABANDONED, wrong-xferId, before-streaming, premature predicate (4 sub-scenarios) |
| `BulkSender` defensive bounds | 4 | OUT_OF_RANGE for ACK + NAK (last-legal boundary + ahead-of-sender) plus the load-bearing post-rewind-gap test that pins `highWaterSentSeq_` accepts stale-but-launched ACKs |
| `BulkSender` end-to-end | 1 | Full happy path: begin → onBeginAck → drain → onDataAck → ALL_SENT → onEndAck OK → DONE_OK |

Tests grew from 385 (M1 baseline on `develop`) to **427** after M2 ships.

### Helper additions

- `drainSends()` test helper in an anonymous namespace — pumps
  `nextChunkToSend()` in a loop until WINDOW_FULL or ALL_SENT, accumulating
  emitted seqs. Used across 15+ tests to keep test bodies focused on the
  assertions under test.

## What does NOT ship in M2 (deferred to M3-M5 or PR set 2)

- **`OtaForwarder` MIXED (master)** + ESP-NOW binary TX wiring — M3
- **`OtaWriter` MIXED (padawan)** with `esp_ota_*` writes + read-back-rehash — M4
- **`FW_DEPLOY_BEGIN` orchestration + `FW_PROGRESS` emission** — M5
- **`esp_ota_set_boot_partition`, reboot, version-confirmation** — PR set 2
- **`OTA_COMMIT` / `OTA_COMMIT_ACK` wire types** — PR set 2

## Verification

- `pio test -e test` — **427/427 passing**
- `pio run -e metro_s3` — SUCCESS
- `pio run -e lolin_d32_pro` — SUCCESS
- `clang-format --dry-run --Werror` on changed files — clean
- `lib_native/` purity: no ESP-IDF / FreeRTOS / driver includes leaked
  (only `<cstdint>`, `<array>`, `<cstring>`, `<cstdlib>`, `<cassert>`,
  `<type_traits>` plus the existing `<OtaWirePayloads.hpp>` from M1)
- Native-purity CI guard already covers `lib_native/AstrOsBulkTransport`
  (added in earlier serial-receive milestone)

## Review cycle — four full PR-toolkit passes

This branch went through `pr-review-toolkit:review-pr` **four times**.
Each pass produced fixes that the next pass then audited; by pass 4, the
remaining items were either polish-grade or M3-boundary contracts.

### Pass 1 — initial post-implementation review

- **code-reviewer**: 0 Critical, 2 Important deferred (cross-lib `src/`
  include placement, NAK upper-bound clamp — both addressed in pass 2)
- **pr-test-analyzer**: Gaps in cumulative-NAK semantics, partial-tick
  timeout, and `NOT_STREAMING` rejection symmetry — all filled
- **comment-analyzer**: 1 inaccurate comment ("tick doesn't keep charging
  retries" — actual mechanism was eviction, not watermark advance), fixed
- **silent-failure-hunter**: 0 Critical, 4 Important fixed inline
  (`TickResult` struct-level `[[nodiscard]]`, `onEndAck` if-chain → switch
  with `-Wswitch`, partial-tick coverage, NAK comment rewrite)
- **type-design-analyzer**: const-fields family 10/10; identified
  `BeginAckResult` and `InFlightEntry` polish as deferrable

### Pass 2 — post-simplifier defensive validation

- All 5 reviewers reported "clean on M2 itself" for the simplifier
- **type-design-analyzer**: Surfaced 2 design-level findings that the
  first pass had let through:
  - `onDataAck`/`onDataNak` accept arbitrary peer-controlled seqs (could
    underflow `newlyConfirmedCount` or skip real chunks via false
    `ALL_SENT`) — fixed by adding `Decision::OUT_OF_RANGE` to both
    `AckResult` and `NakResult`
  - `onEndAck` accepts OK transition even when `nextSeqToSend_ <
    totalChunks_` — violates the documented implicit AWAITING_END_ACK
    invariant — fixed by adding `Decision::PREMATURE` to `EndAckResult`
- Plus 2 trivial polish fixes (stale "loop below" comment after the
  simplifier; test comment "set" → "sorted vector")

### Pass 3 — post-defensive-fix verification

- **code-reviewer**: **CLEAN** — "No high-confidence issues. Ready to PR."
- **comment-analyzer**: Found 1 must-fix accuracy issue (the OUT_OF_RANGE
  rationale comment claimed a "false DONE_OK" path that PREMATURE now
  actually blocks — comment misdescribed current behavior). Fixed in
  `b1ea9b4`.
- **pr-test-analyzer**: Last-legal-value boundary not pinned in
  OUT_OF_RANGE tests. Boundary sub-cases (`cumulativeSeq=9` /
  `nextExpectedSeq=9` with `totalChunks=10` → OK) added inside existing
  tests.
- **silent-failure-hunter**: **CLEAN on M2**. Surfaced 5 M3-boundary
  consumer-validation items recorded as design-doc open questions
  #8-12 (commit `f837bef`).
- **type-design-analyzer**: **CLEAN** — "the defensive fixes validate the
  original implicit-state design choice rather than undermining it"
- **pr-toolkit reviewer (out-of-band)**: Surfaced a real correctness gap —
  the OUT_OF_RANGE bounds checks were structurally complete against
  `totalChunks_` but state-incomplete against the runtime send progression.
  Fixed in `5175e73` by adding a `highWaterSentSeq_` field. The asymmetric
  resolution: ACK uses `highWaterSentSeq_` (monotone, never rewinds) so
  legitimate post-NAK-rewind stale ACKs are accepted; NAK uses
  `nextSeqToSend_` (current) so fast-forward NAKs from before a rewind
  are rejected.

### Pass 4 — post-highWaterSentSeq_ verification

- **code-reviewer**: **CLEAN** — "The 18-commit diff is ready for PR
  against develop."
- **pr-test-analyzer**: Identified critical test gap — the
  `highWaterSentSeq_` mechanism's actual purpose (accepting a stale ACK in
  the post-rewind gap `[nextSeqToSend_, highWaterSentSeq_)`) was untested.
  A future refactor replacing `highWaterSentSeq_` with `nextSeqToSend_`
  would pass all prior tests. Fixed by `BulkSenderOnDataAckAcceptsInFlightAckInPostRewindGap`
  in `be0a95d`.
- **comment-analyzer**: Found 1 must-fix — the ACK test comment from pass
  3 documented the wrong invariant (`nextSeqToSend_` instead of
  `highWaterSentSeq_`). Fixed in `be0a95d` along with an asymmetry note
  on the NAK comment.
- **silent-failure-hunter**: **CLEAN on M2**. Surfaced 2 new M3-boundary
  items #13-14 recorded in `d944e74`.
- **type-design-analyzer**: **CLEAN** — re-rated `BulkSender` 10/10/10/10
  across all dimensions. "The patch is clean, the new field earns its
  keep, the asymmetric bounds are correct-by-construction."
- **code-simplifier**: Nothing actionable.

### External fresh-eyes review — header docstring drift

After the four PR-toolkit passes, an external reviewer caught three
header docstring inaccuracies that all four internal passes missed —
each docstring described what the code did BEFORE the
`highWaterSentSeq_`/PREMATURE work, not after:

- `newlyConfirmedCount` was described as "number of in-flight slots
  freed" but the implementation computes a confirmation-watermark delta
  (the two diverge after a NAK clears the in-flight table). Corrected.
- `AckResult::Decision::OUT_OF_RANGE` enum doc mentioned only the
  `totalChunks_` bound; the actual implementation also checks
  `highWaterSentSeq_`. Corrected.
- `NakResult::Decision::OUT_OF_RANGE` enum doc mentioned only the
  `totalChunks_` bound; the actual implementation also checks
  `nextSeqToSend_`. Corrected.

All three were comment-only fixes (`563fb91`). The pattern that hid
them from internal review: each toolkit pass focused on "what's new in
this commit" — the enum docstrings predated the
`highWaterSentSeq_`/PREMATURE work, so no pass triggered a re-read of
those lines. External reviewers reading the header cold catch this
cross-commit drift that incremental review naturally misses.

### Recorded forward-concerns for M3 (`.docs/plans/20260523-1023-firmware-ota-mesh-forward-design.md` § Open questions)

- #8: M3 must emit `tick()` retransmits before pulling new chunks via
  `nextChunkToSend()` (otherwise retransmits silently never go on the wire)
- #9: M3 must consult `status()` to disambiguate `tick(count=0,
  abandon=false)` (could mean "no timeouts fired" or "not STREAMING")
- #10: NAK-below-watermark protocol contract decision (wire-layer reject
  or new `REWIND_BELOW_WATERMARK` Decision)
- #11: `newlyConfirmedCount` blends explicit + implicit confirmations
  (treat as "slots freed", not "wire-level ACKs received")
- #12: M3 must check `TickResult::abandon` independent of `count`
- #13: M3 wire-layer must log `OUT_OF_RANGE` distinctly from other
  rejections (peer "ACK ahead of sender" must not be indistinguishable
  from benign wrong-xferId)
- #14: M3 progress counter must distinguish retransmits from fresh sends
  (post-NAK retransmits via `nextChunkToSend` advance `nextSeqToSend_`
  but NOT `highWaterSentSeq_`)

These are NOT M2 bugs — they're consumer-side contract reminders the M3
author should design around at the wire-layer boundary.

## Commit history

```
563fb91 docs(bulk-transport): align header docstrings with actual bounds semantics
d944e74 docs(plan): record M2 fourth-pass M3-boundary items #13 + #14
be0a95d test(bulk-transport): pin highWaterSentSeq_ behavior in post-rewind gap + comment fixes
5175e73 fix(bulk-transport): tighten OUT_OF_RANGE bounds against ahead-of-sender peer input
f837bef docs(plan): record M2 third-pass M3-boundary consumer-validation items
b1ea9b4 fix(bulk-transport): correct OUT_OF_RANGE rationale + pin last-legal boundary
a0a19ac feat(bulk-transport): defensive PURE-layer input validation (OUT_OF_RANGE + PREMATURE)
60fdbc8 docs: tighten M2 comments after simplifier + test polish
cedb81d refactor(bulk-transport): mechanical simplifications from PR-toolkit pass
a75b420 fix(bulk-transport): apply PR-toolkit review fixes (comment + nodiscard + switch + test)
fcc8d77 test(bulk-transport): add NOT_STREAMING test for onEndAck
1e386fb feat(bulk-transport): add BulkSender::onEndAck + end-to-end test
a25075d fix(bulk-transport): align TickResult placement + assert abandon count reset
11cf95f feat(bulk-transport): add BulkSender::tick + retry/abandon
fb4c4e7 fix(bulk-transport): NAK implicitly confirms seqs below nextExpectedSeq
ac990f7 feat(bulk-transport): add BulkSender onDataAck + onDataNak
579db57 fix(bulk-transport): nodiscard on SendResult + monotonic-time precondition
4b466ca feat(bulk-transport): add BulkSender::nextChunkToSend + SendResult
4b291f5 docs(test): correct BulkSender result-type discipline comment
86a7d87 feat(bulk-transport): add BulkSender begin/onBeginAck/reset + scaffolding
5a0409b docs(plan): M2 implementation plan — BulkSender PURE state machine
```

## Test plan (for the PR description)

- [ ] PR validation CI passes (native tests, both-board build matrix,
      native-purity guard, clang-format on changed files)
- [ ] Confirm `pio test -e test` reports 427 passing locally
- [ ] Confirm `pio run -e metro_s3` and `pio run -e lolin_d32_pro` both
      build clean from a fresh checkout
- [ ] Sanity-check that the existing OTA serial-receive flow still works
      end-to-end on the bench (regression smoke; M2 doesn't touch the
      serial path but `<OtaWirePayloads.hpp>` from M1 is now consumed by
      `AstrOsBulkTransport` via `EndAckResult::onEndAck`'s parameter type)

## Cross-repo

- Wire-format contract **frozen and unchanged**. PR set 1 binds the
  contract; does not amend it.
- No `AstrOs.Server` changes required.

## Related docs

- Design: `.docs/plans/20260523-1023-firmware-ota-mesh-forward-design.md`
  (now carries open questions #1-#14 covering both M1 and M2 forward concerns)
- M2 plan: `.docs/plans/20260523-1301-firmware-ota-mesh-forward-m2-bulk-sender.md`
- Cross-repo decomposition: `AstrOs.Server/.docs/completed_plans/2026/04/27/20260427-2202-firmware-ota-decomposition.md`
- Preceding milestone design (serial receive): `.docs/plans/20260514-1941-firmware-ota-esp-master-serial-receive-design.md`
- M1 wire-format milestone (merged via PR #35, `9857204`): provides the
  `OtaEndStatus` enum that `EndAckResult::onEndAck` consumes

Next milestone: **M3 — Master `OtaForwarder` (MIXED) + ESP-NOW binary TX
path**. M3 is the first MIXED-layer milestone in this set — it consumes
the M1 wire format + M2 BulkSender to drive actual ESP-NOW traffic from
master to padawans. The 5 forward-concerns recorded in this PR
(design-doc open questions #8-12) are the M3 author's pre-flight checklist.
