### PR TITLE
Fix/ota espnow congestion

### DIFF
--- a/.docs/plans/20260529-1108-ota-espnow-congestion.md
+++ b/.docs/plans/20260529-1108-ota-espnow-congestion.md
@@ -1,0 +1,90 @@
+# Fix: OTA transfer NAK storm — ESP-NOW TX flow control + ack-timeout tuning
+
+## Problem
+
+Bench OTA of a ~1.27 MB image (metro_s3) produces a self-reinforcing congestion
+storm on the master→padawan ESP-NOW link. Observed (operator aborted the run):
+
+- **Master** (`OtaForwarder` / `AstrOsEspNow`): bursts of
+  `OTA_DATA seq=N sendOtaFrame returned ESP_ERR_ESPNOW_NO_MEM; tick will retry`
+  + `sendOtaFrame: esp_now_send returned ESP_ERR_ESPNOW_NO_MEM for type=28`.
+- **Padawan** (`OtaWriter`): bursts of
+  `handleData: xferId=1 seq=111 NAK reason=3 (hcs=113 nes=114 wr=8)` —
+  `reason=3` = `NakReason::OUT_OF_ORDER`; the padawan is at hcs=113/next=114 but
+  the master keeps re-sending 110/111/112 (chunks it already committed).
+
+### Root cause (read from source)
+
+1. **No TX flow control.** `AstrOsEspNow::sendOtaFrame` (AstrOsEspNowService.cpp
+   ~1249) calls `esp_now_send` and returns immediately; it does not gate on the
+   send-done callback. The ESP-NOW internal TX queue (~6 buffers) fills, then
+   every further send returns `ESP_ERR_ESPNOW_NO_MEM`. The registered send
+   callback `espnowSendCallback` (main.cpp ~1920) is a **no-op** today
+   (comment: "Reserved for future flow-control / send-confirmation work").
+2. **Ack-timeout too tight for flash cadence.** `kAckTimeoutMs = 400`
+   (OtaForwarder.hpp:249) with `kWindowSize = 8`. The padawan writes each chunk
+   to OTA flash (slow erase+program) and pauses other ESP-NOW traffic during
+   writes, so its cumulative ACKs lag > 400 ms under load. The 50 ms tick
+   (`BulkSender::tick` → `chunksToRetransmit`) then retransmits in-flight slots
+   the padawan has already received → every dup triggers an OUT_OF_ORDER NAK
+   (`BulkReceiver::onChunk`: `seq != nextSeq_`).
+3. The redundant chunks + NAKs add airtime → more NO_MEM → more ack lag → more
+   spurious retransmits. Tail risk: `kMaxRetries = 3` in `tick()` can trip
+   `data_retry_exceeded` and abort the padawan under a sustained spike.
+
+## Fix (user-selected scope: constants + TX send-done pacing)
+
+### Part A — ack-timeout / window tuning (`lib/OtaForwarder/include/OtaForwarder.hpp`)
+- Raise `kAckTimeoutMs` 400 → 1500 so the master stops retransmitting chunks the
+  padawan is still flashing. (Directly kills the spurious-retransmit half.)
+- Lower `kWindowSize` 8 → 4 to bound in-flight bytes and airtime pressure.
+- Leave `kChunkSize=128`, `kMaxRetries=3` unchanged for now (revisit after bench).
+
+### Part B — ESP-NOW TX credit pacing (`src/main.cpp` + `lib/AstrOsEspNow`)
+Add a counting semaphore ("TX credits") sized a couple below the ESP-NOW internal
+queue depth so the master never outruns the radio:
+- Create `otaTxCredits` (FreeRTOS counting semaphore, max=N, initial=N; N≈5).
+- `sendOtaFrame`: `xSemaphoreTake(credits, timeout)` BEFORE `esp_now_send`. If
+  `esp_now_send` returns non-OK (NO_MEM etc.), **give the credit back
+  immediately** — no send-done callback will fire for a send that didn't
+  enqueue. On take-timeout, return a busy error so the tick retries later.
+- `espnowSendCallback` (main.cpp): on each completion, `xSemaphoreGive(credits)`
+  (ISR/WiFi-task-safe give). Fires once per `esp_now_send` that returned ESP_OK.
+
+**Accounting invariant (the sharp edge):** every successful `esp_now_send`
+(ESP_OK) produces exactly one callback → exactly one give. Every take is paired
+with either (a) a give in the callback (send enqueued) or (b) an immediate give
+on the non-OK return (send not enqueued). Get this wrong and credits leak →
+deadlock. **Scope the credit gate to the OTA path only** (sendOtaFrame), not all
+12 `esp_now_send` sites — but the single shared callback gives unconditionally,
+so non-OTA sends would over-give. Resolve by either: (i) a dedicated OTA-only
+send wrapper whose completions are distinguishable, or (ii) gate ALL sends with
+the credit sem (simplest, uniform accounting) — DECIDE during implementation
+after checking whether the callback can distinguish OTA frames. Default lean:
+gate all sends uniformly (one sem, one give per callback, one take per send).
+
+## Tasks
+
+- [ ] Part A: bump `kAckTimeoutMs` 400→1500, `kWindowSize` 8→4 in OtaForwarder.hpp.
+- [ ] Part B: add TX-credit counting semaphore; take in the send path, give in
+      `espnowSendCallback`, give-back on non-OK `esp_now_send` return. Decide
+      OTA-only vs all-sends gating and document the accounting invariant in code.
+- [ ] `pio run -e metro_s3` and `-e lolin_d32_pro` build clean.
+- [ ] `pio test -e test` green (BulkTransport native tests unaffected — constants
+      are runtime args; no PURE-layer change).
+- [ ] Bench: re-run the padawan-only deploy; confirm NO_MEM bursts gone (or rare)
+      and OUT_OF_ORDER NAK storm gone; transfer completes without manual abort.
+      Capture before/after in `.docs/qa/ota-upgrade-pr-set-2.md`.
+
+## Risk / notes
+
+- Touches the **shared** ESP-NOW send path + the WiFi-task send callback — a
+  known-fragile, brick-adjacent area (CLAUDE.md). Credit-accounting bugs
+  deadlock the mesh, so the take/give pairing must be exhaustively correct
+  across every `esp_now_send` return path.
+- Part A alone may calm the storm enough to ship; if bench after A is clean,
+  Part B can be evaluated separately. Keep the commits split so A can land
+  independently of B.
+- Separate from the server-side "reboot failed" bug
+  (`debug/serial-rx-frame-diag`) and the version-confirm fix
+  (`fix/ota-version-confirm-project-ver`). This branch is mesh-transport only.

--- a/.docs/plans/20260529-1108-ota-espnow-congestion.md
+++ b/.docs/plans/20260529-1108-ota-espnow-congestion.md
@@ -65,7 +65,8 @@ compromise.
   (before the NULL-arg guard), at the top of `espnowSendCallback` in main.cpp —
   the send-done callback fires exactly once per enqueued frame, SUCCESS or FAIL.
 - `AstrOsEspNow::espnowTxAtCapacity()`: `load() >= kEspnowTxInFlightCap`
-  (cap = 6, under the 32 WiFi TX buffers, matching TX_BA_WIN=6).
+  (cap = 6, below metro_s3's 32 dynamic TX buffers and lolin_d32_pro's
+  16 static TX buffers, matching the shared TX_BA_WIN=6).
 - `OtaForwarder::streamDrain`: at the top of each loop iteration, if
   `AstrOs_EspNow.espnowTxAtCapacity()` then stop draining this tick (same exit
   as `WINDOW_FULL`); the 50 ms tick resumes when the radio drains.

--- a/.docs/plans/20260529-1108-ota-espnow-congestion.md
+++ b/.docs/plans/20260529-1108-ota-espnow-congestion.md
@@ -65,7 +65,7 @@ gate all sends uniformly (one sem, one give per callback, one take per send).
 
 ## Tasks
 
-- [ ] Part A: bump `kAckTimeoutMs` 400→1500, `kWindowSize` 8→4 in OtaForwarder.hpp.
+- [x] Part A: bump `kAckTimeoutMs` 400→1500, `kWindowSize` 8→4 in OtaForwarder.hpp.
 - [ ] Part B: add TX-credit counting semaphore; take in the send path, give in
       `espnowSendCallback`, give-back on non-OK `esp_now_send` return. Decide
       OTA-only vs all-sends gating and document the accounting invariant in code.

--- a/.docs/plans/20260529-1108-ota-espnow-congestion.md
+++ b/.docs/plans/20260529-1108-ota-espnow-congestion.md
@@ -97,9 +97,9 @@ a throttle hint, not a data guard (mirrors `espnowMallocFailureCount`).
 ## Risk / notes
 
 - Touches the **shared** ESP-NOW send path + the WiFi-task send callback — a
-  known-fragile, brick-adjacent area (CLAUDE.md). Credit-accounting bugs
-  deadlock the mesh, so the take/give pairing must be exhaustively correct
-  across every `esp_now_send` return path.
+  known-fragile, brick-adjacent area (CLAUDE.md). Credit-accounting bugs can
+  over-throttle OTA or disable throttling, so the add/sub pairing must be
+  exhaustively correct across every `esp_now_send` return path.
 - Part A alone may calm the storm enough to ship; if bench after A is clean,
   Part B can be evaluated separately. Keep the commits split so A can land
   independently of B.

--- a/.docs/plans/20260529-1108-ota-espnow-congestion.md
+++ b/.docs/plans/20260529-1108-ota-espnow-congestion.md
@@ -40,35 +40,53 @@ storm on the master→padawan ESP-NOW link. Observed (operator aborted the run):
 - Lower `kWindowSize` 8 → 4 to bound in-flight bytes and airtime pressure.
 - Leave `kChunkSize=128`, `kMaxRetries=3` unchanged for now (revisit after bench).
 
-### Part B — ESP-NOW TX credit pacing (`src/main.cpp` + `lib/AstrOsEspNow`)
-Add a counting semaphore ("TX credits") sized a couple below the ESP-NOW internal
-queue depth so the master never outruns the radio:
-- Create `otaTxCredits` (FreeRTOS counting semaphore, max=N, initial=N; N≈5).
-- `sendOtaFrame`: `xSemaphoreTake(credits, timeout)` BEFORE `esp_now_send`. If
-  `esp_now_send` returns non-OK (NO_MEM etc.), **give the credit back
-  immediately** — no send-done callback will fire for a send that didn't
-  enqueue. On take-timeout, return a busy error so the tick retries later.
-- `espnowSendCallback` (main.cpp): on each completion, `xSemaphoreGive(credits)`
-  (ISR/WiFi-task-safe give). Fires once per `esp_now_send` that returned ESP_OK.
+### Part B — ESP-NOW TX in-flight counter (`src/main.cpp` + `lib/AstrOsEspNow`)
 
-**Accounting invariant (the sharp edge):** every successful `esp_now_send`
-(ESP_OK) produces exactly one callback → exactly one give. Every take is paired
-with either (a) a give in the callback (send enqueued) or (b) an immediate give
-on the non-OK return (send not enqueued). Get this wrong and credits leak →
-deadlock. **Scope the credit gate to the OTA path only** (sendOtaFrame), not all
-12 `esp_now_send` sites — but the single shared callback gives unconditionally,
-so non-OTA sends would over-give. Resolve by either: (i) a dedicated OTA-only
-send wrapper whose completions are distinguishable, or (ii) gate ALL sends with
-the credit sem (simplest, uniform accounting) — DECIDE during implementation
-after checking whether the callback can distinguish OTA frames. Default lean:
-gate all sends uniformly (one sem, one give per callback, one take per send).
+**Design choice: non-blocking atomic counter, NOT a counting semaphore.** A
+blocking semaphore `take` in front of every send means any credit-accounting leak
+deadlocks the whole mesh (all 9 send sites share one callback). An atomic counter
+whose only consumer is a *poll-and-decline* check in the OTA drain degrades a leak
+to "OTA throttles a bit more than it should" (slow), never "mesh hangs." The
+window+tick machinery already polls-and-declines on `WINDOW_FULL`, so this fits
+the existing control flow with no new blocking primitive.
+
+**Centralize accounting in ONE wrapper.** All 9 `esp_now_send(mac,data,size)`
+calls in `AstrOsEspNowService.cpp` are uniform, so route them through a single
+file-static helper rather than counting at each site (per-site counting is the
+leak hazard). Count ALL sends (poll, registration, servo-test, OTA) — they share
+the same radio TX buffers, so counting them all is physically accurate, not a
+compromise.
+
+- `static std::atomic<int> espnowTxInFlight_{0};` (file-static in the .cpp).
+- `espnowSendCounted(mac,data,size)`: `fetch_add(1)` → `esp_now_send` →
+  `fetch_sub(1)` if it returns non-OK (no send-done callback fires for a frame
+  that never enqueued). Replace all 9 raw `esp_now_send` calls with this helper.
+- `AstrOsEspNow::notifyTxComplete()`: `fetch_sub(1)`. Called once, unconditionally
+  (before the NULL-arg guard), at the top of `espnowSendCallback` in main.cpp —
+  the send-done callback fires exactly once per enqueued frame, SUCCESS or FAIL.
+- `AstrOsEspNow::espnowTxAtCapacity()`: `load() >= kEspnowTxInFlightCap`
+  (cap = 6, under the 32 WiFi TX buffers, matching TX_BA_WIN=6).
+- `OtaForwarder::streamDrain`: at the top of each loop iteration, if
+  `AstrOs_EspNow.espnowTxAtCapacity()` then stop draining this tick (same exit
+  as `WINDOW_FULL`); the 50 ms tick resumes when the radio drains.
+
+**Accounting invariant:** every `fetch_add` is matched by exactly one
+`fetch_sub` — either the immediate non-OK give-back (frame not enqueued) or the
+one callback (frame enqueued). Centralizing both the add and the non-OK sub in
+`espnowSendCounted`, and the callback sub in the single `notifyTxComplete`, makes
+the pairing auditable in two functions. **Failure direction is safe:** if a
+sub is ever missed (e.g. pending callbacks dropped on ESP-NOW teardown / abort),
+the counter drifts HIGH → OTA throttles more → slower, never hung. It self-heals
+as in-flight callbacks arrive. `memory_order_relaxed` throughout — the counter is
+a throttle hint, not a data guard (mirrors `espnowMallocFailureCount`).
 
 ## Tasks
 
 - [x] Part A: bump `kAckTimeoutMs` 400→1500, `kWindowSize` 8→4 in OtaForwarder.hpp.
-- [ ] Part B: add TX-credit counting semaphore; take in the send path, give in
-      `espnowSendCallback`, give-back on non-OK `esp_now_send` return. Decide
-      OTA-only vs all-sends gating and document the accounting invariant in code.
+- [ ] Part B: add `espnowTxInFlight_` atomic + `espnowSendCounted` wrapper (route
+      all 9 send sites through it), `notifyTxComplete` (called from
+      `espnowSendCallback`), `espnowTxAtCapacity` accessor, and the cap check in
+      `streamDrain`. Non-blocking — leak degrades to slow, never deadlock.
 - [ ] `pio run -e metro_s3` and `-e lolin_d32_pro` build clean.
 - [ ] `pio test -e test` green (BulkTransport native tests unaffected — constants
       are runtime args; no PURE-layer change).

--- a/.docs/plans/20260529-1108-ota-espnow-congestion.md
+++ b/.docs/plans/20260529-1108-ota-espnow-congestion.md
@@ -83,12 +83,12 @@ a throttle hint, not a data guard (mirrors `espnowMallocFailureCount`).
 ## Tasks
 
 - [x] Part A: bump `kAckTimeoutMs` 400→1500, `kWindowSize` 8→4 in OtaForwarder.hpp.
-- [ ] Part B: add `espnowTxInFlight_` atomic + `espnowSendCounted` wrapper (route
+- [x] Part B: add `espnowTxInFlight_` atomic + `espnowSendCounted` wrapper (route
       all 9 send sites through it), `notifyTxComplete` (called from
       `espnowSendCallback`), `espnowTxAtCapacity` accessor, and the cap check in
       `streamDrain`. Non-blocking — leak degrades to slow, never deadlock.
-- [ ] `pio run -e metro_s3` and `-e lolin_d32_pro` build clean.
-- [ ] `pio test -e test` green (BulkTransport native tests unaffected — constants
+- [x] `pio run -e metro_s3` and `-e lolin_d32_pro` build clean.
+- [x] `pio test -e test` green (BulkTransport native tests unaffected — constants
       are runtime args; no PURE-layer change).
 - [ ] Bench: re-run the padawan-only deploy; confirm NO_MEM bursts gone (or rare)
       and OUT_OF_ORDER NAK storm gone; transfer completes without manual abort.

--- a/lib/AstrOsEspNow/src/AstrOsEspNowService.cpp
+++ b/lib/AstrOsEspNow/src/AstrOsEspNowService.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <esp_err.h>
 #include <esp_log.h>
 #include <esp_mac.h>
@@ -36,6 +37,45 @@ AstrOsEspNow AstrOs_EspNow;
 
 static void (*espnowSendCallback)(const esp_now_send_info_t *tx_info, esp_now_send_status_t status);
 static void (*espnowRecvCallback)(const esp_now_recv_info_t *recv_info, const uint8_t *data, int len);
+
+// ESP-NOW TX in-flight counter — frames handed to esp_now_send but not yet
+// send-done-acked. All sends route through espnowSendCounted (one accounting
+// site); the registered send-done callback decrements via notifyTxComplete.
+// relaxed ordering: this is a throttle hint, not a data guard (mirrors
+// espnowMallocFailureCount in main.cpp). A miscount drifts the value HIGH at
+// worst (pending callbacks dropped on teardown), which throttles OTA harder —
+// degraded, never deadlocked — and self-heals as in-flight callbacks arrive.
+static std::atomic<int> espnowTxInFlight_{0};
+
+// Cap on concurrent ESP-NOW frames in flight. Held well under
+// CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER_NUM (32); matches CONFIG_ESP_WIFI_TX_BA_WIN
+// (6). Past this, esp_now_send starts returning ESP_ERR_ESPNOW_NO_MEM.
+static constexpr int kEspnowTxInFlightCap = 6;
+
+// Single accounting site for every esp_now_send. Increments before the send;
+// on a non-OK return the frame never enqueued and no send-done callback will
+// fire, so decrement back immediately to keep the count exact. The matching
+// decrement for an enqueued (ESP_OK) frame happens once in notifyTxComplete.
+static esp_err_t espnowSendCounted(const uint8_t *mac, const uint8_t *data, size_t size)
+{
+    espnowTxInFlight_.fetch_add(1, std::memory_order_relaxed);
+    esp_err_t err = esp_now_send(mac, data, size);
+    if (err != ESP_OK)
+    {
+        espnowTxInFlight_.fetch_sub(1, std::memory_order_relaxed);
+    }
+    return err;
+}
+
+void AstrOsEspNow::notifyTxComplete()
+{
+    espnowTxInFlight_.fetch_sub(1, std::memory_order_relaxed);
+}
+
+bool AstrOsEspNow::espnowTxAtCapacity() const
+{
+    return espnowTxInFlight_.load(std::memory_order_relaxed) >= kEspnowTxInFlightCap;
+}
 
 AstrOsEspNow::AstrOsEspNow() {}
 
@@ -741,7 +781,7 @@ void AstrOsEspNow::sendRegistrationRequest()
     if (IS_BROADCAST_ADDR(destMac))
     {
         astros_espnow_data_t data = this->messageService.generateEspNowMsg(AstrOsPacketType::REGISTRATION_REQ)[0];
-        if (esp_now_send(destMac, data.data, data.size) != ESP_OK)
+        if (espnowSendCounted(destMac, data.data, data.size) != ESP_OK)
         {
             ESP_LOGE(TAG, "Error sending registraion request");
         }
@@ -819,7 +859,7 @@ bool AstrOsEspNow::handleRegistrationReq(uint8_t *src)
     astros_espnow_data_t data =
         this->messageService.generateEspNowMsg(AstrOsPacketType::REGISTRATION, macStr, padawanName)[0];
 
-    err = esp_now_send(broadcastMac, data.data, data.size);
+    err = espnowSendCounted(broadcastMac, data.data, data.size);
     if (logError(TAG, __FUNCTION__, __LINE__, err))
     {
         return false;
@@ -900,7 +940,7 @@ bool AstrOsEspNow::sendRegistrationAck()
     astros_espnow_data_t data =
         this->messageService.generateEspNowMsg(AstrOsPacketType::REGISTRATION_ACK, this->mac, this->name)[0];
 
-    if (esp_now_send(destMac, data.data, data.size) != ESP_OK)
+    if (espnowSendCounted(destMac, data.data, data.size) != ESP_OK)
     {
         ESP_LOGE(TAG, "Error sending registration ack");
         result = false;
@@ -984,7 +1024,7 @@ void AstrOsEspNow::pollPadawans()
 
         astros_espnow_data_t data = this->messageService.generateEspNowMsg(AstrOsPacketType::POLL, this->mac)[0];
 
-        if (esp_now_send(peer.mac_addr, data.data, data.size) != ESP_OK)
+        if (espnowSendCounted(peer.mac_addr, data.data, data.size) != ESP_OK)
         {
             ESP_LOGE(TAG, "Error sending poll message to " MACSTR, MAC2STR(peer.mac_addr));
         }
@@ -1023,7 +1063,7 @@ bool AstrOsEspNow::handlePoll(astros_packet_t packet)
     astros_espnow_data_t data =
         this->messageService.generateEspNowMsg(AstrOsPacketType::POLL_ACK, this->mac, ss.str())[0];
 
-    esp_err_t sendErr = esp_now_send(destMac, data.data, data.size);
+    esp_err_t sendErr = espnowSendCounted(destMac, data.data, data.size);
     if (sendErr != ESP_OK)
     {
         ESP_LOGE(TAG, "Error sending poll ack");
@@ -1168,7 +1208,7 @@ void AstrOsEspNow::sendConfigAckNak(std::string msgId, bool success)
 
     auto packet = this->messageService.generateEspNowMsg(ackNak, this->getMac(), ss.str())[0];
 
-    if (esp_now_send(destMac, packet.data, packet.size) != ESP_OK)
+    if (espnowSendCounted(destMac, packet.data, packet.size) != ESP_OK)
     {
         ESP_LOGE(TAG, "Error sending config update to " MACSTR, MAC2STR(destMac));
     }
@@ -1216,7 +1256,7 @@ void AstrOsEspNow::sendBasicAckNak(std::string msgId, AstrOsPacketType type, std
 
     auto packet = this->messageService.generateEspNowMsg(type, this->getMac(), ss.str())[0];
 
-    if (esp_now_send(destMac, packet.data, packet.size) != ESP_OK)
+    if (espnowSendCounted(destMac, packet.data, packet.size) != ESP_OK)
     {
         ESP_LOGE(TAG, "Error sending basic ack/nak for type %d to " MACSTR, (int)type, MAC2STR(destMac));
     }
@@ -1246,7 +1286,7 @@ esp_err_t AstrOsEspNow::sendOtaFrame(const uint8_t mac[6], AstrOsPacketType type
     }
 
     astros_espnow_data_t frame = frames[0];
-    esp_err_t err = esp_now_send(mac, frame.data, frame.size);
+    esp_err_t err = espnowSendCounted(mac, frame.data, frame.size);
     if (err != ESP_OK)
     {
         ESP_LOGW(TAG, "sendOtaFrame: esp_now_send returned %s for type=%d", esp_err_to_name(err), (int)type);
@@ -1285,7 +1325,7 @@ void AstrOsEspNow::sendEspNowMessage(AstrOsPacketType type, std::string peer, st
 
     for (auto &packet : data)
     {
-        if (esp_now_send(destMac, packet.data, packet.size) != ESP_OK)
+        if (espnowSendCounted(destMac, packet.data, packet.size) != ESP_OK)
         {
             ESP_LOGE(TAG, "Error sending packet type %d to " MACSTR, (int)type, MAC2STR(destMac));
         }

--- a/lib/AstrOsEspNow/src/AstrOsEspNowService.cpp
+++ b/lib/AstrOsEspNow/src/AstrOsEspNowService.cpp
@@ -47,9 +47,11 @@ static void (*espnowRecvCallback)(const esp_now_recv_info_t *recv_info, const ui
 // degraded, never deadlocked — and self-heals as in-flight callbacks arrive.
 static std::atomic<int> espnowTxInFlight_{0};
 
-// Cap on concurrent ESP-NOW frames in flight. Held well under
-// CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER_NUM (32); matches CONFIG_ESP_WIFI_TX_BA_WIN
-// (6). Past this, esp_now_send starts returning ESP_ERR_ESPNOW_NO_MEM.
+// Cap on concurrent ESP-NOW frames in flight. Held below the WiFi TX buffer
+// pool on both boards (metro_s3: CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER_NUM=32;
+// lolin_d32_pro: CONFIG_ESP_WIFI_STATIC_TX_BUFFER_NUM=16) and matching the
+// shared CONFIG_ESP_WIFI_TX_BA_WIN=6. Past the pool, esp_now_send starts
+// returning ESP_ERR_ESPNOW_NO_MEM.
 static constexpr int kEspnowTxInFlightCap = 6;
 
 // Single accounting site for every esp_now_send. Increments before the send;
@@ -75,6 +77,11 @@ void AstrOsEspNow::notifyTxComplete()
 bool AstrOsEspNow::espnowTxAtCapacity() const
 {
     return espnowTxInFlight_.load(std::memory_order_relaxed) >= kEspnowTxInFlightCap;
+}
+
+esp_err_t AstrOsEspNow::sendCounted(const uint8_t *mac, const uint8_t *data, size_t len)
+{
+    return espnowSendCounted(mac, data, len);
 }
 
 AstrOsEspNow::AstrOsEspNow() {}

--- a/lib/AstrOsEspNow/src/AstrOsEspNowService.hpp
+++ b/lib/AstrOsEspNow/src/AstrOsEspNowService.hpp
@@ -171,6 +171,20 @@ public:
     // returns (Pattern A immediate-free, matching the other send-helpers).
     esp_err_t sendOtaFrame(const uint8_t mac[6], AstrOsPacketType type, const uint8_t *payload, size_t len);
 
+    // ESP-NOW TX backpressure (OTA congestion control). The radio's send queue
+    // is bounded; pushing past it returns ESP_ERR_ESPNOW_NO_MEM and, during an
+    // OTA transfer, drives a retransmit/NAK storm. A file-static atomic counts
+    // frames handed to esp_now_send but not yet send-done-acked.
+    //
+    // notifyTxComplete: decrement the in-flight count. Call exactly once per
+    //   send-done callback (the callback fires once per enqueued frame). Safe
+    //   from the WiFi-task callback context (lock-free atomic).
+    // espnowTxAtCapacity: true when in-flight has reached the cap. The OTA drain
+    //   polls this and declines to send (non-blocking) rather than overrunning
+    //   the radio; a miscount degrades to "throttle harder", never to a hang.
+    void notifyTxComplete();
+    bool espnowTxAtCapacity() const;
+
     // OTA ACK/NAK arrivals on the master are routed into this queue.
     // Called from main.cpp during init; before this is set, OTA arrivals
     // on master fall through to ESP_LOGW + drop (same path as padawan).

--- a/lib/AstrOsEspNow/src/AstrOsEspNowService.hpp
+++ b/lib/AstrOsEspNow/src/AstrOsEspNowService.hpp
@@ -182,8 +182,14 @@ public:
     // espnowTxAtCapacity: true when in-flight has reached the cap. The OTA drain
     //   polls this and declines to send (non-blocking) rather than overrunning
     //   the radio; a miscount degrades to "throttle harder", never to a hang.
+    // sendCounted: in-flight-counted esp_now_send for raw, pre-formed frames
+    //   sent from outside the class (the ESPNOW_SEND queue path in main.cpp).
+    //   Keeps the increment/decrement pairing total — every send-done callback
+    //   fires notifyTxComplete, so an uncounted send drifts the counter and
+    //   silently disables throttling.
     void notifyTxComplete();
     bool espnowTxAtCapacity() const;
+    esp_err_t sendCounted(const uint8_t *mac, const uint8_t *data, size_t len);
 
     // OTA ACK/NAK arrivals on the master are routed into this queue.
     // Called from main.cpp during init; before this is set, OTA arrivals

--- a/lib/OtaForwarder/include/OtaForwarder.hpp
+++ b/lib/OtaForwarder/include/OtaForwarder.hpp
@@ -245,8 +245,17 @@ private:
 
     // BulkSender params (from the frozen contract).
     static constexpr uint16_t kChunkSize = 128;
-    static constexpr uint8_t kWindowSize = 8;
-    static constexpr uint32_t kAckTimeoutMs = 400;
+    // Window + ack-timeout tuned against the padawan's OTA-flash write cadence.
+    // The padawan writes each chunk to flash (slow erase+program) and pauses
+    // other ESP-NOW traffic during writes, so cumulative ACKs lag well past the
+    // original 400 ms timeout under load — the 50 ms tick then retransmits
+    // chunks the padawan has already committed, and every dup draws an
+    // OUT_OF_ORDER NAK. That spurious-retransmit loop (plus an 8-deep window
+    // overrunning the ESP-NOW TX queue) produced a NAK/NO_MEM congestion storm
+    // on a 1.27 MB image. Smaller window bounds in-flight airtime; longer
+    // timeout stops retransmitting chunks still being flashed.
+    static constexpr uint8_t kWindowSize = 4;
+    static constexpr uint32_t kAckTimeoutMs = 1500;
     static constexpr uint8_t kMaxRetries = 3;
 
     // Hard upper bound on the order list size. Must stay well below 254 so

--- a/lib/OtaForwarder/src/OtaForwarder.cpp
+++ b/lib/OtaForwarder/src/OtaForwarder.cpp
@@ -962,6 +962,20 @@ void OtaForwarder::streamDrain(uint64_t nowMs)
 {
     for (;;)
     {
+        // ESP-NOW TX backpressure: if the radio already has kEspnowTxInFlightCap
+        // frames queued, stop draining new chunks this pass rather than piling on
+        // (which returns ESP_ERR_ESPNOW_NO_MEM and, under load, feeds the
+        // retransmit/NAK storm). Checked BEFORE nextChunkToSend so we don't
+        // reserve an in-flight window slot we then decline to send. Non-blocking:
+        // the 50 ms tick re-enters streamDrain as send-done callbacks drain the
+        // count — same poll-and-decline shape as the WINDOW_FULL exit below. The
+        // tick-driven retransmit path is intentionally NOT gated here: it's
+        // bounded by the window and is higher-priority recovery traffic, and its
+        // own NO_MEM handling already backstops it.
+        if (AstrOs_EspNow.espnowTxAtCapacity())
+        {
+            return;
+        }
         auto sr = bulk_.nextChunkToSend(nowMs);
         if (sr.decision == AstrOsBulkTransport::SendResult::Decision::SEND)
         {

--- a/lib/OtaWriter/src/OtaWriter.cpp
+++ b/lib/OtaWriter/src/OtaWriter.cpp
@@ -290,9 +290,11 @@ void OtaWriter::handleBegin(queue_ota_writer_msg_t &msg)
         return;
     }
 
-    // Must equal the master's BulkSender kWindowSize. Mismatched windows
-    // desync ack accounting.
-    constexpr uint8_t kWindowSize = 8;
+    // Must equal the master's BulkSender kWindowSize in OtaForwarder.hpp
+    // (currently 4). Mismatched windows desync ack accounting. windowSize is
+    // not carried on the OTA_BEGIN wire payload, so it can't be derived here —
+    // the two compile-time constants must be kept in lockstep by hand.
+    constexpr uint8_t kWindowSize = 4;
     auto br = bulk_.begin(xferId, msg.begin.totalSize, msg.begin.totalChunks, msg.begin.chunkSize, kWindowSize);
     if (!br.valid)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1918,6 +1918,12 @@ void displaySetDefault(std::string line1, std::string line2, std::string line3)
 
 static void espnowSendCallback(const esp_now_send_info_t *tx_info, esp_now_send_status_t status)
 {
+    // Decrement the ESP-NOW TX in-flight counter — once per callback, before any
+    // early return. The send-done callback fires exactly once per frame that
+    // esp_now_send enqueued (ESP_OK), regardless of SUCCESS/FAIL status, so this
+    // is the unconditional match for the fetch_add in espnowSendCounted.
+    AstrOs_EspNow.notifyTxComplete();
+
     if (tx_info == NULL)
     {
         ESP_LOGE(TAG, "Send cb arg error");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1669,7 +1669,12 @@ void espnowQueueTask(void *arg)
             {
                 ESP_LOGD(TAG, "Send data to " MACSTR, MAC2STR(msg.dest));
 
-                if (esp_now_send(msg.dest, msg.data, msg.data_len) != ESP_OK)
+                // Route through the in-flight-counted send so this path's
+                // send-done callback has a matching increment — espnowSendCallback
+                // calls notifyTxComplete() unconditionally, so an uncounted send
+                // here would drift espnowTxInFlight_ negative and disable OTA
+                // throttling.
+                if (AstrOs_EspNow.sendCounted(msg.dest, msg.data, msg.data_len) != ESP_OK)
                 {
                     ESP_LOGE(TAG, "Send error");
                 }


### PR DESCRIPTION
## Summary

Bench OTA of a ~1.27 MB image (metro_s3 → padawan) drove a self-reinforcing
congestion storm on the master→padawan ESP-NOW link — bad enough that the
operator had to abort the transfer manually. Two compounding causes, fixed in two
parts:

- **Part A** — the master retransmitted chunks the padawan had already committed
  (ack-timeout too tight for the padawan's flash-write cadence), and every
  duplicate drew an `OUT_OF_ORDER` NAK.
- **Part B** — the master fired a full window of `OTA_DATA` frames per tick with
  no backpressure on the radio, overran the ESP-NOW TX queue, and
  `esp_now_send` started returning `ESP_ERR_ESPNOW_NO_MEM`.

The two loops fed each other: redundant chunks + NAKs added airtime → more
NO_MEM → more ACK lag → more spurious retransmits.

This branch is mesh-transport only. It is independent of, and stacks on top of,
the version-confirm fix (PR #43, already merged to `develop`) — a deploy built
from this branch carries both.

## Observed symptom (bench logs)

**Padawan (`OtaWriter`):**
```
handleData: xferId=1 seq=111 NAK reason=3 (hcs=113 nes=114 wr=8)
handleData: xferId=1 seq=110 NAK reason=3 (hcs=113 nes=114 wr=8)
```
`reason=3` = `NakReason::OUT_OF_ORDER`. The padawan has committed through seq 113
(`hcs=113`, wants 114) but the master keeps re-sending 110/111/112 — chunks it
already holds. `BulkReceiver::onChunk` rejects any `seq != nextSeq_` as
OUT_OF_ORDER, so every redundant chunk = one NAK.

**Master (`OtaForwarder` / `AstrOsEspNow`):**
```
OTA_DATA seq=161 sendOtaFrame returned ESP_ERR_ESPNOW_NO_MEM; tick will retry
sendOtaFrame: esp_now_send returned ESP_ERR_ESPNOW_NO_MEM for type=28
```
The ESP-NOW internal TX queue is full — sends outrunning the radio.

## Root cause (read from source)

1. **Ack-timeout too tight for flash cadence.** `kAckTimeoutMs = 400` with
   `kWindowSize = 8` (`OtaForwarder.hpp`). The padawan writes each chunk to OTA
   flash (slow erase+program) and pauses other ESP-NOW traffic during writes, so
   its cumulative ACKs lag past 400 ms under load. The 50 ms tick
   (`BulkSender::tick` → retransmit) then resends in-flight slots the padawan has
   already received → the OUT_OF_ORDER NAK storm.
2. **No TX flow control.** `AstrOsEspNow::sendOtaFrame` called `esp_now_send` and
   returned immediately, never gating on the send-done callback (which was a
   no-op). `streamDrain` pushed a full window per tick → TX queue overrun →
   NO_MEM. Tail risk: `kMaxRetries = 3` in `tick()` can trip
   `data_retry_exceeded` and abort the padawan under a sustained spike.

## Fix

### Part A — ack-timeout / window tuning (`lib/OtaForwarder/include/OtaForwarder.hpp`)
- `kAckTimeoutMs` 400 → 1500: the master stops retransmitting chunks the padawan
  is still flashing (kills the spurious-retransmit half directly).
- `kWindowSize` 8 → 4: bounds in-flight bytes and airtime pressure.
- `kChunkSize=128`, `kMaxRetries=3` unchanged.

### Part B — ESP-NOW TX in-flight counter (`lib/AstrOsEspNow`, `src/main.cpp`, `lib/OtaForwarder`)

A **non-blocking atomic** in-flight counter, deliberately **not** a counting
semaphore (see "Why not a semaphore" below):

- `static std::atomic<int> espnowTxInFlight_{0}` (file-static in
  `AstrOsEspNowService.cpp`).
- **One accounting site** — `espnowSendCounted(mac,data,size)`: `fetch_add(1)` →
  `esp_now_send` → `fetch_sub(1)` if it returns non-OK (a frame that never
  enqueued gets no send-done callback). All **9** raw `esp_now_send` call sites
  in `AstrOsEspNowService.cpp` now route through this one wrapper, so the
  accounting can't drift per-site.
- `AstrOsEspNow::notifyTxComplete()`: `fetch_sub(1)`, called **once,
  unconditionally** at the top of `espnowSendCallback` (`src/main.cpp`) — the
  send-done callback fires exactly once per enqueued frame, SUCCESS or FAIL.
- `AstrOsEspNow::espnowTxAtCapacity()`: `load() >= 6`. Cap = 6, held well under
  `CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER_NUM` (32) and matching
  `CONFIG_ESP_WIFI_TX_BA_WIN` (6).
- `OtaForwarder::streamDrain`: checks `espnowTxAtCapacity()` at the top of each
  loop and stops draining when 6 frames are in flight — the same poll-and-decline
  exit as `WINDOW_FULL`. The 50 ms tick re-enters `streamDrain` as send-done
  callbacks drain the count. The tick-driven *retransmit* path is intentionally
  not gated (window-bounded, higher-priority recovery, with its own NO_MEM
  backstop).

**Counts all sends, not just OTA** — poll, registration, servo-test, and OTA
share the same radio TX buffers, so counting them all against the cap is
physically accurate, and a single wrapper + single callback give keeps the
add/sub pairing auditable in two functions.

## Why not a counting semaphore

A blocking semaphore `take` in front of the **shared** send path means any
credit-accounting leak deadlocks the *entire mesh* (all 9 sites share one
send-done callback). The atomic counter's only consumer is a poll-and-decline
check in the OTA drain, so:

```
Leak in a semaphore design  → take() blocks → mesh deadlock (hang).
Leak in the atomic design    → count drifts HIGH → OTA throttles harder (slow),
                               never hangs, and self-heals as callbacks arrive.
```

The failure mode degrades to "slow," which the existing window+tick machinery
already tolerates. No new blocking primitive is introduced on a brick-adjacent,
known-fragile path (CLAUDE.md flags `AstrOsEspNow` send + the WiFi-task callback).

### Accounting invariant
Every `fetch_add` (in `espnowSendCounted`) is matched by exactly one `fetch_sub`
— either the immediate non-OK give-back (frame not enqueued) or the one
`notifyTxComplete` from the send-done callback (frame enqueued). `memory_order_relaxed`
throughout: the counter is a throttle hint, not a data guard (mirrors
`espnowMallocFailureCount`).

## Test coverage

- **482/482 native tests pass** (`pio test -e test`). No PURE-layer change — the
  window/timeout are runtime args to `BulkSender::begin`, and the in-flight
  counter is MIXED-layer (ESP-NOW), so `AstrOsBulkTransport` tests are unaffected.
- Both boards build clean: metro_s3, lolin_d32_pro.

## ⚠ Requires on-device bench (not yet run)

The fix builds and the accounting is provably correct, but the storm being gone
can only be confirmed on hardware. On the next padawan-only deploy, watch the ESP
serial for:
- `ESP_ERR_ESPNOW_NO_MEM` bursts gone (or rare — occasional is fine; the cap
  throttles and the tick retries).
- `OUT_OF_ORDER` NAK (`reason=3`) storm gone.
- Transfer completes without a manual abort.

If it's now too slow rather than stormy, the cap (6) or window (4) is the dial to
loosen.

## Files touched

| File | Change |
|---|---|
| `lib/OtaForwarder/include/OtaForwarder.hpp` | `kWindowSize` 8→4, `kAckTimeoutMs` 400→1500 (Part A) |
| `lib/AstrOsEspNow/src/AstrOsEspNowService.cpp` | `espnowTxInFlight_` atomic + `espnowSendCounted` wrapper; 9 send sites routed through it |
| `lib/AstrOsEspNow/src/AstrOsEspNowService.hpp` | `notifyTxComplete()` + `espnowTxAtCapacity()` declarations |
| `src/main.cpp` | `espnowSendCallback` decrements the in-flight count once per completion |
| `lib/OtaForwarder/src/OtaForwarder.cpp` | `streamDrain` declines to send at capacity |
| `.docs/plans/20260529-1108-ota-espnow-congestion.md` | light plan |

## Commit history

```
0a21783 fix(ota): bound ESP-NOW TX in-flight to stop NO_MEM during OTA streaming
899fb47 docs(ota): rewrite Part B as non-blocking atomic in-flight counter
657200e fix(ota): widen ack-timeout 400->1500ms, shrink window 8->4 to stop NAK storm
ae790ab docs(ota): light plan — fix ESP-NOW transfer NAK storm (flow control + ack-timeout)
```

## Test plan

- [x] CI: native tests, both-board build matrix, native-purity guard, clang-format
- [x] 482/482 native tests pass
- [x] Both boards build clean (metro_s3, lolin_d32_pro)
- [x] Send-accounting audit: 1 raw `esp_now_send` (inside the wrapper), 9 sites via `espnowSendCounted`, 1 unconditional `notifyTxComplete`
- [ ] Bench: padawan-only deploy completes without NO_MEM/NAK storm and without manual abort
- [ ] Bench: confirm throughput is acceptable at window=4 / cap=6 (tune if sluggish)

🤖