### PR TITLE
Fix/ota writer self flash stack

### DIFF
--- a/.docs/plans/20260529-1621-ota-writer-self-flash-stack.md
+++ b/.docs/plans/20260529-1621-ota-writer-self-flash-stack.md
@@ -50,8 +50,8 @@ single handler that overruns mid-execution.
    (~112 KB free on the bench run); +4 KB stack is comfortable.
 
 Net permanent RAM cost: +4 KB. No behavior change beyond stack/buffer layout.
-Not unit-testable (stack depth is invisible to host tests); verified by build +
-bench re-run of the master self-flash.
+Not unit-testable (stack depth is invisible to host tests); build checks pass,
+and master self-flash still needs a bench re-run.
 
 ## Tasks
 

--- a/.docs/plans/20260529-1621-ota-writer-self-flash-stack.md
+++ b/.docs/plans/20260529-1621-ota-writer-self-flash-stack.md
@@ -1,0 +1,62 @@
+# Fix: ota_writer_task stack overflow during master self-flash
+
+## Problem
+
+Bench run (2026-05-29, metro_s3 / ESP32-S3) crashed with a FreeRTOS stack
+overflow in `ota_writer_task` immediately after `startMasterSelfFlash` →
+`OtaWriter::handleLocalFlashReq` began streaming a ~1.27 MB firmware image
+from `/sdcard/firmware/…`:
+
+```
+***ERROR*** A stack overflow in task ota_writer_task has been detected.
+  vApplicationStackOverflowHook → vTaskSwitchContext (mid-fread context switch)
+```
+
+### Root cause
+
+`OtaWriter::handleLocalFlashReq` declares **two** 4 KB buffers at function
+scope:
+
+- `uint8_t buf[4096]` (`lib/OtaWriter/src/OtaWriter.cpp` Step 3) — file streaming
+- `uint8_t rbBuf[4096]` (Step 6) — read-back verify
+
+metro_s3 builds with `CONFIG_COMPILER_OPTIMIZATION_DEFAULT` (`-Og`). GCC's
+`-fstack-reuse` only reclaims a slot when a variable's *scope* ends; both
+arrays are function-scoped, so they coexist for the whole call = **8192 bytes
+of arrays alone** on an **8192-byte** task stack (`ota_writer_task`,
+`src/main.cpp:248`). Add the `AstrOsSha256Ctx rbCtx` (108 B), digests, the
+`postResult` lambda frame, and the deep `fread → FATFS → SD/SPI` call chain
+layered on top during Step 3 → guaranteed overflow.
+
+The padawan receive path survives the same 8 KB stack because `handleData`
+writes ~180 B chunk payloads straight from the queue (no big array) and
+`handleEnd` uses exactly **one** 4 KB buffer reading via the shallow
+`esp_partition_read` (not FATFS/SD). The self-flash path both doubled the
+buffers and swapped in a deeper read path.
+
+The 500-byte high-water-mark warning (`src/main.cpp:1618`) never fired: it runs
+*after* `process()` returns, between messages, so it is structurally blind to a
+single handler that overruns mid-execution.
+
+## Approach (Option A)
+
+1. **Collapse the two 4 KB buffers into one reused buffer.** Step 3 and Step 6
+   run strictly sequentially (the file is `fclose`'d before readback begins),
+   so a single `buf[4096]` is provably safe and mirrors the proven-good
+   `handleEnd` single-buffer pattern. Halves buffer footprint to 4 KB.
+2. **Bump `ota_writer_task` stack 8192 → 12288.** Gives margin for the
+   `fread → FATFS → SD/SPI` call depth that the receive path never exercises
+   and that cannot be measured precisely from source. RAM is plentiful
+   (~112 KB free on the bench run); +4 KB stack is comfortable.
+
+Net permanent RAM cost: +4 KB. No behavior change beyond stack/buffer layout.
+Not unit-testable (stack depth is invisible to host tests); verified by build +
+bench re-run of the master self-flash.
+
+## Tasks
+
+- [ ] Collapse Step 6's `rbBuf`/`kRbBufSize` to reuse Step 3's `buf`/`kChunkBytes` in `lib/OtaWriter/src/OtaWriter.cpp`; add a comment noting the single-buffer stack budget
+- [ ] Update the `handleEnd` readback comment that references "otaWriterTask's stack (8 KB)" to "(12 KB)"
+- [ ] Bump `ota_writer_task` stack 8192 → 12288 in `src/main.cpp:248` and refresh the sizing comment to mention the self-flash FATFS/SD read depth
+- [ ] Build `pio run -e metro_s3` (crashing board) and run `pio test -e test`; confirm both pass
+- [ ] Commit; bench-verify master self-flash on hardware (manual, off-plan)

--- a/.docs/plans/20260529-1621-ota-writer-self-flash-stack.md
+++ b/.docs/plans/20260529-1621-ota-writer-self-flash-stack.md
@@ -55,8 +55,8 @@ bench re-run of the master self-flash.
 
 ## Tasks
 
-- [ ] Collapse Step 6's `rbBuf`/`kRbBufSize` to reuse Step 3's `buf`/`kChunkBytes` in `lib/OtaWriter/src/OtaWriter.cpp`; add a comment noting the single-buffer stack budget
-- [ ] Update the `handleEnd` readback comment that references "otaWriterTask's stack (8 KB)" to "(12 KB)"
-- [ ] Bump `ota_writer_task` stack 8192 → 12288 in `src/main.cpp:248` and refresh the sizing comment to mention the self-flash FATFS/SD read depth
-- [ ] Build `pio run -e metro_s3` (crashing board) and run `pio test -e test`; confirm both pass
+- [x] Collapse Step 6's `rbBuf`/`kRbBufSize` to reuse Step 3's `buf`/`kChunkBytes` in `lib/OtaWriter/src/OtaWriter.cpp`; add a comment noting the single-buffer stack budget
+- [x] Update the `handleEnd` readback comment that references "otaWriterTask's stack (8 KB)" to "(12 KB)"
+- [x] Bump `ota_writer_task` stack 8192 → 12288 in `src/main.cpp:248` and refresh the sizing comment to mention the self-flash FATFS/SD read depth
+- [x] Build + tests: `pio test -e test` 482/482 pass; `pio run -e metro_s3` and `pio run -e lolin_d32_pro` both SUCCESS; clang-format clean on both changed files
 - [ ] Commit; bench-verify master self-flash on hardware (manual, off-plan)

--- a/lib/OtaWriter/src/OtaWriter.cpp
+++ b/lib/OtaWriter/src/OtaWriter.cpp
@@ -553,7 +553,7 @@ void OtaWriter::handleEnd(queue_ota_writer_msg_t &msg)
     // Read-back-and-rehash: catches silent flash corruption that landed
     // between esp_ota_write and esp_ota_end's finalize. 4 KB buffer
     // matches the flash sector size. Stack-allocated; sized against
-    // otaWriterTask's stack (8 KB). Re-verify HWM if the stack is shrunk.
+    // otaWriterTask's stack (12 KB). Re-verify HWM if the stack is shrunk.
     AstrOsSha256Ctx rbCtx;
     AstrOsSha256_init(&rbCtx);
 
@@ -732,6 +732,8 @@ void OtaWriter::handleLocalFlashReq(queue_ota_writer_msg_t &msg)
     }
 
     // ─── Step 3: stream the file in 4 KB chunks ──────────────────────
+    // This buffer is reused by the Step 6 readback verify — keep it a single
+    // 4 KB array. A second function-scoped 4 KB buffer overflows the stack.
     AstrOsSha256_init(&shaCtx_);
     shaActive_ = true;
     constexpr size_t kChunkBytes = 4096;
@@ -800,14 +802,17 @@ void OtaWriter::handleLocalFlashReq(queue_ota_writer_msg_t &msg)
     otaHandle_ = 0;
 
     // ─── Step 6: read-back-rehash verify ─────────────────────────────
+    // Reuse the Step 3 streaming buffer `buf`: the file is closed and the
+    // write phase is complete, so the two phases never touch it at once.
+    // Keeping a single 4 KB buffer (not two) holds ota_writer_task's stack
+    // within budget — two function-scoped 4 KB arrays coexist under -Og and
+    // overflow the stack mid-flash (see src/main.cpp ota_writer_task sizing).
     AstrOsSha256Ctx rbCtx;
     AstrOsSha256_init(&rbCtx);
-    constexpr size_t kRbBufSize = 4096;
-    uint8_t rbBuf[kRbBufSize];
     for (size_t off = 0; off < expectedSize;)
     {
-        size_t chunk = std::min(kRbBufSize, static_cast<size_t>(expectedSize - off));
-        err = esp_partition_read(inactivePartition_, off, rbBuf, chunk);
+        size_t chunk = std::min(kChunkBytes, static_cast<size_t>(expectedSize - off));
+        err = esp_partition_read(inactivePartition_, off, buf, chunk);
         if (err != ESP_OK)
         {
             ESP_LOGE(TAG, "handleLocalFlashReq: esp_partition_read at off=%zu failed: %s", off, esp_err_to_name(err));
@@ -816,7 +821,7 @@ void OtaWriter::handleLocalFlashReq(queue_ota_writer_msg_t &msg)
             postResult(OtaFlashStatus::FAILED, esp_err_to_name(err));
             return;
         }
-        AstrOsSha256_update(&rbCtx, rbBuf, chunk);
+        AstrOsSha256_update(&rbCtx, buf, chunk);
         off += chunk;
     }
     uint8_t readbackDigest[32];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -241,11 +241,14 @@ void app_main()
         }
     }
 
-    // 8 KB stack (larger than the OTA receiver/forwarder family):
-    // OtaWriter::handleEnd declares a 4 KB readback buffer plus the
-    // SHA-256 ctx and call frames; that does not fit in 4 KB.
+    // 12 KB stack (larger than the OTA receiver/forwarder family):
+    // OtaWriter declares a 4 KB readback buffer plus the SHA-256 ctx and
+    // call frames; that does not fit in 4 KB. The master self-flash path
+    // (handleLocalFlashReq) layers a deep fread→FATFS→SD/SPI call chain on
+    // top of that buffer — deeper than the padawan wire path's shallow
+    // esp_partition_read — so it needs more headroom than 8 KB.
     // Task runs on both master (self-flash loopback) and padawan (wire OTA).
-    if (xTaskCreatePinnedToCore(&otaWriterTask, "ota_writer_task", 8192, (void *)otaWriterQueue, 6, NULL, 1) != pdPASS)
+    if (xTaskCreatePinnedToCore(&otaWriterTask, "ota_writer_task", 12288, (void *)otaWriterQueue, 6, NULL, 1) != pdPASS)
     {
         ESP_LOGE(TAG, "Failed to create otaWriterTask — aborting init");
         abort();


### PR DESCRIPTION
# fix(ota): stop ota_writer_task stack overflow in master self-flash

## Summary

Bench testing the PR-set-2 OTA mesh-forward feature (with version-confirm and the ESP-NOW congestion fixes now merged) reached the **master self-flash** step and **panicked**: a FreeRTOS stack overflow in `ota_writer_task` the moment `OtaWriter::handleLocalFlashReq` started streaming the ~1.27 MB image off the SD card.

```
I (...) OtaForwarder: startMasterSelfFlash: beginning master self-flash
I (...) OtaWriter: handleLocalFlashReq: path=/sdcard/firmware/7a4c6d13c23fe630.bin expectedSize=1268816
...
***ERROR*** A stack overflow in task ota_writer_task has been detected.
  vApplicationStackOverflowHook → vTaskSwitchContext   (detected mid-read, ~4 s in)
```

Root cause: `handleLocalFlashReq` declared **two** 4 KB buffers at **function scope** — `buf` (Step 3 file-stream) and `rbBuf` (Step 6 read-back verify).

| Buffer | Location | Purpose |
|---|---|---|
| `buf[4096]` | `OtaWriter.cpp` Step 3 | stream firmware from SD via `fread` |
| `rbBuf[4096]` | `OtaWriter.cpp` Step 6 | read flash back via `esp_partition_read` |

`metro_s3` builds with `CONFIG_COMPILER_OPTIMIZATION_DEFAULT` → `-Og`. GCC's `-fstack-reuse` only reclaims a variable's slot when its **scope** ends; both arrays are function-scoped, so they coexist for the entire call = **8192 bytes of arrays alone** on the **8192-byte** `ota_writer_task` stack (`src/main.cpp:248`). Add the `AstrOsSha256Ctx rbCtx` (108 B), the digests, the `postResult` lambda frame, and — the part that tips it over — the deep `fread → FATFS → SD/SPI` call chain layered on top during Step 3. Overflow is structurally guaranteed.

## Why the padawan wire path never hit this

The receive path runs on the same 8 KB `ota_writer_task` and flashed padawans fine, because it never builds this stack profile:

- `handleData` writes ~180 B chunk payloads straight from the queue message — **no large stack array**.
- `handleEnd` uses exactly **one** 4 KB buffer, reading via the shallow `esp_partition_read` (flash), not FATFS/SD.

The self-flash path is the only one that both **doubled** the buffers *and* swapped the shallow flash read for a deep FATFS/SD read. Two compounding regressions on one stack.

## Why the HWM warning didn't catch it first

`ota_writer_task` has a `uxTaskGetStackHighWaterMark` check that warns at <500 B remaining (`src/main.cpp:1618`). It never fired — it runs **after** `process()` returns, between messages. A single handler that overruns mid-execution blows past the canary before control returns. The between-messages canary is structurally blind to within-handler overflow.

## Fix (Option A — footprint reduction + margin)

1. **Collapse the two 4 KB buffers into one.** Step 3 and Step 6 run strictly sequentially — the file is `fclose`'d and the write phase is complete before readback begins — so reusing the Step 3 `buf` is provably safe and mirrors the proven-good `handleEnd` single-buffer pattern. Buffer footprint: 8 KB → 4 KB.
2. **Bump `ota_writer_task` stack 8192 → 12288.** Gives headroom for the `fread → FATFS → SD/SPI` call depth the receive path never exercises and that can't be measured precisely from source.

Net permanent RAM: **+4 KB**. No behavior change beyond stack/buffer layout; no wire-format, queue, or server-side changes.

## What ships

- **`lib/OtaWriter/src/OtaWriter.cpp`** — Step 6 readback reuses Step 3's `buf`/`kChunkBytes` (removes the `rbBuf`/`kRbBufSize` pair); comments at both Step 3 and Step 6 document the single-buffer stack budget so the second buffer isn't reintroduced. `handleEnd`'s readback comment updated `8 KB` → `12 KB`.
- **`src/main.cpp`** — `ota_writer_task` stack `8192` → `12288`; sizing comment now explains the self-flash FATFS/SD read depth vs the padawan wire path's shallow `esp_partition_read`.
- **Light plan** — `.docs/plans/20260529-1621-ota-writer-self-flash-stack.md`.

## Why not "just grow the stack"

A one-line bump to 16 KB would also clear the crash, but it keeps the redundant double-buffer (a latent smell the next handler copies) and costs +8 KB. Reusing the buffer fixes the cause, aligns self-flash with the receive path's known-good shape, and the modest stack bump only hedges the FATFS/SD depth unknown — all for +4 KB.

## Verification

Build- and test-level — the layers I can prove off-hardware:

| Check | metro_s3 | lolin_d32_pro |
|---|---|---|
| `pio run` | ✅ SUCCESS | ✅ SUCCESS |
| RAM static use | 14.6% (47752 B) | — |
| clang-format (`--Werror`) | ✅ clean | ✅ clean |

- ✅ **482/482 native tests pass** (`pio test -e test`).
- ✅ Both-board build matrix clean.

## ⚠ Still requires on-device confirmation

A stack overflow is invisible to host tests and to the build — the **bench is the proof**. The fix removes a definitive 4 KB overrun and adds margin, so it's very likely correct, but the live master self-flash is what confirms it. On the next on-device deploy, expect:

- `handleLocalFlashReq: success — boot partition flipped` with no panic, master reboots into the new image.
- **No** `OTA Writer Stack HWM` warning. If one appears, 12 KB is still tight — that's the canary to watch (unlikely; one 4 KB buffer + FATFS/SD frames should leave several KB free).

## Notes / risk

- The overflow does **not** scale with firmware size — the buffer is a fixed 4 KB and the file is read in chunks, so the ~1.27 MB image only changes the loop count, not the stack depth. This was fixed buffers + call-chain depth, full stop.
- `ota_writer_task` is the sole consumer of its queue, so `handleData` / `handleEnd` / `handleLocalFlashReq` never run concurrently — reusing one buffer across the two phases of a single call has no aliasing hazard.

## Commit history

```
6237e8c fix(ota): stop ota_writer_task stack overflow in master self-flash
57e6dd8 docs(ota): light plan — fix ota_writer_task self-flash stack overflow
```

## Test plan

- [x] CI: PR validation (native tests, both-board build matrix, native-purity guard, clang-format)
- [x] 482/482 native tests pass at HEAD
- [x] Both boards build clean (metro_s3, lolin_d32_pro)
- [x] clang-format clean on both changed files
- [ ] Bench: master self-flash reaches `boot partition flipped` and reboots into the new image with no `ota_writer_task` overflow and no HWM warning

