### PR TITLE
Feature/master ota progress

### DIFF
--- a/.docs/plans/20260530-1430-master-ota-progress.md
+++ b/.docs/plans/20260530-1430-master-ota-progress.md
@@ -55,15 +55,16 @@ left untouched.
 
 ## Tasks
 
-- [ ] In `startMasterSelfFlash`: set `currentControllerId_ = "00:00:00:00:00:00"`
+- [x] In `startMasterSelfFlash`: set `currentControllerId_ = "00:00:00:00:00:00"`
       and `firmwareTotalSize_ = expectedSize` early; emit `VERIFYING` before
-      `computeFileSha256`.
-- [ ] In `startMasterSelfFlash`: emit `FLASHING` immediately after the writer-queue
+      `computeFileSha256`. (Removed the redundant later `currentControllerId_`
+      assignment.)
+- [x] In `startMasterSelfFlash`: emit `FLASHING` immediately after the writer-queue
       `xQueueSend` succeeds.
-- [ ] In `handleLocalFlashResult` OK branch: emit `REBOOTING` before
+- [x] In `handleLocalFlashResult` OK branch: emit `REBOOTING` before
       `insertMasterRow` / reboot.
-- [ ] Compile both boards (`pio run -e metro_s3` and `-e lolin_d32_pro`).
-- [ ] Add QA plan `.docs/qa/master-ota-progress.md`.
+- [x] Compile both boards (`pio run -e metro_s3` and `-e lolin_d32_pro`) — both SUCCESS.
+- [x] Add QA plan `.docs/qa/master-ota-progress.md`.
 
 ## Out of scope / notes
 

--- a/.docs/plans/20260530-1430-master-ota-progress.md
+++ b/.docs/plans/20260530-1430-master-ota-progress.md
@@ -1,0 +1,73 @@
+# Master OTA self-flash progress (verify / flash / reboot)
+
+## Problem
+
+During a firmware deploy, padawan rows surface live progress in the web UI via
+`FW_PROGRESS` messages (`SENDING → VERIFYING → FLASHING → REBOOTING`). The
+**master self-flash** path emits **no** `FW_PROGRESS` — the master's own row sits
+on the server-set `SENDING` state for the whole multi-second self-flash, then
+jumps straight to `PENDING` (via `FW_DEPLOY_DONE`) and finally
+`VERSION_CONFIRMED` (via the post-reboot heartbeat). The operator sees no
+verify/flash/reboot activity for the master.
+
+Goal: the master emits `VERIFYING`, `FLASHING`, and `REBOOTING` `FW_PROGRESS`
+messages using its sentinel MAC `00:00:00:00:00:00`, in the same wire format as a
+padawan, so the web server's controller-agnostic state machine renders the master
+identically.
+
+## Design (forwarder-only — no `OtaWriter` changes)
+
+One `FW_PROGRESS` per stage at 100% (`bytesSent == totalBytes`), mirroring how the
+forwarder already emits for padawans (one milestone per stage, not an
+in-progress/complete pair). The stages map onto the forwarder's own work:
+
+| Stage | Emitted where | Meaning |
+|---|---|---|
+| `VERIFYING` | `startMasterSelfFlash`, just before `computeFileSha256` | forwarder hashes + checks the staged image |
+| `FLASHING`  | `startMasterSelfFlash`, right after the writer-queue `xQueueSend` succeeds | image handed to `OtaWriter`; covers its write + read-back verify + commit |
+| `REBOOTING` | `handleLocalFlashResult` OK branch, before `insertMasterRow`/reboot | about to `esp_restart` |
+
+`VERSION_CONFIRMED` is **not** emitted by the master — it reboots immediately. The
+existing `FW_DEPLOY_DONE`=`PENDING` (sentinel row) → server `FINALIZING` →
+post-reboot heartbeat → `VERSION_CONFIRMED` flow already handles the finish and is
+left untouched.
+
+## Verified against the web server (`AstrOs.Server/astros_api`) — no rework risk
+
+- **Wire format** (`message_handler.ts:304-335`): `FW_PROGRESS` type 38, payload
+  `transferId␟controllerId␟stage␟bytesSent␟totalBytes␟detail`. The forwarder's
+  existing `sendFwProgress(...)` already produces exactly this.
+- **`VERIFYING` is a legal first message for the master row.** The orchestrator
+  pre-advances *every* row (including the sentinel-MAC master row) `Queued →
+  UploadingToMaster → Sending` when the upload to the master completes, before
+  `FW_DEPLOY_BEGIN` (`flash_orchestrator.ts:833-848`). `Sending → Verifying` is
+  legal (`flash_job_state_machine.ts:31-33`). So the master needs **no** `SENDING`
+  message.
+- **Order is mandatory.** Illegal transitions throw and `handleDeployProgress`
+  turns that into `failDeployPhase('protocol_violation')`
+  (`flash_orchestrator.ts:1294-1300`). Must emit `VERIFYING → FLASHING →
+  REBOOTING`; `Sending→Flashing` (skipping verify) would fail the deploy.
+- **Failure path stays via `FW_DEPLOY_DONE`.** A writer `FAILED` after we emitted
+  `FLASHING` lands `Flashing → Failed` through `handleDeployDone` (legal) — same as
+  padawans; no extra `FW_PROGRESS` on failure.
+- **Sentinel MAC** `00:00:00:00:00:00` is the master's controller id in the job's
+  target list (`post_deploy_heartbeat.ts`), matched in `handleDeployProgress`.
+
+## Tasks
+
+- [ ] In `startMasterSelfFlash`: set `currentControllerId_ = "00:00:00:00:00:00"`
+      and `firmwareTotalSize_ = expectedSize` early; emit `VERIFYING` before
+      `computeFileSha256`.
+- [ ] In `startMasterSelfFlash`: emit `FLASHING` immediately after the writer-queue
+      `xQueueSend` succeeds.
+- [ ] In `handleLocalFlashResult` OK branch: emit `REBOOTING` before
+      `insertMasterRow` / reboot.
+- [ ] Compile both boards (`pio run -e metro_s3` and `-e lolin_d32_pro`).
+- [ ] Add QA plan `.docs/qa/master-ota-progress.md`.
+
+## Out of scope / notes
+
+- No new native logic (the `getFwProgress` builder is already unit-tested); change
+  is MIXED forwarder wiring only, covered by the QA plan.
+- No `OtaWriter` edits — deliberately avoids the just-stabilized
+  `ota_writer_task` stack (PR #47, bench-verify pending).

--- a/.docs/qa/master-ota-progress.md
+++ b/.docs/qa/master-ota-progress.md
@@ -1,0 +1,101 @@
+# OTA — Master Self-Flash Progress QA
+
+Verifies the master emits `FW_PROGRESS` (`VERIFYING` → `FLASHING` → `REBOOTING`)
+for its own self-flash, under the sentinel MAC `00:00:00:00:00:00`, so the web
+UI renders the master row through the same stages as a padawan.
+
+Plan: `.docs/plans/20260530-1430-master-ota-progress.md`.
+Change is forwarder-only (`lib/OtaForwarder/src/OtaForwarder.cpp`).
+
+## Preconditions
+
+- A master node (real hardware) connected to the AstrOs server / Pi over the
+  interface UART (serial channel 1, 115200).
+- The web app open on the firmware-deploy view, server logs tailable.
+- A valid new firmware image stageable to the master (different version string
+  than what's running, so the post-reboot heartbeat confirms a real change).
+- At least one deploy target list that **includes the master** (sentinel MAC in
+  the order). Test both: (a) master + ≥1 padawan, (b) master-only.
+
+## Happy path — master + padawan deploy
+
+### Steps
+1. Select a padawan **and** the master in the deploy UI; start the deploy.
+2. Watch the master row in the UI and the server log as the deploy proceeds
+   past the padawan(s) to the master self-flash.
+
+### Expected results
+- Padawan row advances normally (`SENDING` %→ `VERIFYING` → `FLASHING` →
+  `REBOOTING` → `VERSION_CONFIRMED`).
+- Master row (sentinel `00:00:00:00:00:00`) — which the server pre-set to
+  `SENDING` during upload — then advances:
+  - `VERIFYING` appears as the master begins hashing the staged image.
+  - `FLASHING` appears once the image is handed to the writer (stays for the
+    multi-second write + read-back verify + commit window).
+  - `REBOOTING` appears just before the master restarts.
+- After reboot, the master's heartbeat resolves the row
+  `FINALIZING → VERSION_CONFIRMED` with the new version string.
+- **No** `protocol_violation` / "illegal flash-job transition" in the server log
+  for the sentinel MAC.
+- Each master `FW_PROGRESS` carries `bytesSent == totalBytes` == the firmware
+  size (non-zero), and `controllerId == 00:00:00:00:00:00`.
+
+## Happy path — master-only deploy
+
+### Steps
+1. Select **only** the master; start the deploy.
+
+### Expected results
+- Same master-row progression as above (`VERIFYING → FLASHING → REBOOTING`,
+  then heartbeat → `VERSION_CONFIRMED`).
+- `totalBytes` is the real firmware size (regression guard: `firmwareTotalSize_`
+  is now set on the master path — previously only set during a padawan transfer,
+  so a master-only deploy would otherwise have reported `0`).
+
+## Negative path 1 — staged image fails verification
+
+Force a bad/oversized/missing staged image (e.g., corrupt `staging.bin` or a
+size mismatch) before the master self-flash step.
+
+### Expected results
+- `VERIFYING` may appear (emitted before hashing), then the master records
+  `FAILED`; `FW_DEPLOY_DONE` carries the master row as `FAILED` with the reason
+  (`firmware_sha_failed` / `no_firmware` / `firmware_stat_failed`).
+- Server takes the row `Verifying → Failed` (or `Sending → Failed` if the failure
+  precedes the `VERIFYING` emit). **No** `REBOOTING`, **no** reboot.
+- No illegal-transition error in the server log.
+
+## Negative path 2 — writer reports flash failure
+
+Induce a writer-side flash failure (e.g., partition write / `esp_ota_end` error)
+so `OtaWriter` posts `OTA_FWD_LOCAL_FLASH_RESULT` = FAILED.
+
+### Expected results
+- Master row shows `VERIFYING` then `FLASHING`, then `FW_DEPLOY_DONE` carries it
+  as `FAILED`. Server takes `Flashing → Failed`. **No** `REBOOTING`, **no**
+  reboot (bootloader still points at the running image).
+
+## Negative path 3 — self-flash timeout
+
+Make `OtaWriter` hang / never post a result (or queue-full the post).
+
+### Expected results
+- After the 60 s `masterSelfFlashTimer`, master records `FAILED`
+  (`self_flash_timeout`) and emits `FW_DEPLOY_DONE`. Master row ends `FAILED`
+  (`Flashing → Failed`). No reboot, no illegal transition.
+
+## Wire-order check (optional, with a serial sniffer on ch1)
+
+Confirm the on-wire `FW_PROGRESS` sequence for the sentinel MAC during a
+successful self-flash is exactly:
+
+```
+FW_PROGRESS … 00:00:00:00:00:00 VERIFYING  <size> <size>
+FW_PROGRESS … 00:00:00:00:00:00 FLASHING   <size> <size>
+FW_PROGRESS … 00:00:00:00:00:00 REBOOTING  <size> <size>
+FW_DEPLOY_DONE … 00:00:00:00:00:00 PENDING
+```
+
+`VERIFYING` must precede `FLASHING` must precede `REBOOTING` — out-of-order
+emission fails the whole deploy server-side (`failDeployPhase('protocol_violation')`).
+`REBOOTING` must precede `FW_DEPLOY_DONE`.

--- a/lib/OtaForwarder/src/OtaForwarder.cpp
+++ b/lib/OtaForwarder/src/OtaForwarder.cpp
@@ -1525,6 +1525,20 @@ void OtaForwarder::startMasterSelfFlash()
     }
     uint32_t expectedSize = static_cast<uint32_t>(st.st_size);
 
+    // The master reports its own self-flash progress under the sentinel MAC so
+    // the server's controller-agnostic state machine renders it like a padawan.
+    // firmwareTotalSize_ is otherwise only set on the padawan transfer path; the
+    // master row needs it for the FW_PROGRESS byte counts (esp. a master-only
+    // deploy, where no padawan transfer ran to populate it).
+    currentControllerId_ = "00:00:00:00:00:00";
+    firmwareTotalSize_ = expectedSize;
+
+    // VERIFYING: the server pre-advanced the master row to SENDING during upload,
+    // so Sending->Verifying is the legal first master FW_PROGRESS. Emit it before
+    // hashing so the verify row is visible while computeFileSha256 reads the file.
+    AstrOs_SerialMsgHandler.sendFwProgress(deployTransferId_, currentControllerId_, "VERIFYING", firmwareTotalSize_,
+                                           firmwareTotalSize_, "");
+
     // ─── Compute SHA-256 ────────────────────────────────────────────
     uint8_t expectedSha[32];
     if (!computeFileSha256(firmwarePath, expectedSha))
@@ -1551,8 +1565,6 @@ void OtaForwarder::startMasterSelfFlash()
         emitDeployDoneAndReset();
         return;
     }
-
-    currentControllerId_ = "00:00:00:00:00:00";
 
     // Start the timer FIRST — before posting the request. If the timer fails
     // to start AFTER the request was posted, OtaWriter would already be
@@ -1584,6 +1596,15 @@ void OtaForwarder::startMasterSelfFlash()
         emitDeployDoneAndReset();
         return;
     }
+
+    // FLASHING: the image is now handed to OtaWriter, which runs the full
+    // write + read-back verify + esp_ota_set_boot_partition inline. Emit here so
+    // the flash row stays visible for that whole window (the writer reports only
+    // a single OK/FAILED result at the end, not intermediate progress).
+    // Sending->Verifying->Flashing is the legal order; the FAILED path lands
+    // Flashing->Failed via FW_DEPLOY_DONE, same as a padawan.
+    AstrOs_SerialMsgHandler.sendFwProgress(deployTransferId_, currentControllerId_, "FLASHING", firmwareTotalSize_,
+                                           firmwareTotalSize_, "");
 }
 
 void OtaForwarder::handleLocalFlashResult(queue_ota_forwarder_msg_t &msg)
@@ -1603,10 +1624,20 @@ void OtaForwarder::handleLocalFlashResult(queue_ota_forwarder_msg_t &msg)
 
     if (status == OtaFlashStatus::OK)
     {
+        // REBOOTING: writer committed the new partition; we're about to restart.
+        // Flashing->Rebooting is the legal transition. The server then takes the
+        // sentinel row Rebooting->Finalizing on the PENDING FW_DEPLOY_DONE below,
+        // and the post-reboot heartbeat resolves it to VERSION_CONFIRMED. Emit
+        // before insertMasterRow so REBOOTING precedes FW_DEPLOY_DONE on the wire.
+        AstrOs_SerialMsgHandler.sendFwProgress(deployTransferId_, currentControllerId_, "REBOOTING", firmwareTotalSize_,
+                                               firmwareTotalSize_, "");
+
         insertMasterRow(PadawanStatus::PENDING, "", "awaiting_post_reboot_version");
         emitDeployDoneAndReset();
 
         ESP_LOGI(TAG, "Master self-flash complete; rebooting in 500ms");
+        // The 500 ms delay also gives serialCh1Queue time to drain the REBOOTING
+        // + FW_DEPLOY_DONE frames to the Pi before esp_restart tears down tasks.
         vTaskDelay(pdMS_TO_TICKS(500));
         esp_restart();
         // not reached

--- a/lib/OtaForwarder/src/OtaForwarder.cpp
+++ b/lib/OtaForwarder/src/OtaForwarder.cpp
@@ -1536,6 +1536,8 @@ void OtaForwarder::startMasterSelfFlash()
     // VERIFYING: the server pre-advanced the master row to SENDING during upload,
     // so Sending->Verifying is the legal first master FW_PROGRESS. Emit it before
     // hashing so the verify row is visible while computeFileSha256 reads the file.
+    // Authoritative stage-transition graph: AstrOs.Server
+    // flash_job_state_machine.ts LEGAL_NEXT_STAGES (the order claims below track it).
     AstrOs_SerialMsgHandler.sendFwProgress(deployTransferId_, currentControllerId_, "VERIFYING", firmwareTotalSize_,
                                            firmwareTotalSize_, "");
 
@@ -1628,7 +1630,10 @@ void OtaForwarder::handleLocalFlashResult(queue_ota_forwarder_msg_t &msg)
         // Flashing->Rebooting is the legal transition. The server then takes the
         // sentinel row Rebooting->Finalizing on the PENDING FW_DEPLOY_DONE below,
         // and the post-reboot heartbeat resolves it to VERSION_CONFIRMED. Emit
-        // before insertMasterRow so REBOOTING precedes FW_DEPLOY_DONE on the wire.
+        // before insertMasterRow: this is load-bearing, not cosmetic —
+        // emitDeployDoneAndReset (below) clears deployTransferId_, so REBOOTING
+        // must go out first to carry a valid transferId (and so precede
+        // FW_DEPLOY_DONE on the wire).
         AstrOs_SerialMsgHandler.sendFwProgress(deployTransferId_, currentControllerId_, "REBOOTING", firmwareTotalSize_,
                                                firmwareTotalSize_, "");
 


### PR DESCRIPTION
# fix(ota): stop ota_writer_task stack overflow in master self-flash

## Summary

Bench testing the PR-set-2 OTA mesh-forward feature (with version-confirm and the ESP-NOW congestion fixes now merged) reached the **master self-flash** step and **panicked**: a FreeRTOS stack overflow in `ota_writer_task` the moment `OtaWriter::handleLocalFlashReq` started streaming the ~1.27 MB image off the SD card.

```
I (...) OtaForwarder: startMasterSelfFlash: beginning master self-flash
I (...) OtaWriter: handleLocalFlashReq: path=/sdcard/firmware/7a4c6d13c23fe630.bin expectedSize=1268816
...
***ERROR*** A stack overflow in task ota_writer_task has been detected.
  vApplicationStackOverflowHook → vTaskSwitchContext   (detected mid-read, ~4 s in)
```

Root cause: `handleLocalFlashReq` declared **two** 4 KB buffers at **function scope** — `buf` (Step 3 file-stream) and `rbBuf` (Step 6 read-back verify).

| Buffer | Location | Purpose |
|---|---|---|
| `buf[4096]` | `OtaWriter.cpp` Step 3 | stream firmware from SD via `fread` |
| `rbBuf[4096]` | `OtaWriter.cpp` Step 6 | read flash back via `esp_partition_read` |

`metro_s3` builds with `CONFIG_COMPILER_OPTIMIZATION_DEFAULT` → `-Og`. GCC's `-fstack-reuse` only reclaims a variable's slot when its **scope** ends; both arrays are function-scoped, so they coexist for the entire call = **8192 bytes of arrays alone** on the **8192-byte** `ota_writer_task` stack (`src/main.cpp:248`). Add the `AstrOsSha256Ctx rbCtx` (108 B), the digests, the `postResult` lambda frame, and — the part that tips it over — the deep `fread → FATFS → SD/SPI` call chain layered on top during Step 3. Overflow is structurally guaranteed.

## Why the padawan wire path never hit this

The receive path runs on the same 8 KB `ota_writer_task` and flashed padawans fine, because it never builds this stack profile:

- `handleData` writes ~180 B chunk payloads straight from the queue message — **no large stack array**.
- `handleEnd` uses exactly **one** 4 KB buffer, reading via the shallow `esp_partition_read` (flash), not FATFS/SD.

The self-flash path is the only one that both **doubled** the buffers *and* swapped the shallow flash read for a deep FATFS/SD read. Two compounding regressions on one stack.

## Why the HWM warning didn't catch it first

`ota_writer_task` has a `uxTaskGetStackHighWaterMark` check that warns at <500 B remaining (`src/main.cpp:1618`). It never fired — it runs **after** `process()` returns, between messages. A single handler that overruns mid-execution blows past the canary before control returns. The between-messages canary is structurally blind to within-handler overflow.

## Fix (Option A — footprint reduction + margin)

1. **Collapse the two 4 KB buffers into one.** Step 3 and Step 6 run strictly sequentially — the file is `fclose`'d and the write phase is complete before readback begins — so reusing the Step 3 `buf` is provably safe and mirrors the proven-good `handleEnd` single-buffer pattern. Buffer footprint: 8 KB → 4 KB.
2. **Bump `ota_writer_task` stack 8192 → 12288.** Gives headroom for the `fread → FATFS → SD/SPI` call depth the receive path never exercises and that can't be measured precisely from source.

Net permanent RAM: **+4 KB**. No behavior change beyond stack/buffer layout; no wire-format, queue, or server-side changes.

## What ships

- **`lib/OtaWriter/src/OtaWriter.cpp`** — Step 6 readback reuses Step 3's `buf`/`kChunkBytes` (removes the `rbBuf`/`kRbBufSize` pair); comments at both Step 3 and Step 6 document the single-buffer stack budget so the second buffer isn't reintroduced. `handleEnd`'s readback comment updated `8 KB` → `12 KB`.
- **`src/main.cpp`** — `ota_writer_task` stack `8192` → `12288`; sizing comment now explains the self-flash FATFS/SD read depth vs the padawan wire path's shallow `esp_partition_read`.
- **Light plan** — `.docs/plans/20260529-1621-ota-writer-self-flash-stack.md`.

## Why not "just grow the stack"

A one-line bump to 16 KB would also clear the crash, but it keeps the redundant double-buffer (a latent smell the next handler copies) and costs +8 KB. Reusing the buffer fixes the cause, aligns self-flash with the receive path's known-good shape, and the modest stack bump only hedges the FATFS/SD depth unknown — all for +4 KB.

## Verification

Build- and test-level — the layers I can prove off-hardware:

| Check | metro_s3 | lolin_d32_pro |
|---|---|---|
| `pio run` | ✅ SUCCESS | ✅ SUCCESS |
| RAM static use | 14.6% (47752 B) | — |
| clang-format (`--Werror`) | ✅ clean | ✅ clean |

- ✅ **482/482 native tests pass** (`pio test -e test`).
- ✅ Both-board build matrix clean.

## ⚠ Still requires on-device confirmation

A stack overflow is invisible to host tests and to the build — the **bench is the proof**. The fix removes a definitive 4 KB overrun and adds margin, so it's very likely correct, but the live master self-flash is what confirms it. On the next on-device deploy, expect:

- `handleLocalFlashReq: success — boot partition flipped` with no panic, master reboots into the new image.
- **No** `OTA Writer Stack HWM` warning. If one appears, 12 KB is still tight — that's the canary to watch (unlikely; one 4 KB buffer + FATFS/SD frames should leave several KB free).

## Notes / risk

- The overflow does **not** scale with firmware size — the buffer is a fixed 4 KB and the file is read in chunks, so the ~1.27 MB image only changes the loop count, not the stack depth. This was fixed buffers + call-chain depth, full stop.
- `ota_writer_task` is the sole consumer of its queue, so `handleData` / `handleEnd` / `handleLocalFlashReq` never run concurrently — reusing one buffer across the two phases of a single call has no aliasing hazard.

## Commit history

```
6237e8c fix(ota): stop ota_writer_task stack overflow in master self-flash
57e6dd8 docs(ota): light plan — fix ota_writer_task self-flash stack overflow
```

## Test plan

- [x] CI: PR validation (native tests, both-board build matrix, native-purity guard, clang-format)
- [x] 482/482 native tests pass at HEAD
- [x] Both boards build clean (metro_s3, lolin_d32_pro)
- [x] clang-format clean on both changed files
- [ ] Bench: master self-flash reaches `boot partition flipped` and reboots into the new image with no `ota_writer_task` overflow and no HWM warning


